### PR TITLE
Permettre l'extraction des fiches en CSV

### DIFF
--- a/sv/export.py
+++ b/sv/export.py
@@ -1,0 +1,96 @@
+from .models import FicheDetection
+import csv
+
+
+class FicheDetectionExport:
+    fields = [
+        "numero",
+        "numero_europhyt",
+        "numero_rasff",
+        "statut_evenement",
+        "organisme_nuisible",
+        "statut_reglementaire",
+        "date_premier_signalement",
+        "commentaire",
+        "mesures_conservatoires_immediates",
+        "mesures_consignation",
+        "mesures_phytosanitaires",
+        "mesures_surveillance_specifique",
+        "etat",
+        "date_creation",
+    ]
+    lieux_fields = [
+        "nom",
+        "wgs84_longitude",
+        "wgs84_latitude",
+        "lambert93_latitude",
+        "lambert93_longitude",
+        "adresse_lieu_dit",
+        "commune",
+        "code_insee",
+        "departement",
+    ]
+    prelevement_fields = [
+        "numero_echantillon",
+        "date_prelevement",
+        "is_officiel",
+        "numero_phytopass",
+        "resultat",
+        "structure_preleveur",
+        "site_inspection",
+        "matrice_prelevee",
+        "espece_echantillon",
+        "laboratoire_agree",
+        "laboratoire_confirmation_officielle",
+    ]
+
+    def _clean_field_name(self, field):
+        return field.replace("_", " ").title()
+
+    def get_queryset(self):
+        queryset = FicheDetection.objects.select_related("etat", "numero")
+        queryset = queryset.prefetch_related("lieux", "lieux__prelevements", "lieux__prelevements__structure_preleveur")
+        return queryset
+
+    def get_fieldnames(self):
+        return [self._clean_field_name(field) for field in self.fields + self.lieux_fields + self.prelevement_fields]
+
+    def get_fiche_data(self, fiche):
+        result = {}
+        for field in self.fields:
+            result[self._clean_field_name(field)] = getattr(fiche, field)
+        return result
+
+    def get_fiche_data_with_lieu(self, fiche, lieu):
+        result = self.get_fiche_data(fiche)
+        for field in self.lieux_fields:
+            result[self._clean_field_name(field)] = getattr(lieu, field)
+        return result
+
+    def get_fiche_data_with_prelevement(self, fiche, prelevement):
+        result = self.get_fiche_data_with_lieu(fiche, prelevement.lieu)
+        for field in self.prelevement_fields:
+            result[self._clean_field_name(field)] = getattr(prelevement, field)
+        return result
+
+    def get_lines_from_instance(self, fiche_detection):
+        lieux = fiche_detection.lieux.all()
+        if lieux:
+            for lieu in lieux:
+                prelevements = lieu.prelevements.all()
+                if prelevements:
+                    for prelevement in prelevements:
+                        yield self.get_fiche_data_with_prelevement(fiche_detection, prelevement)
+                else:
+                    yield self.get_fiche_data_with_lieu(fiche_detection, lieu)
+        else:
+            yield self.get_fiche_data(fiche_detection)
+
+    def export(self, stream):
+        queryset = self.get_queryset()
+        writer = csv.DictWriter(stream, fieldnames=self.get_fieldnames())
+        writer.writeheader()
+
+        for instance in queryset:
+            for line in self.get_lines_from_instance(instance):
+                writer.writerow(line)

