### PR TITLE
Permettre la suppression d'un contact d'une fiche

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -1,3 +1,5 @@
+from django.contrib.contenttypes.models import ContentType
+
 from core.forms import DocumentUploadForm, DocumentEditForm
 from .filters import DocumentFilter
 from core.models import Document
@@ -43,4 +45,5 @@ class WithContactListInContextMixin:
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["contacts"] = self.get_object().contacts.prefetch_related("agent__structure")
+        context["content_type"] = ContentType.objects.get_for_model(self.get_object())
         return context

--- a/core/templates/core/_carte_resume_contact.html
+++ b/core/templates/core/_carte_resume_contact.html
@@ -6,6 +6,10 @@
             <p class="fr-tag">{{contact.agent.structure}}</p>
             <p class="fr-mt-3w fr-mb-1w"><a href="mailto:{{ contact.email }}" class="fr-link">{{ contact.email }}</a></p>
             <p class="fr-mt-1w">{{ contact.agent.telephone }}</p>
+            <div class="fr-btns-group--right">
+                <a href="#" class="fr-icon-delete-line fr-btn fr-btn--tertiary" data-fr-opened="false" aria-controls="fr-modal-contact-{{ contact.pk }}"></a>
+            </div>
         </div>
     </div>
 </div>
+{% include "core/_modale_suppression_contact.html" %}

--- a/core/templates/core/_modale_suppression_contact.html
+++ b/core/templates/core/_modale_suppression_contact.html
@@ -1,0 +1,32 @@
+<dialog aria-labelledby="fr-modal-contact-{{ contact.pk }}-title" id="fr-modal-contact-{{ contact.pk }}" class="fr-modal" role="dialog">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button class="fr-btn--close fr-btn" aria-controls="fr-modal-contact-{{ contact.pk }}">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content"><h1 class="fr-modal__title"><span
+                        class="fr-icon-arrow-right-line fr-icon--lg"></span>Supprimer</h1>
+                        Voulez-vous supprimer le contact {{ contact }} ?
+                    </div>
+
+                    <div class="fr-modal__footer">
+                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg">
+                            <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-contact-{{ contact.pk }}">Annuler</button>
+                            <form action="{% url 'contact-delete' %}" method="POST">
+                                {% csrf_token %}
+                                <input type="hidden" value="{{ fiche.pk }}" name="fiche_pk">
+                                <input type="hidden" value="{{ content_type.pk }}" name="content_type_pk">
+                                <input type="hidden" value="{{ contact.pk }}" name="pk">
+                                <input type="hidden" value="{{ redirect_url }}" name="next">
+                                <button type="submit" class="fr-btn" data-testid="contact-delete-{{ contact.pk }}">Oui, je supprime</button>
+                            </form>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/core/urls.py
+++ b/core/urls.py
@@ -6,6 +6,7 @@ from .views import (
     DocumentUpdateView,
     ContactAddFormView,
     ContactSelectionView,
+    ContactDeleteView,
     MessageCreateView,
     MessageDetailsView,
 )
@@ -38,6 +39,11 @@ urlpatterns = [
     ),
     path("contacts/ajout", ContactAddFormView.as_view(), name="contact-add-form"),
     path("contacts/ajout/agents", ContactSelectionView.as_view(), name="contact-add-form-select-agents"),
+    path(
+        "contacts/suppression/",
+        ContactDeleteView.as_view(),
+        name="contact-delete",
+    ),
     path(
         "message-add/<str:message_type>/<int:obj_type_pk>/<int:obj_pk>/",
         MessageCreateView.as_view(),

--- a/core/views.py
+++ b/core/views.py
@@ -15,7 +15,7 @@ from django.http import HttpResponseRedirect
 from django.utils.translation import ngettext
 
 
-from .models import Document, Message
+from .models import Document, Message, Contact
 
 from django.contrib.contenttypes.models import ContentType
 
@@ -138,6 +138,18 @@ class ContactSelectionView(FormView):
                 "selection_form": form,
             },
         )
+
+
+class ContactDeleteView(View):
+    def post(self, request, *args, **kwargs):
+        content_type = ContentType.objects.get(id=request.POST.get("content_type_pk"))
+        ModelClass = content_type.model_class()
+        fiche = get_object_or_404(ModelClass, pk=request.POST.get("fiche_pk"))
+        contact = Contact.objects.get(pk=self.request.POST.get("pk"))
+
+        fiche.contacts.remove(contact)
+        messages.success(request, "Le contact a bien été supprimé de la fiche.", extra_tags="core contacts")
+        return HttpResponseRedirect(request.POST.get("next") + "#tabpanel-contacts-panel")
 
 
 class MessageCreateView(CreateView):

--- a/sv/tests/test_fichedetection_contacts_remove.py
+++ b/sv/tests/test_fichedetection_contacts_remove.py
@@ -1,0 +1,40 @@
+import pytest
+from model_bakery import baker
+from playwright.sync_api import expect
+
+from core.models import Contact, Agent
+
+
+@pytest.mark.django_db(transaction=True, serialized_rollback=True)
+def test_can_remove_myself_from_a_fiche(live_server, page, fiche_detection, mocked_authentification_user):
+    contact = mocked_authentification_user.agent.contact_set.get()
+    fiche_detection.contacts.set([contact])
+    page.goto(f"{live_server.url}/{fiche_detection.get_absolute_url()}")
+    page.get_by_role("tab", name="Contacts").click()
+
+    page.locator(f'a[aria-controls="fr-modal-contact-{contact.id}"]').click()
+    expect(page.get_by_text(str(mocked_authentification_user.agent), exact=True)).to_be_visible()
+    expect(page.locator(f"#fr-modal-contact-{contact.id}")).to_be_visible()
+    page.get_by_test_id(f"contact-delete-{contact.id}").click()
+
+    assert page.url == f"{live_server.url}{fiche_detection.get_absolute_url()}#tabpanel-contacts-panel"
+    assert fiche_detection.contacts.count() == 0
+    expect(page.get_by_text(str(mocked_authentification_user.agent), exact=True)).not_to_be_visible()
+
+
+@pytest.mark.django_db(transaction=True, serialized_rollback=True)
+def test_can_remove_another_contact_from_a_fiche(live_server, page, fiche_detection):
+    agent = baker.make(Agent)
+    contact = baker.make(Contact, agent=agent)
+    fiche_detection.contacts.set([contact])
+    page.goto(f"{live_server.url}/{fiche_detection.get_absolute_url()}")
+    page.get_by_role("tab", name="Contacts").click()
+
+    page.locator(f'a[aria-controls="fr-modal-contact-{contact.id}"]').click()
+    expect(page.get_by_text(str(agent), exact=True)).to_be_visible()
+    expect(page.locator(f"#fr-modal-contact-{contact.id}")).to_be_visible()
+    page.get_by_test_id(f"contact-delete-{contact.id}").click()
+
+    assert page.url == f"{live_server.url}{fiche_detection.get_absolute_url()}#tabpanel-contacts-panel"
+    assert fiche_detection.contacts.count() == 0
+    expect(page.get_by_text(str(agent), exact=True)).not_to_be_visible()


### PR DESCRIPTION
Ce commit permet de retirer un contact d'une fiche si il ne fait plus partie de l'équipe en charge du traitement de la fiche. On peut retirer un autre contact ou bien soi-même.