### PR TITLE
Permettre d'éditer les descripteurs d'un document

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -28,7 +28,7 @@ class DocumentUploadForm(DSFRForm, forms.ModelForm):
     )
     document_type = forms.ChoiceField(choices=Document.DOCUMENT_TYPE_CHOICES, label="Type de document")
     description = forms.CharField(
-        widget=forms.Textarea(attrs={"cols": 30, "rows": 4}), label="Description - facultatif", required=False
+        widget=forms.Textarea(attrs={"cols": 30, "rows": 4}), label="Commentaire - facultatif", required=False
     )
     file = forms.FileField(label="Ajouter un Document")
 
@@ -48,3 +48,17 @@ class DocumentUploadForm(DSFRForm, forms.ModelForm):
         if next:
             self.fields["next"] = forms.CharField(widget=forms.HiddenInput())
             self.initial["next"] = next
+
+
+class DocumentEditForm(DSFRForm, forms.ModelForm):
+    nom = forms.CharField(
+        help_text="Nommer le document de manière claire et compréhensible pour tous", label="Intitulé du document"
+    )
+    document_type = forms.ChoiceField(choices=Document.DOCUMENT_TYPE_CHOICES, label="Type de document")
+    description = forms.CharField(
+        widget=forms.Textarea(attrs={"cols": 30, "rows": 4}), label="Commentaire - facultatif", required=False
+    )
+
+    class Meta:
+        model = Document
+        fields = ["nom", "document_type", "description"]

--- a/core/mixins.py
+++ b/core/mixins.py
@@ -1,4 +1,4 @@
-from core.forms import DocumentUploadForm
+from core.forms import DocumentUploadForm, DocumentEditForm
 
 
 class WithDocumentUploadFormMixin:
@@ -18,5 +18,8 @@ class WithDocumentUploadFormMixin:
 class WithDocumentListInContextMixin:
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["document_list"] = self.get_object().documents.ordered()
+        documents = self.get_object().documents.ordered()
+        for document in documents:
+            document.edit_form = DocumentEditForm(instance=document)
+        context["document_list"] = documents
         return context

--- a/core/templates/core/_carte_resume_document.html
+++ b/core/templates/core/_carte_resume_document.html
@@ -10,9 +10,11 @@
                 Document supprimé
             {% else %}
                 <div class="fr-btns-group--right document__actions">
+                    <a href="#" class="fr-icon-edit-line fr-btn fr-btn--tertiary" data-fr-opened="false" aria-controls="fr-modal-edit-{{ document.pk }}"></a>
                     <a href="{{ document.file.url }}" target="_blank" class="fr-icon-download-line fr-btn fr-btn--tertiary fr-mr-1w"></a>
                     <a href="#" class="fr-icon-delete-line fr-btn fr-btn--tertiary" data-fr-opened="false" aria-controls="fr-modal-{{ document.pk }}"></a>
                 </div>
+                {% include "core/_modale_edition_document.html" %}
                 {% include "core/_modale_suppression_document.html" %}
             {% endif %}
         </div>

--- a/core/templates/core/_modale_edition_document.html
+++ b/core/templates/core/_modale_edition_document.html
@@ -1,0 +1,30 @@
+<dialog aria-labelledby="fr-modal-edit-{{ document.pk }}-title" id="fr-modal-edit-{{ document.pk }}" class="fr-modal" role="dialog">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <form action="{% url 'document-update' document.pk %}" method="POST">
+                        <div class="fr-modal__header">
+                            <button class="fr-btn--close fr-btn" aria-controls="fr-modal-edit-{{ document.pk }}">Fermer</button>
+                        </div>
+                        <div class="fr-modal__content"><h1 class="fr-modal__title">
+                            <span class="fr-icon-arrow-right-line fr-icon--lg"></span>Modifier le document</h1>
+                            {{ document.edit_form.as_dsfr_div }}
+                        </div>
+
+                        <div class="fr-modal__footer">
+                            <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg">
+
+                                    {% csrf_token %}
+                                    <input type="hidden" value="{{ document.pk }}" name="pk">
+                                    <input type="hidden" value="{{ redirect_url }}" name="next">
+                                    <button type="submit" class="fr-btn" data-testid="documents-edit-{{ document.pk }}">Enregistrer les modifications</button>
+
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
-from .views import DocumentUploadView, DocumentDeleteView
+from .views import DocumentUploadView, DocumentDeleteView, DocumentUpdateView
 
 urlpatterns = [
     path(
@@ -11,5 +11,10 @@ urlpatterns = [
         "document-delete/<int:pk>/",
         DocumentDeleteView.as_view(),
         name="document-delete",
+    ),
+    path(
+        "document-update/<int:pk>/",
+        DocumentUpdateView.as_view(),
+        name="document-update",
     ),
 ]

--- a/core/views.py
+++ b/core/views.py
@@ -1,9 +1,10 @@
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.messages.views import SuccessMessageMixin
 from django.shortcuts import get_object_or_404
 from django.views import View
-from django.views.generic.edit import FormView
-from .forms import DocumentUploadForm
+from django.views.generic.edit import FormView, UpdateView
+from .forms import DocumentUploadForm, DocumentEditForm
 from django.http import HttpResponseRedirect
 from django.utils.http import url_has_allowed_host_and_scheme
 
@@ -26,7 +27,7 @@ class DocumentUploadView(FormView):
         form = DocumentUploadForm(request.POST, request.FILES)
         if form.is_valid():
             form.save()
-            messages.success(request, "Le document a été ajouté avec succés.")
+            messages.success(request, "Le document a été ajouté avec succès.")
             return self._get_redirect()
 
         messages.error(request, "Une erreur s'est produite lors de l'ajout du document")
@@ -40,3 +41,13 @@ class DocumentDeleteView(View):
         document.save()
         messages.success(request, "Le document a été marqué comme supprimé.")
         return HttpResponseRedirect(request.POST.get("next"))
+
+
+class DocumentUpdateView(SuccessMessageMixin, UpdateView):
+    model = Document
+    success_message = "Le document a bien été mis à jour."
+    form_class = DocumentEditForm
+    http_method_names = ["post"]
+
+    def get_success_url(self):
+        return self.request.POST.get("next")


### PR DESCRIPTION
Permet d'éditer les descripteurs d'un document (nom, description et type) afin de pouvoir corriger une erreur / faute d'orthographe / etc.

Petite correction d'une faute d'accent sur un message de confirmation.
Renommage du champs description en commentaire (remontée atelier).