### PR TITLE
Ajout d'une configuration pour la CI

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,0 +1,32 @@
+name: Django application
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: github_actions
+        ports:
+          - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11.1
+      - name: Install dependencies
+        run: pip install pip-tools && pip-sync && playwright install
+      - name: Run ruff
+        run: ruff check .
+      - name: Run DjHTML
+        run: find -name *.html -not -path "./venv/*" | xargs djhtml
+      - name: Run tests
+        run: pytest
+        env:
+          SECRET_KEY: NOT_A_REAL_SECRET
+          DATABASE_URL: postgres://postgres:postgres@localhost/github_actions

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = seves.settings
 python_files = test_*.py
+addopts = -nauto

--- a/sv/tests/conftest.py
+++ b/sv/tests/conftest.py
@@ -7,6 +7,13 @@ from model_bakery import baker
 from sv.models import Etat, FicheDetection
 
 
+@pytest.fixture
+def page(page):
+    timeout = 2_000
+    page.set_default_navigation_timeout(timeout)
+    page.set_default_timeout(timeout)
+    yield page
+
 @pytest.fixture(scope="module", autouse=True)
 def set_django_allow_async_unsafe():
     os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"


### PR DESCRIPTION
- Permet de lancer les tests et ruff à chaque commit
- Réduit le timeout à 2 secondes par page afin que les test prennents moins de temps en cas de problème / attente du navigateur
- Lance les tests en parallèle en fonction des capacités de la machine
- Lance le formatage des templates en excluant les dépendances

https://github.com/rtts/djhtml/issues/48