### PR TITLE
Ajustement design sur le formulaire d'ajout de contact

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,3 +1,4 @@
+import math
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
@@ -101,6 +102,7 @@ class ContactSelectionForm(forms.Form):
     content_type_id = forms.IntegerField(widget=forms.HiddenInput())
     fiche_id = forms.IntegerField(widget=forms.HiddenInput())
     next = forms.CharField(widget=forms.HiddenInput(), required=False)
+    contacts_count_half = forms.IntegerField(widget=forms.HiddenInput(), required=False)
 
     def __init__(self, *args, **kwargs):
         structure = kwargs.pop("structure")
@@ -120,6 +122,8 @@ class ContactSelectionForm(forms.Form):
             .exclude(pk__in=existing_contacts)
             .order_by("structure", "agent__nom")
         )
+        # Calcul du nombre de contacts à afficher dans la première colonne (arrondi supérieur)
+        self.fields["contacts_count_half"].initial = math.ceil(self.fields["contacts"].queryset.count() / 2)
 
 
 class MessageForm(DSFRForm, WithNextUrlMixin, WithContentTypeMixin, forms.ModelForm):

--- a/core/static/core/contact_add_form.css
+++ b/core/static/core/contact_add_form.css
@@ -1,0 +1,4 @@
+.contact-add-form__container {
+    background-color: var(--background-default-grey);
+    min-height: 600px
+}

--- a/core/templates/core/_contact_add_form.html
+++ b/core/templates/core/_contact_add_form.html
@@ -3,7 +3,9 @@
 {% load static %}
 
 {% block extrahead %}
-<!-- choicesjs (autocompletion pour select) -->
+    <link rel="stylesheet" href="{% static 'core/contact_add_form.css' %}">
+
+    <!-- choicesjs (autocompletion pour select) -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/styles/choices.min.css" />
     <script src="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/scripts/choices.min.js"></script>
 {% endblock %}
@@ -15,7 +17,7 @@
             const choices = new Choices(element, {
                 searchResultLimit: 500,
                 classNames: {
-                    containerInner: 'fr-select',
+                    containerInner: 'fr-select fr-mt-1w',
                 }
             });
         });
@@ -25,51 +27,84 @@
 
 {% block content %}
     <div class="fr-container">
-        <div class="fr-grid-row">
-            <div class="fr-col">
-                <p class="fr-my-4w"><a href="{{form.next.value}}" class="fr-link fr-icon-arrow-left-line fr-link--icon-left">Retour à la fiche</a></p>
-                <h2>Ajouter un agent</h2>
-                <form id="form-search" method="post" action="{% url 'contact-add-form' %}">
-                    {% csrf_token %}
-                    {{ form.as_p }}
-                    <button type="submit" form="form-search" class="fr-btn">Rechercher</button>
-                </form>
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-9">
+                <div class="fr-grid-row">
+                    <div class="fr-col-12">
+                        <p class="fr-my-2w"><a href="{{form.next.value}}" class="fr-link fr-icon-arrow-left-line fr-link--icon-left">Retour à la fiche</a></p>
+                    </div>
+                </div>
+                <div class="fr-grid-row">
+                    <div class="fr-col-12">
+                        <h1>Ajouter un agent</h1>
+                    </div>
+                </div>
+                <div class="contact-add-form__container fr-p-5w fr-mb-6w">
+                    <div class="fr-grid-row fr-pl-1w">
+                        <div class="fr-col-7">
+                            <form id="form-search" method="post" action="{% url 'contact-add-form' %}">
+                                {% csrf_token %}
+                                {{ form.as_p }}
+                                <button type="submit" form="form-search" class="fr-btn">Rechercher</button>
+                            </form>
+                        </div>
+                        <div class="fr-col-5"></div>
+                    </div>
+                    {% if selection_form%}
+                        <div class="fr-grid-row">
+                            <div class="fr-col">
+                                <form id="form-selection" method="post" action="{% url 'contact-add-form-select-agents' %}" class="fr-mt-4w">
+                                    {% csrf_token %}
 
