### PR TITLE
Configuration automatique ALLOWED_HOSTS

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,7 @@
+{
+	"env": {
+	  "ALLOWED_HOSTS": {
+		"generator": "url"
+	  }
+	}
+  }


### PR DESCRIPTION
Lors de la création d'une review app sur scalingo, la variable d'environnement ALLOWED_HOSTS prend comme valeur l'url automatiquement. 
Exemple : pour ma review app "seves-recette-pr92", la valeur de ALLOWED_HOSTS doit égal à seves-recette-pr92.osc-fr1.scalingo.io