### PR TITLE
Corriger le design du bloc commun

### DIFF
--- a/core/templates/core/_documents.html
+++ b/core/templates/core/_documents.html
@@ -1,7 +1,7 @@
 <div class="fr-container--fluid fr-mb-4w" id="documents">
     <div class="fr-grid-row">
         <div class="fr-col-4">
-            <form method="get" action="#documents" class="documents__filters">
+            <form method="get" action="#tabpanel-documents-panel" class="documents__filters">
                 {{ document_filter.form.as_dsfr_div }}
                 <p class="fr-my-2w fr-ml-2w"> <button type="submit" class="fr-btn" data-testid="documents-filter">Filtrer</button></p>
             </form>

--- a/core/templates/core/_fiche_bloc_commun.html
+++ b/core/templates/core/_fiche_bloc_commun.html
@@ -1,24 +1,27 @@
-
 <div class="bloc-commun-gestion">
     <div class="fr-tabs fr-mt-2w">
         <ul class="fr-tabs__list" role="tablist">
             <li role="presentation">
-                <button id="tabpanel-404" class="fr-tabs__tab fr-icon-message-2-line fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-selected="true" aria-controls="tabpanel-404-panel">Fil de suivi</button>
+                <button id="tabpanel-messages" class="fr-tabs__tab fr-icon-message-2-line fr-tabs__tab--icon-left" tabindex="0" role="tab" aria-selected="false" aria-controls="tabpanel-messages-panel">Fil de suivi</button>
             </li>
             <li role="presentation">
-                <button id="tabpanel-405" class="fr-tabs__tab fr-icon-user-line fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-selected="false" aria-controls="tabpanel-405-panel">Contacts</button>
+                <button id="tabpanel-contacts" class="fr-tabs__tab fr-icon-user-line fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-selected="false" aria-controls="tabpanel-contacts-panel">Contacts</button>
             </li>
             <li role="presentation">
-                <button id="tabpanel-406" class="fr-tabs__tab fr-icon-book-2-line fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-selected="false" aria-controls="tabpanel-406-panel" data-testid="documents">Documents</button>
+                <button id="tabpanel-documents" class="fr-tabs__tab fr-icon-book-2-line fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-selected="false" aria-controls="tabpanel-documents-panel" data-testid="documents">Documents</button>
             </li>
         </ul>
-        <div id="tabpanel-404-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-404" tabindex="0">
+        <div id="tabpanel-messages-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-messages" tabindex="0">
+            {% include "core/_messages.html" with value="messages" %}
             {% include "core/_fil-de-suivi.html" %}
         </div>
-        <div id="tabpanel-405-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-405" tabindex="0">
+
+        <div id="tabpanel-contacts-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-contacts" tabindex="0">
+            {% include "core/_messages.html" with value="contacts" %}
             {% include "core/_contacts.html" %}
         </div>
-        <div id="tabpanel-406-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-406" tabindex="0">
+        <div id="tabpanel-documents-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-documents" tabindex="0">
+            {% include "core/_messages.html" with value="documents" %}
             {% include "core/_documents.html" %}
         </div>
     </div>

--- a/core/templates/core/_messages.html
+++ b/core/templates/core/_messages.html
@@ -1,0 +1,14 @@
+{% if messages %}
+    <div class="fr-my-1w">
+        {% for message in messages %}
+            {% if value in message.extra_tags %}
+                <div class="fr-alert fr-alert--{{ message.level_tag }}">
+                    <h3 class="fr-alert__title">{{message}}</h3>
+                    <button class="fr-btn--close fr-btn" title="Masquer le message" onclick="const alert = this.parentNode; alert.parentNode.removeChild(alert)">
+                        Masquer le message
+                    </button>
+                </div>
+            {% endif %}
+        {% endfor %}
+    </div>
+{% endif %}

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -73,12 +73,14 @@
             {% if messages %}
                 <div class="alert-container">
                     {% for message in messages %}
-                        <div class="fr-alert fr-alert--{{ message.tags }}">
-                            <h3 class="fr-alert__title">{{message}}</h3>
-                            <button class="fr-btn--close fr-btn" title="Masquer le message" onclick="const alert = this.parentNode; alert.parentNode.removeChild(alert)">
-                                Masquer le message
-                            </button>
-                        </div>
+                        {% if "core" not in message.extra_tags %}
+                            <div class="fr-alert fr-alert--{{ message.level_tag }}">
+                                <h3 class="fr-alert__title">{{message}}</h3>
+                                <button class="fr-btn--close fr-btn" title="Masquer le message" onclick="const alert = this.parentNode; alert.parentNode.removeChild(alert)">
+                                    Masquer le message
+                                </button>
+                            </div>
+                        {% endif %}
                     {% endfor %}
                 </div>
             {% endif %}

