### PR TITLE
Rendre le champs des organismes nuisibles cherchable

### DIFF
--- a/core/static/core/base.css
+++ b/core/static/core/base.css
@@ -25,3 +25,10 @@ header{
 .menu__item--active {
     border-bottom: 4px solid var(--background-active-blue-france);
 }
+.choices .fr-select {
+	/* Make sure we never have 2 down arrows (1 via choices js, 1 via DSFR) for select inputs that uses choices js*/
+    background-image: none;
+}
+.choices__list--dropdown{
+    z-index: 10 !important;
+}

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -19,6 +19,7 @@
         <link rel="stylesheet" href="{% static 'core/bloc_commun.css' %}">
         <link rel="stylesheet" href="{% static 'core/message.css' %}">
         <link rel="stylesheet" href="{% static 'core/fil_de_suivi.css' %}">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/styles/choices.min.css" />
         {% block extrahead %}{% endblock %}
     </head>
 
@@ -87,6 +88,7 @@
 
             <script type="module" src="{% static 'dsfr.module.min.js' %}"></script>
             <script type="text/javascript" nomodule src="{% static 'dsfr.nomodule.min.js' %}"></script>
+            <script src="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/scripts/choices.min.js"></script>
             {% block scripts %}{% endblock %}
         </body>
 

--- a/sv/static/sv/fichedetection_form.css
+++ b/sv/static/sv/fichedetection_form.css
@@ -105,10 +105,6 @@ main {
 #organisme-nuisible .choices {
     flex: 1.42;
 }
-#organisme-nuisible .fr-select {
-	/* supprime la flèche située à droite dans le select car déjà présente via choices.js */
-    background-image: none;
-}
 
 
 /* Lieux */

--- a/sv/static/sv/fichedetection_list.css
+++ b/sv/static/sv/fichedetection_list.css
@@ -19,6 +19,11 @@ body{
 .form-search__field {
     flex: 1;
 }
+.choices__list--single{
+    overflow: hidden;
+  max-height: 1.5rem;
+}
+
 
 .fiches__list-container {
     margin: 2rem;

--- a/sv/static/sv/fichedetection_list.js
+++ b/sv/static/sv/fichedetection_list.js
@@ -8,4 +8,10 @@ document.addEventListener('DOMContentLoaded', function() {
         this.elements['date_fin'].value = '';
         this.elements['etat'].value = '';
     });
+
+    const choices = new Choices(document.getElementById('id_organisme_nuisible'), {
+        classNames: {
+            containerInner: 'fr-select',
+        }
+    });
 });

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -9,9 +9,7 @@
 <!-- Alpine Core -->
     <script defer src="{% static 'alpineV3.cdn.min.js' %}"></script>
 
-<!-- choicesjs (autocompletion pour select) -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/styles/choices.min.css" />
-    <script src="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/scripts/choices.min.js"></script>
+
 {% endblock %}
 
 {% block scripts %}

--- a/sv/views.py
+++ b/sv/views.py
@@ -55,7 +55,7 @@ class FicheDetectionSearchForm(forms.Form, DSFRForm):
     )
     region = forms.ModelChoiceField(label="Région", queryset=Region.objects.all(), required=False)
     organisme_nuisible = forms.ModelChoiceField(
-        label="Organisme", queryset=OrganismeNuisible.objects.all(), required=False
+        label="Organisme", queryset=OrganismeNuisible.objects.none(), required=False
     )
     date_debut = forms.DateField(label="Période du", widget=forms.DateInput(attrs={"type": "date"}), required=False)
     date_fin = forms.DateField(label="Au", widget=forms.DateInput(attrs={"type": "date"}), required=False)
@@ -71,6 +71,10 @@ class FicheDetectionSearchForm(forms.Form, DSFRForm):
             except ValueError:
                 raise forms.ValidationError("Format 'numero' invalide. Il devrait être 'annee.numero'")
         return numero
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["organisme_nuisible"].queryset = OrganismeNuisible.objects.all()
 
 
 class FicheDetectionListView(ListView):


### PR DESCRIPTION
Permet que le champ de filtre sur les organismes nuisibles soit cherchable en utilisant Choices.js.
Factorisation de la bibliothéque au niveau du template de base.