### PR TITLE
Permettre de filtrer sur les unités - Documents

### DIFF
--- a/core/filters.py
+++ b/core/filters.py
@@ -1,7 +1,7 @@
 import django_filters
 from django.forms import forms
 
-from .models import Document
+from .models import Document, Structure
 from .forms import DSFRForm
 
 
@@ -10,9 +10,32 @@ class FilterForm(DSFRForm, forms.Form):
 
 
 class DocumentFilter(django_filters.FilterSet):
+    document_type = django_filters.ChoiceFilter(
+        choices=[],
+        label="Type de Document",
+    )
+    created_by_structure = django_filters.ModelChoiceFilter(
+        queryset=Structure.objects.all(),
+        field_name="created_by_structure",
+        label="Unité",
+    )
+
     class Meta:
         model = Document
-        fields = [
-            "document_type",
-        ]
+        fields = ["document_type", "created_by_structure"]
         form = FilterForm
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        actual_document_types = (
+            self.queryset.values_list("document_type", flat=True).order_by("document_type").distinct("document_type")
+        )
+        self.filters["document_type"].extra["choices"] = [
+            (k, v) for (k, v) in Document.DOCUMENT_TYPE_CHOICES if k in actual_document_types
+        ]
+
+        structure_queryset = Structure.objects.filter(
+            id__in=self.queryset.values_list("created_by_structure", flat=True).distinct()
+        )
+        self.filters["created_by_structure"].queryset = structure_queryset

--- a/sv/tests/conftest.py
+++ b/sv/tests/conftest.py
@@ -95,7 +95,7 @@ def document_recipe(fiche_detection_bakery):
         fiche = fiche_detection_bakery()
         content_type = ContentType.objects.get_for_model(fiche)
         agent_recipe = Recipe(Agent)
-        structure_recipe = Recipe(Structure)
+        structure_recipe = Recipe(Structure, libelle="Structure Test")
         return Recipe(
             Document,
             created_by=foreign_key(agent_recipe),


### PR DESCRIPTION
Dans l'onglet Documents ce commit va permettre de filtrer sur les unités a l'origine de l'upload d'un document.

J'ai revu le fonctionnement des deux filtres pour ne lister que les valeurs possibles extraites de la liste des documents. Ainsi on affiche que les types de documents présents dans la liste (il n'est pas possible de filtrer sur Cartographie si il n'y a pas de Cartographie dans les documents). De même pour les unités, afin d'éviter de présenter des centaines d'unités si la fiche que fait intervenir que quelques unités.