### PR TITLE
Ajouter le créateur en tant que contact par défaut

### DIFF
--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -127,3 +127,6 @@ def test_fiche_detection_create_without_lieux_and_prelevement(
     assert fiche_detection.mesures_consignation == "test mesures consignation"
     assert fiche_detection.mesures_phytosanitaires == "test mesures phyto"
     assert fiche_detection.mesures_surveillance_specifique == "test mesures surveillance"
+
+    page.get_by_test_id("contacts").click()
+    expect(page.get_by_text(str(mocked_authentification_user.agent), exact=True)).to_be_visible()

--- a/sv/views.py
+++ b/sv/views.py
@@ -288,7 +288,7 @@ class FicheDetectionCreateView(FicheDetectionContextMixin, CreateView):
             mesures_surveillance_specifique=data["mesuresSurveillanceSpecifique"],
         )
         fiche.save()
-
+        fiche.contacts.add(self.request.user.agent.contact_set.get())
         return fiche
 
     def create_lieux(self, lieux, fiche):


### PR DESCRIPTION
Ce commit permet l'ajout du créateur d'une fiche détection en tant que contact par défaut de la fiche. Pour le moment n'est pas généralisé car je ne sais pas si cela doit être fait pour les autres types de fiches. Autre pistes:
- Mettre la logique dans le save de l'objet
- Utiliser un signal pour ajouter le contact