### PR TITLE
Améliorer le rendus des descripteurs en synthèse

### DIFF
--- a/sv/static/sv/fichedetection_detail.css
+++ b/sv/static/sv/fichedetection_detail.css
@@ -120,17 +120,7 @@ main{
 /* Bloc synthèse */
 .fiche-synthese {
     background-color: var(--fiche-detail-bloc-background-color);
-    padding: var(--fiche-detail-bloc-padding);
-}
-.fiche-synthese__field {
-    display: flex;
-    justify-content: space-between;
 }
 .fiche-synthese__label{
-    flex: 0.2;
     font-weight: var(--field-label-font-weight);
-}
-.fiche-synthese__value {
-    flex: 1;
-    text-align: left;
 }

--- a/sv/templates/sv/_fichedetection_synthese.html
+++ b/sv/templates/sv/_fichedetection_synthese.html
@@ -1,0 +1,44 @@
+<div class="fiche-synthese fr-p-3w">
+    <div class="fr-grid-row">
+        <div class="fr-col-3">
+            <div class="fr-grid-row">
+                <div class="fr-col-5 fiche-synthese__label fr-pb-1w">Créateur</div>
+                <div class="fr-col-7">{{ fichedetection.createur }}</div>
+            </div>
+            <div class="fr-grid-row">
+                <div class="fr-col-5 fiche-synthese__label fr-pb-1w">Date 1er signalement</div>
+                <div class="fr-col-7">{{ fichedetection.date_premier_signalement|default:"nc." }}</div>
+            </div>
+
+            <div class="fr-grid-row">
+                <div class="fr-col-5 fiche-synthese__label fr-pb-1w">Organisme nuisible</div>
+                <div class="fr-col-7">{{ fichedetection.organisme_nuisible.libelle_court|default:"nc." }}</div>
+            </div>
+        </div>
+        <div class="fr-col-3">
+            <div class="fr-grid-row">
+                <div class="fr-col-5 fiche-synthese__label fr-pb-1w">Commune</div>
+                <div class="fr-col-7">                    {% if lieux_initiaux %}
+                    {{ lieux_initiaux.0.commune }}
+                {% else %}
+                    nc.
+                {% endif %}</div>
+            </div>
+
+            <div class="fr-grid-row">
+                <div class="fr-col-5 fiche-synthese__label fr-pb-1w">Région</div>
+                <div class="fr-col-7">                   {% if lieux_initiaux %}
+                    {{ lieux_initiaux.0.region.nom }}
+                {% else %}
+                    nc.
+                {% endif %}</div>
+            </div>
+        </div>
+        <div class="fr-col-6">
+            <div class="fr-grid-row">
+                <div class="fr-col-3 fiche-synthese__label fr-pb-1w">Mesures conservatoires</div>
+                <div class="fr-col-9">{{ fichedetection.mesures_conservatoires_immediates|default:"nc." }}</div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/sv/templates/sv/fichedetection_detail.html
+++ b/sv/templates/sv/fichedetection_detail.html
@@ -166,49 +166,8 @@
                 </div>
             </div>
         </div>
+        {% include "sv/_fichedetection_synthese.html" %}
 
-        <div class="fiche-synthese">
-            <div class="fiche-synthese__field">
-                <p class="fiche-synthese__label">Créateur</p>
-                <p class="fiche-synthese__value">{{ fichedetection.createur }}</p>
-            </div>
-            <div class="fiche-synthese__field">
-                <p class="fiche-synthese__label">Date 1er signalement</p>
-                <p class="fiche-synthese__value">{{ fichedetection.date_premier_signalement|default:"nc." }}</p>
-            </div>
-            <div class="fiche-synthese__field">
-                <p class="fiche-synthese__label">Organisme nuisible</p>
-                <p class="fiche-synthese__value">{{ fichedetection.organisme_nuisible.libelle_court|default:"nc." }}</p>
-            </div>
-            <div class="fiche-synthese__field">
-                <p class="fiche-synthese__label">Commune</p>
-                <p class="fiche-synthese__value">
-                    {% if lieux_initiaux %}
-                        {{ lieux_initiaux.0.commune }}
-                    {% else %}
-                        nc.
-                    {% endif %}
-                </p>
-            </div>
-            <div class="fiche-synthese__field">
-                <p class="fiche-synthese__label">Région</p>
-                <p class="fiche-synthese__value">
-                    {% if lieux_initiaux %}
-                        {{ lieux_initiaux.0.region.nom }}
-                    {% else %}
-                        nc.
-                    {% endif %}
-                </p>
-            </div>
-            <div class="fiche-synthese__field">
-                <p class="fiche-synthese__label">Mesure de gestion</p>
-                <p class="fiche-synthese__value">???</p>
-            </div>
-            <div class="fiche-synthese__field">
-                <p class="fiche-synthese__label">Mesures conservatoires</p>
-                <p class="fiche-synthese__value">{{ fichedetection.mesures_conservatoires_immediates|default:"nc." }}</p>
-            </div>
-        </div>
         {% include "core/_fiche_bloc_commun.html" with redirect_url=fichedetection.get_absolute_url fiche=fichedetection pk=fichedetection.pk content_type_id=fichedetection.get_content_type_id %}
     </main>
 


### PR DESCRIPTION
Améliore le rendus des descripteurs de la fiche détection en mode "Synthèse" en passant les descripteurs sur 3 colonne (cf maquette).