--- a/sv/tests/test_export.py
+++ b/sv/tests/test_export.py
@@ -1,0 +1,159 @@
+from io import StringIO
+import pytest
+from model_bakery import baker
+from unittest import mock
+from sv.export import FicheDetectionExport
+from sv.models import Etat, FicheDetection, NumeroFiche, Lieu, Prelevement, StructurePreleveur
+import datetime
+
+
+def _create_fiche_with_lieu_and_prelevement(numero=123):
+    etat = Etat.objects.get(id=Etat.get_etat_initial())
+    numero = NumeroFiche.objects.create(annee=2024, numero=numero)
+    mocked = datetime.datetime(2024, 8, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    with mock.patch("django.utils.timezone.now", mock.Mock(return_value=mocked)):
+        fiche = baker.make(
+            FicheDetection,
+            etat=etat,
+            numero=numero,
+            numero_europhyt="EUROPHYT",
+            numero_rasff="RASFF",
+            date_premier_signalement="2024-01-01",
+            commentaire="Mon commentaire",
+            mesures_conservatoires_immediates="MCI",
+            mesures_consignation="MC",
+            mesures_phytosanitaires="MP",
+            mesures_surveillance_specifique="MSP",
+        )
+    lieu = baker.make(
+        Lieu,
+        fiche_detection=fiche,
+        nom="Mon lieu",
+        wgs84_longitude=10,
+        wgs84_latitude=20,
+        lambert93_latitude=30,
+        lambert93_longitude=40,
+        adresse_lieu_dit="L'angle",
+        commune="Saint-Pierre",
+        code_insee="12345",
+    )
+    structure = StructurePreleveur.objects.create(nom="My structure")
+    baker.make(
+        Prelevement,
+        lieu=lieu,
+        numero_echantillon="Echantillon 3",
+        date_prelevement="2023-12-12",
+        is_officiel=True,
+        numero_phytopass="Phyto123",
+        resultat="detecte",
+        structure_preleveur=structure,
+    )
+
+
+@pytest.mark.django_db
+def test_export_fiche_detection_content():
+    stream = StringIO()
+    _create_fiche_with_lieu_and_prelevement()
+    FicheDetectionExport().export(stream=stream)
+
+    stream.seek(0)
+    lines = stream.readlines()
+    assert len(lines) == 2
+
+    headers = [
+        "Numero",
+        "Numero Europhyt",
+        "Numero Rasff",
+        "Statut Evenement",
+        "Organisme Nuisible",
+        "Statut Reglementaire",
+        "Date Premier Signalement",
+        "Commentaire",
+        "Mesures Conservatoires Immediates",
+        "Mesures Consignation",
+        "Mesures Phytosanitaires",
+        "Mesures Surveillance Specifique",
+        "Etat",
+        "Date Creation",
+        "Nom",
+        "Wgs84 Longitude",
+        "Wgs84 Latitude",
+        "Lambert93 Latitude",
+        "Lambert93 Longitude",
+        "Adresse Lieu Dit",
+        "Commune",
+        "Code Insee",
+        "Departement",
+        "Numero Echantillon",
+        "Date Prelevement",
+        "Is Officiel",
+        "Numero Phytopass",
+        "Resultat",
+        "Structure Preleveur",
+        "Site Inspection",
+        "Matrice Prelevee",
+        "Espece Echantillon",
+        "Laboratoire Agree",
+        "Laboratoire Confirmation Officielle",
+    ]
+    assert lines[0] == ",".join(headers) + "\r\n"
+    assert (
+        lines[1]
+        == "2024.123,EUROPHYT,RASFF,,,,2024-01-01,Mon commentaire,MCI,MC,MP,MSP,nouveau,2024-08-01 00:00:00+00:00,Mon lieu,10.0,20.0,30.0,40.0,L'angle,Saint-Pierre,12345,,Echantillon 3,2023-12-12,True,Phyto123,detecte,My structure,,,,,\r\n"
+    )
+
+
+@pytest.mark.django_db
+def test_export_fiche_detection_performance(django_assert_num_queries):
+    stream = StringIO()
+    _create_fiche_with_lieu_and_prelevement()
+
+    with django_assert_num_queries(4):
+        FicheDetectionExport().export(stream=stream)
+
+    stream.seek(0)
+    lines = stream.readlines()
+    assert len(lines) == 2
+
+    stream = StringIO()
+    _create_fiche_with_lieu_and_prelevement(numero=4)
+    _create_fiche_with_lieu_and_prelevement(numero=5)
+    _create_fiche_with_lieu_and_prelevement(numero=6)
+    with django_assert_num_queries(4):
+        FicheDetectionExport().export(stream=stream)
+
+    stream.seek(0)
+    lines = stream.readlines()
+    assert len(lines) == 5
+
+
+@pytest.mark.django_db
+def test_export_fiche_detection_numbers_of_lines(django_assert_num_queries):
+    stream = StringIO()
+    etat = Etat.objects.get(id=Etat.get_etat_initial())
+    numero = NumeroFiche.objects.create(annee=2024, numero=123)
+    mocked = datetime.datetime(2024, 8, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    with mock.patch("django.utils.timezone.now", mock.Mock(return_value=mocked)):
+        fiche = baker.make(FicheDetection, etat=etat, numero=numero)
+    _lieu_without_prelevement = baker.make(Lieu, fiche_detection=fiche)
+    _lieu_without_prelevement_2 = baker.make(Lieu, fiche_detection=fiche)
+    lieu = baker.make(
+        Lieu,
+        fiche_detection=fiche,
+        nom="Mon lieu",
+        wgs84_longitude=10,
+        wgs84_latitude=20,
+        lambert93_latitude=30,
+        lambert93_longitude=40,
+        adresse_lieu_dit="L'angle",
+        commune="Saint-Pierre",
+        code_insee="12345",
+    )
+    baker.make(Prelevement, lieu=lieu)
+    baker.make(Prelevement, lieu=lieu)
+
+    FicheDetectionExport().export(stream=stream)
+
+    stream.seek(0)
+    lines = stream.readlines()
+    assert len(lines) == 5


### PR DESCRIPTION
Ce commit va permettre l'extraction des informations d'une fiche détection au format CSV. Ce commit n'introduit que la base sans interface pour lancer l'export pour le moment (en attente de design). Les tests vérifient le contenu du fichier, les règles métiers sur le nombre de lignes dans le fichiers ansi que la performance en termes de requêtes SQL.