-                {% if selection_form%}
-                    <form id="form-selection" method="post" action="{% url 'contact-add-form-select-agents' %}" class="fr-mt-4w">
-                        {% csrf_token %}
-                        <fieldset class="fr-fieldset" id="checkboxes" aria-labelledby="checkboxes-legend checkboxes-messages">
-                            <legend class="fr-fieldset__legend--regular fr-fieldset__legend fr-my-2w" id="checkboxes-legend">
-                                <span class="agents-count">{{ selection_form.contacts.field.queryset.count }} agents</span> dans cette structure
-                            </legend>
-                            {% if selection_form.contacts.errors %}
-                                <div class="fr-alert fr-alert--error fr-alert--sm fr-mb-4w">
-                                    {% for error in selection_form.contacts.errors %}
-                                        <p>{{ error }}</p>
-                                    {% endfor %}
-                                    <button class="fr-btn--close fr-btn" title="Masquer le message" onclick="const alert = this.parentNode; alert.parentNode.removeChild(alert)">
-                                        Masquer le message
-                                    </button>
-                                </div>
-                            {% endif %}
-                            {% for contact in selection_form.contacts.field.queryset %}
-                                <div class="fr-fieldset__element">
-                                    <div class="fr-checkbox-group">
-                                        <input name="contacts" id="checkboxes-{{ forloop.counter }}" type="checkbox" value="{{ contact.id }}" aria-describedby="checkboxes-{{ forloop.counter }}-messages">
-                                        <label class="fr-label" for="checkboxes-{{ forloop.counter }}">
-                                            <span class='fr-badge'>{{contact.agent.structure.libelle}}</span> - {{contact.agent.nom}} {{contact.agent.prenom}}{% if contact.agent.fonction_hierarchique %} ({{ contact.agent.fonction_hierarchique }}){% endif %}
-                                        </label>
+                                    <div class="fr-grid-row fr-pl-1w">
+                                        <div class="fr-col">
+                                            <p><span class="agents-count">{{ selection_form.contacts.field.queryset.count }} agents</span> dans cette structure</p>
+                                        </div>
                                     </div>
-                                </div>
-                            {% endfor %}
-                        </fieldset>
-                        {{ selection_form.structure }}
-                        {{ selection_form.content_type_id }}
-                        {{ selection_form.fiche_id }}
-                        {{ selection_form.next }}
-                        <button type="submit" form="form-selection" class="fr-btn">Ajouter les contacts sélectionnés</button>
-                    </form>
-                {% endif %}
+
+                                    {% if selection_form.contacts.errors %}
+                                        <div class="grid-row">
+                                            <div class="fr-col-8">
+                                                <div class="fr-alert fr-alert--error fr-alert--sm fr-mb-4w">
+                                                    {% for error in selection_form.contacts.errors %}
+                                                        <p>{{ error }}</p>
+                                                    {% endfor %}
+                                                    <button class="fr-btn--close fr-btn" title="Masquer le message" onclick="const alert = this.parentNode; alert.parentNode.removeChild(alert)">
+                                                        Masquer le message
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    {% endif %}
+
+                                    {% with half_value=selection_form.contacts_count_half.value|stringformat:"s" %}
+                                        {% with first_half=":"|add:half_value last_half=half_value|add:":" %}
+                                            <div class="fr-grid-row">
+                                                <div class="fr-col-6">
+                                                    {% for contact in selection_form.contacts.field.queryset|slice:first_half %}
+                                                        {% include "core/_contact_checkbox.html" with checkbox_id=forloop.counter %}
+                                                    {% endfor %}
+                                                </div>
+                                                <div class="fr-col-6">
+                                                    {% for contact in selection_form.contacts.field.queryset|slice:last_half %}
+                                                        {% include "core/_contact_checkbox.html" with checkbox_id=forloop.counter|add:half_value %}
+                                                    {% endfor %}
+                                                </div>
+                                            </div>
+                                        {% endwith %}
+                                    {% endwith %}
+
+                                    {{ selection_form.structure }}
+                                    {{ selection_form.content_type_id }}
+                                    {{ selection_form.fiche_id }}
+                                    {{ selection_form.next }}
+
+                                    <button type="submit" form="form-selection" class="fr-btn fr-mt-2w">Ajouter les contacts sélectionnés</button>
+                                </form>
+                            </div>
+                        </div>
+                    {% endif %}
+                </div>
             </div>
         </div>
 

--- a/core/templates/core/_contact_checkbox.html
+++ b/core/templates/core/_contact_checkbox.html
@@ -1,0 +1,8 @@
+<div class="fr-fieldset__element">
+    <div class="fr-checkbox-group">
+        <input name="contacts" id="checkboxes-{{ checkbox_id }}" type="checkbox" value="{{ contact.id }}" aria-describedby="checkboxes-{{ checkbox_id }}-messages">
+        <label class="fr-label" for="checkboxes-{{ checkbox_id }}">
+            {{ contact.agent.nom }} {{ contact.agent.prenom }}{% if contact.agent.fonction_hierarchique %} ({{ contact.agent.fonction_hierarchique }}){% endif %}
+        </label>
+    </div>
+</div>

