### PR TITLE
Génération fichier CSV contenant des contacts fictifs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-yaml
     -   id: check-added-large-files
+        exclude: '^fake_contacts.csv'
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
   rev: v0.4.1

--- a/core/management/commands/generate_fake_contacts.py
+++ b/core/management/commands/generate_fake_contacts.py
@@ -1,0 +1,56 @@
+import csv
+from faker import Faker
+from django.core.management.base import BaseCommand
+from itertools import islice
+
+fake = Faker("fr_FR")
+
+
+class Command(BaseCommand):
+    help = "Anonymise les contacts du fichier CSV d'entrée avec des données fictives mais réalistes et exporte le résultat dans un nouveau fichier CSV."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "input_file", type=str, help="Chemin vers le fichier CSV d'entrée (export fichier de contacts AGRICOLL)"
+        )
+        parser.add_argument("--count", type=int, help="Nombre de contacts à anonymiser", default=None)
+
+    def handle(self, *args, **kwargs):
+        input_file = kwargs["input_file"]
+        count = kwargs["count"]
+        output_file = "fake_contacts.csv"
+
+        with open(input_file, mode="r", newline="", encoding="utf-8") as file:
+            reader = csv.reader(file, delimiter=";")
+
+            with open(output_file, mode="w", newline="", encoding="utf-8") as new_file:
+                writer = csv.writer(new_file, delimiter=";")
+                headers = next(reader)  # Lecture et écriture des en-têtes dans le nouveau fichier
+                writer.writerow(headers)
+
+                rows = islice(reader, count) if count is not None else reader
+
+                for row in rows:
+                    fake_first_name = fake.first_name()
+                    fake_last_name = fake.last_name()
+                    fake_email = f"{fake_first_name.lower()}.{fake_last_name.lower()}@example.com"
+                    fake_fixed_phone = (
+                        f"+33 {fake.random_element(elements=('1', '2', '3', '4', '5'))} {fake.numerify('## ## ## ##')}"
+                    )
+                    fake_mobile_phone = f"+33 {fake.random_element(elements=('6', '7'))} {fake.numerify('## ## ## ##')}"
+
+                    row[1], row[2], row[3], row[6], row[7] = (
+                        fake_first_name,
+                        fake_last_name,
+                        fake_email,
+                        fake_fixed_phone,
+                        fake_mobile_phone,
+                    )
+                    writer.writerow(row)
+
+                message = "Toutes les données" if count is None else f"Les {count} premières données"
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"{message} ont été anonymisées et enregistrées avec succès dans le fichier {output_file}"
+                    )
+                )

--- a/fake_contacts.csv
+++ b/fake_contacts.csv
@@ -1,0 +1,11 @@
+Structure;Prénom;Nom;Mail;Fonction_hiérarchique;Complément_fonction;Téléphone;Mobile
+DDI/DDPP/DDPP95/PECRM;André;Lebon;andré.lebon@example.com;;;+33 2 05 03 47 67;+33 7 79 64 87 96
+DDI/DDPP/DDPP27/SG;Agnès;Gomes;agnès.gomes@example.com;;anais girard;+33 4 65 47 00 09;+33 6 31 86 11 49
+DDI/DDPP/DDPP91/SSA;Océane;Voisin;océane.voisin@example.com;;;+33 1 65 67 73 19;+33 6 51 04 70 44
+DDI/DDPP/DDPP64/ASP;Valérie;Hamel;valérie.hamel@example.com;;;+33 4 15 41 93 44;+33 7 36 55 76 74
+DDI/DDPP/DDPP64/ASP;Stéphanie;Carlier;stéphanie.carlier@example.com;;;+33 3 11 06 81 83;+33 6 25 78 49 06
+DDI/DDPP/DDPP64/ASP;Paulette;Schneider;paulette.schneider@example.com;;;+33 5 89 85 22 61;+33 6 29 49 03 53
+DDI/DDPP/DDPP71/SQA/AB-Cuiseaux;Martin;Delaunay;martin.delaunay@example.com;;Pour gérer la boite institutionnelle en dur et archivant les message;+33 3 75 89 17 38;+33 6 42 02 75 78
+DDI/DDPP/DDPP64/ASP;Benjamin;Evrard;benjamin.evrard@example.com;;;+33 4 23 64 16 82;+33 6 62 79 91 61
+DDI/DDPP/DDPP64/ASP;Robert;Aubry;robert.aubry@example.com;;;+33 5 30 19 37 68;+33 6 97 89 15 27
+DDI/DDPP/DDPP64/ASP;Alain;Pruvost;alain.pruvost@example.com;;;+33 3 02 55 80 01;+33 7 69 17 50 97

--- a/requirements.in
+++ b/requirements.in
@@ -16,3 +16,4 @@ sentry-sdk[django]
 django-storages[s3]
 mozilla-django-oidc
 django-filter
+faker

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,6 +49,8 @@ djhtml==3.0.6
     # via -r requirements.in
 execnet==2.1.1
     # via pytest-xdist
+faker==26.0.0
+    # via -r requirements.in
 filelock==3.13.4
     # via virtualenv
 greenlet==3.0.3
@@ -113,7 +115,9 @@ pytest-playwright==0.4.4
 pytest-xdist==3.5.0
     # via -r requirements.in
 python-dateutil==2.9.0.post0
-    # via botocore
+    # via
+    #   botocore
+    #   faker
 python-slugify==8.0.4
     # via pytest-playwright
 pyyaml==6.0.1


### PR DESCRIPTION
Cette PR introduit une commande Django permettant la génération d'une liste de contacts fictifs dans le fichier fake_contacts.csv à partir du fichier d'extraction Agricoll (fourni par le MASA). 
Le fichier `fake_contacts.csv` est inclus à la racine du projet pour pouvoir être utilisé par la suite sans devoir exécuter à nouveau la commande.

Cette commande permet également de spécifier un nombre limité de contacts à anonymiser grâce à l'option `--count`. 

Le fichier généré peut être utilisé pour importer des données de contacts dans l'environnement de développement et de recette, évitant ainsi d'utiliser des données de contacts de production dans ces environnements.

Pour générer des données fictives, la commande utilise la bibliothèque faker.

Commandes d'utilisation :

- Générer tous les contacts anonymisés : `python manage.py generate_fake_contacts /chemin/vers/fichier_entrée.csv`
- Générer un nombre spécifique de contacts anonymisés : `python manage.py generate_fake_contacts /chemin/vers/fichier_entrée.csv --count 100`