--- a/sv/static/sv/fichedetection_detail.js
+++ b/sv/static/sv/fichedetection_detail.js
@@ -22,10 +22,4 @@ document.addEventListener('DOMContentLoaded', function() {
     detailElement.classList.remove(hiddenClass);
     syntheseElement.classList.add(hiddenClass);
 
-    if(window.location.hash && window.location.hash === "#documents") {
-        document.getElementById("tabpanel-404").setAttribute("aria-selected", false);
-        document.getElementById("tabpanel-405").setAttribute("aria-selected", false);
-        document.getElementById("tabpanel-406").setAttribute("aria-selected", true);
-
-    }
 });

--- a/sv/tests/test_fiche_detection_message.py
+++ b/sv/tests/test_fiche_detection_message.py
@@ -15,7 +15,7 @@ def test_can_add_and_see_message_without_document(live_server, page: Page, fiche
     page.locator("#id_content").fill("My content \n with a line return")
     page.get_by_test_id("fildesuivi-add-submit").click()
 
-    page.wait_for_url(f"**{fiche_detection.get_absolute_url()}")
+    page.wait_for_url(f"**{fiche_detection.get_absolute_url()}#tabpanel-messages-panel")
 
     cell_selector = f"#table-sm-row-key-1 td:nth-child({2}) a"
     assert page.text_content(cell_selector) == "Title of the message"
@@ -61,7 +61,7 @@ def test_can_add_and_see_message_multiple_documents(live_server, page: Page, fic
     expect(page.get_by_text("requirements.in", exact=True)).not_to_be_visible()
 
     page.get_by_test_id("fildesuivi-add-submit").click()
-    page.wait_for_url(f"**{fiche_detection.get_absolute_url()}")
+    page.wait_for_url(f"**{fiche_detection.get_absolute_url()}#tabpanel-messages-panel")
 
     cell_selector = f"#table-sm-row-key-1 td:nth-child({2}) a"
     assert page.text_content(cell_selector) == "Title of the message"

--- a/sv/tests/test_fichedetection_documents.py
+++ b/sv/tests/test_fichedetection_documents.py
@@ -72,7 +72,7 @@ def test_can_edit_document_on_fiche_detection(live_server, page: Page, fiche_det
     page.locator(f"#fr-modal-edit-{document.id} #id_description").fill("")
     page.get_by_test_id(f"documents-edit-{document.pk}").click()
 
-    page.wait_for_url(f"**{fiche_detection.get_absolute_url()}")
+    page.wait_for_url(f"**{fiche_detection.get_absolute_url()}#tabpanel-documents-panel")
 
     document = fiche_detection.documents.get()
     assert document.nom == "New name"
@@ -87,7 +87,7 @@ def test_can_filter_documents_on_fiche_detection(live_server, page: Page, fiche_
     document_2 = baker.make(Document, nom="Cartographie", document_type="cartographie", _create_files=True)
     fiche_detection.documents.set([document_1, document_2])
 
-    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}#documents")
+    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}#tabpanel-documents-panel")
 
     expect(page.get_by_role("heading", name="Test document")).to_be_visible()
     expect(page.get_by_role("heading", name="Cartographie")).to_be_visible()
@@ -95,7 +95,7 @@ def test_can_filter_documents_on_fiche_detection(live_server, page: Page, fiche_
     page.locator(".documents__filters #id_document_type").select_option("autre")
     page.get_by_test_id("documents-filter").click()
 
-    page.wait_for_url(f"**{fiche_detection.get_absolute_url()}?document_type=autre#documents")
+    page.wait_for_url(f"**{fiche_detection.get_absolute_url()}?document_type=autre#tabpanel-documents-panel")
 
     expect(page.get_by_role("heading", name="Test document")).to_be_visible()
     expect(page.get_by_role("heading", name="Cartographie")).not_to_be_visible()


### PR DESCRIPTION
Ce commit a pour but de corriger le plus gros problème d'interaction remonté lors de la review design: lors d'un action dans le bloc commun le navigateur doit arriver au niveau du bloc concerné (ancre) et avec le bon onglet d'ouvert, le message de feedback doit être dans le bloc concerné.

- Introduction d'une mécanique pour identifier les messages a afficher en haut et ceux a afficher dans un bloc particulier
- Utilisation d'ancre pour amener le navigateur directement au bon bloc
- Utilisation d'anche pour ouvrir le bon onglet du bloc commun. Lors d'un commit précédent j'avais introduit un petit bout de JS pour cela, mais en relisant la doc du DSFR (voir notes) je me suis rendu compte que cela était possible directement avec une ancre
- Retrait d'un mécanisme de vérification sur la redirection qui semble de trop (requête post + CSRF + identification).

```
il est possible de faire un lien depuis une autre page vers un onglet qui n'est pas le premier en mettant l'ID de l'onglet correspondant en ancre dans l'URL tel que : #tad-id
```
https://www.systeme-de-design.gouv.fr/composants-et-modeles/composants/onglet/