### PR TITLE
Ajouter Remixicon pour avoir des icônes hors DSFR

### DIFF
--- a/core/templates/core/_tableau_fil_de_suivi.html
+++ b/core/templates/core/_tableau_fil_de_suivi.html
@@ -26,7 +26,7 @@
                 </td>
                 <td>
                     {% if message.documents.count %}
-                        <a href="{% url 'message-view' message.pk  %}"><span class="fr-icon-file-fill" aria-hidden="true"></span></a>
+                        <a href="{% url 'message-view' message.pk  %}"><i class="ri-attachment-line ri-xl" aria-hidden="true"></i></a>
                     {% endif %}
                 </td>
                 <td>

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -20,6 +20,7 @@
         <link rel="stylesheet" href="{% static 'core/message.css' %}">
         <link rel="stylesheet" href="{% static 'core/fil_de_suivi.css' %}">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/styles/choices.min.css" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.3.0/fonts/remixicon.css"/>
         {% block extrahead %}{% endblock %}
     </head>
 


### PR DESCRIPTION
Permet d'utiliser des icônes qui ne seraient pas dans le DSFR.