### PR TITLE
Corrige le script de détection des erreurs HTML

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Run ruff format
         run: ruff format --check .
       - name: Run DjHTML
-        run: find -name *.html -not -path "./venv/*" | xargs djhtml
+        run: ./bin/check_html_format.sh
       - name: Run tests
         run: pytest
         env:

--- a/bin/check_html_format.sh
+++ b/bin/check_html_format.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e # exit if any command has a non-zero exit status
+set -u # consider unset variables as errors
+set -o pipefail # prevents errors in a pipeline from being masked
+
+for file in $(find . -name "*.html" -not -path "./venv/*"); do
+  djhtml --check "$file"
+done
+
+exit 0

--- a/core/templates/core/_dsfr_div.html
+++ b/core/templates/core/_dsfr_div.html
@@ -1,22 +1,22 @@
 {% spaceless %}
-{{ errors }}
-{% if errors and not fields %}
-  <div>{% for field in hidden_fields %}{{ field }}{% endfor %}</div>
-{% endif %}
-{% for field, errors in fields %}
   {{ errors }}
-  <div {% with classes=field.css_classes %}class="{{ classes }} fr-fieldset__element"{% endwith %}>
-    {% if field.label %}{{ field.label_tag }}{% endif %}
-    {{ field }}
-    {% if field.help_text %}
-      <span class="helptext fr-hint-text"{% if field.auto_id %} id="{{ field.auto_id }}_helptext"{% endif %}>{{ field.help_text|safe }}</span>
-    {% endif %}
-    {% if forloop.last %}
-      {% for field in hidden_fields %}{{ field }}{% endfor %}
-    {% endif %}
-  </div>
-{% endfor %}
-{% if not fields and not errors %}
-  {% for field in hidden_fields %}{{ field }}{% endfor %}
-{% endif %}
+  {% if errors and not fields %}
+    <div>{% for field in hidden_fields %}{{ field }}{% endfor %}</div>
+  {% endif %}
+  {% for field, errors in fields %}
+    {{ errors }}
+    <div {% with classes=field.css_classes %}class="{{ classes }} fr-fieldset__element"{% endwith %}>
+      {% if field.label %}{{ field.label_tag }}{% endif %}
+      {{ field }}
+      {% if field.help_text %}
+        <span class="helptext fr-hint-text"{% if field.auto_id %} id="{{ field.auto_id }}_helptext"{% endif %}>{{ field.help_text|safe }}</span>
+      {% endif %}
+      {% if forloop.last %}
+        {% for field in hidden_fields %}{{ field }}{% endfor %}
+      {% endif %}
+    </div>
+  {% endfor %}
+  {% if not fields and not errors %}
+    {% for field in hidden_fields %}{{ field }}{% endfor %}
+  {% endif %}
 {% endspaceless %}

--- a/core/templates/core/login.html
+++ b/core/templates/core/login.html
@@ -43,10 +43,10 @@
                 </header>
                 <main>
                     <div>
-                    <h1 class="fr-h1">Connexion</h1>
+                        <h1 class="fr-h1">Connexion</h1>
 
-                    <a href="{% url 'oidc_authentication_init' %}" class="fr-btn">Me connecter via le portail EAP</a>
-                        </div>
+                        <a href="{% url 'oidc_authentication_init' %}" class="fr-btn">Me connecter via le portail EAP</a>
+                    </div>
                 </main>
 
 

--- a/sv/templates/sv/base.html
+++ b/sv/templates/sv/base.html
@@ -50,16 +50,16 @@
 
                             {% if user.is_authenticated %}
                                 <button class="fr-nav__btn" aria-expanded="false" aria-controls="menu-777"><span class="fr-icon-account-circle-line"></span>{{ user.email }}</button>
-                            <div class="fr-collapse fr-menu" id="menu-777">
-                                <ul class="fr-menu__list">
-                                    <li>
-                                        <form action="{% url 'oidc_logout' %}" method="post">
-                                {% csrf_token %}
-                                <input type="submit" value="Se déconnecter" class="fr-nav__link">
-                              </form>
-                                    </li>
-                                </ul>
-                            </div>
+                                <div class="fr-collapse fr-menu" id="menu-777">
+                                    <ul class="fr-menu__list">
+                                        <li>
+                                            <form action="{% url 'oidc_logout' %}" method="post">
+                                                {% csrf_token %}
+                                                <input type="submit" value="Se déconnecter" class="fr-nav__link">
+                                            </form>
+                                        </li>
+                                    </ul>
+                                </div>
                             {% endif %}
                         </li>
                     </ul>


### PR DESCRIPTION
Le code de status n'était pas le bon car il est "avalé" par xargs, qui renvoit son propre code de status. Utilisation d'un petit script pour corriger le problème.