### PR TITLE
Configuration du endpoint OIDC pour les review app Scalingo

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -2,6 +2,27 @@
 	"env": {
 	  "ALLOWED_HOSTS": {
 		"generator": "url"
+	  },
+	  "OIDC_RP_CLIENT_ID": {
+		"value": "private"
+	  },
+	  "OIDC_RP_CLIENT_SECRET": {
+		"value": "tardis"
+	  },
+	  "OIDC_RP_AUTH_ENDPOINT": {
+		"value": "https://oidctest.wsweet.org/oauth2/authorize"
+	  },
+	  "OIDC_RP_TOKEN_ENDPOINT": {
+		"value": "https://oidctest.wsweet.org/oauth2/token"
+	  },
+	  "OIDC_RP_USER_ENDPOINT": {
+		"value": "https://oidctest.wsweet.org/oauth2/userinfo"
+	  },
+	  "OIDC_RP_JWKS_ENDPOINT": {
+		"value": "https://oidctest.wsweet.org/oauth2/jwks"
+	  },
+	  "OIDC_RP_LOGOUT_ENDPOINT": {
+		"value": "https://oidctest.wsweet.org/oauth2/logout"
 	  }
 	}
-  }
+}


### PR DESCRIPTION
## Problème
Sur scalingo, les URL des review app étant dynamique, elles ne peuvent pas être déclarées à l'avance dans le portail EAP.
Donc, erreur de connexion lors du login.
![image](https://github.com/user-attachments/assets/592bf3c6-5de2-4385-a145-f48ac4fdaacd)

## Solution
Ajout d'une configuration pour utiliser le portail de test oidctest.wsweet.org seulement pour les review app.