--- a/core/templates/core/_contacts.html
+++ b/core/templates/core/_contacts.html
@@ -3,7 +3,6 @@
         Ajouter un agent
     </a>
 </div>
-{{contact_list}}
 <div class="fr-container--fluid">
     <div class="fr-grid-row fr-grid-row--gutters">
         {% for contact in contacts %}

--- a/sv/tests/test_contact_add.py
+++ b/sv/tests/test_contact_add.py
@@ -79,25 +79,22 @@ def test_add_contact_form_select_structure(live_server, page, fiche_detection, c
     page.get_by_role("button", name="Rechercher").click()
     contact1 = contacts[0]
     contact2 = contacts[1]
-    expect(page.get_by_text(f"MUS - {contact1.agent.nom}")).to_be_visible()
-    expect(page.get_by_text(f"MUS - {contact1.agent.nom}")).to_contain_text(
-        f"{contact1.agent.structure.libelle} - {contact1.agent.nom}"
-    )
-    expect(page.get_by_text(f"MUS - {contact2.agent.nom}")).to_be_visible()
-    expect(page.get_by_text(f"MUS - {contact2.agent.nom}")).to_contain_text(
-        f"{contact2.agent.structure.libelle} - {contact2.agent.nom}"
-    )
+    expect(page.get_by_text(f"{contact1.agent.nom}")).to_be_visible()
+    expect(page.get_by_text(f"{contact1.agent.nom}")).to_contain_text(f"{contact1.agent.nom} {contact1.agent.prenom}")
+    expect(page.get_by_text(f"{contact2.agent.nom}")).to_be_visible()
+    expect(page.get_by_text(f"{contact2.agent.nom}")).to_contain_text(f"{contact2.agent.nom} {contact2.agent.prenom}")
 
 
 @pytest.mark.django_db(transaction=True, serialized_rollback=True)
 def test_add_contact_to_a_fiche(live_server, page, fiche_detection, contacts):
     """Test l'ajout d'un contact à une fiche de détection"""
+    contact1 = contacts[0]
     page.goto(f"{live_server.url}/{fiche_detection.get_absolute_url()}")
     page.get_by_role("tab", name="Contacts").click()
     page.get_by_role("link", name="Ajouter un agent").click()
     _pick_structure(page, "MUS")
     page.get_by_role("button", name="Rechercher").click()
-    page.get_by_text("MUS -").first.click()
+    page.get_by_text(f"{contact1.agent.nom} {contact1.agent.prenom}").click()
     page.get_by_role("button", name="Ajouter les contacts sélectionnés").click()
     page.get_by_role("tab", name="Contacts").click()
 
@@ -108,13 +105,15 @@ def test_add_contact_to_a_fiche(live_server, page, fiche_detection, contacts):
 @pytest.mark.django_db(transaction=True, serialized_rollback=True)
 def test_add_multiple_contacts_to_a_fiche(live_server, page, fiche_detection, contacts):
     """Test l'ajout de plusieurs contacts à une fiche de détection"""
+    contact1 = contacts[0]
+    contact2 = contacts[1]
     page.goto(f"{live_server.url}/{fiche_detection.get_absolute_url()}")
     page.get_by_role("tab", name="Contacts").click()
     page.get_by_role("link", name="Ajouter un agent").click()
     _pick_structure(page, "MUS")
     page.get_by_role("button", name="Rechercher").click()
-    page.get_by_text("MUS -").first.click()
-    page.get_by_text("MUS -").nth(1).click()
+    page.get_by_text(f"{contact1.agent.nom} {contact1.agent.prenom}").click()
+    page.get_by_text(f"{contact2.agent.nom} {contact2.agent.prenom}").click()
     page.get_by_role("button", name="Ajouter les contacts sélectionnés").click()
 
     expect(page.get_by_text("Les 2 contacts ont été ajoutés avec succès.")).to_be_visible()


### PR DESCRIPTION
Cette PR apporte quelques modifications pour respecter le design du formulaire d'ajout de contacts sur une fiche détection : 
- Liste des contacts sur 2 colonnes
- Suppression de l'affichage de la structure dans les résultats
- Fond blanc + padding/margin