### PR TITLE
Améliorer et tester les perfs de la page fiche

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -22,7 +22,7 @@ class WithDocumentUploadFormMixin:
 class WithDocumentListInContextMixin:
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        documents = Document.objects.for_fiche(self.get_object())
+        documents = Document.objects.for_fiche(self.get_object()).prefetch_related("created_by_structure")
         document_filter = DocumentFilter(self.request.GET, queryset=documents)
         for document in document_filter.qs:
             document.edit_form = DocumentEditForm(instance=document)
@@ -36,7 +36,9 @@ class WithMessagesListInContextMixin:
         context["message_list"] = (
             self.get_object()
             .messages.all()
-            .prefetch_related("recipients__structure", "recipients__agent", "recipients_copy", "sender__agent")
+            .prefetch_related(
+                "recipients__structure", "recipients__agent", "recipients_copy", "sender__agent", "documents"
+            )
         )
         return context
 

--- a/core/templates/core/_carte_resume_document.html
+++ b/core/templates/core/_carte_resume_document.html
@@ -2,7 +2,7 @@
     <div class="fr-card__body">
         <div class="fr-card__content document__details {% if document.is_deleted %}document__details--deleted{% endif %}">
             <p class="fr-hint-text fr-mb-0-5v">Ajouté le {{ document.date_creation }}</p>
-            <p class="fr-text--sm document__details--structure fr-mb-1v">{{ document.created_by_structure.niveau2 | default:document.created_by_structure.niveau1 | upper }}</p>
+            <p class="fr-text--sm document__details--structure fr-mb-1v">{{ document.created_by_structure.libelle | default:document.created_by_structure.niveau2 | upper }}</p>
             <p class="fr-text--sm fr-mb-0-5v">{{ document.nom }}
                 {% if document.description %}
                     <button class="fr-btn--tooltip fr-btn" type="button" id="button-{{ document.pk }}" aria-describedby="tooltip-{{ document.pk }}">

--- a/core/templates/core/_tableau_fil_de_suivi.html
+++ b/core/templates/core/_tableau_fil_de_suivi.html
@@ -43,7 +43,7 @@
                     <a href="{% url 'message-view' message.pk  %}">{{ message.title|truncatechars:100 }}</a>
                 </td>
                 <td>
-                    {% if message.documents.count %}
+                    {% if message.documents.exists %}
                         <a href="{% url 'message-view' message.pk  %}"><i class="ri-attachment-line ri-xl" aria-hidden="true"></i></a>
                     {% endif %}
                 </td>

--- a/sv/tests/test_fichedetection_performances.py
+++ b/sv/tests/test_fichedetection_performances.py
@@ -1,0 +1,77 @@
+import pytest
+from model_bakery import baker
+
+from core.models import Message, Document
+from sv.models import FicheDetection, Lieu, Prelevement
+
+BASE_NUM_QUERIES = 9  # Please note a first call is made without assertion to warm up any possible cache
+
+
+@pytest.mark.django_db
+def test_empty_fiche_detection_performances(client, django_assert_num_queries):
+    fiche = baker.make(FicheDetection)
+    client.get(fiche.get_absolute_url())
+
+    with django_assert_num_queries(BASE_NUM_QUERIES):
+        client.get(fiche.get_absolute_url())
+
+
+@pytest.mark.django_db
+def test_fiche_detection_performances_with_messages_from_same_user(
+    client, django_assert_num_queries, mocked_authentification_user
+):
+    fiche = baker.make(FicheDetection)
+    client.get(fiche.get_absolute_url())
+
+    baker.make(Message, content_object=fiche, sender=mocked_authentification_user.agent.contact_set.get())
+    with django_assert_num_queries(BASE_NUM_QUERIES + 6):
+        client.get(fiche.get_absolute_url())
+
+    baker.make(Message, content_object=fiche, sender=mocked_authentification_user.agent.contact_set.get(), _quantity=3)
+
+    with django_assert_num_queries(BASE_NUM_QUERIES + 6):
+        response = client.get(fiche.get_absolute_url())
+
+    assert len(response.context["message_list"]) == 4
+
+
+@pytest.mark.django_db
+def test_fiche_detection_performances_with_lieux(client, django_assert_num_queries):
+    fiche = baker.make(FicheDetection)
+    client.get(fiche.get_absolute_url())
+
+    with django_assert_num_queries(BASE_NUM_QUERIES):
+        client.get(fiche.get_absolute_url())
+
+    baker.make(Lieu, fiche_detection=fiche, _quantity=3)
+    with django_assert_num_queries(BASE_NUM_QUERIES):
+        client.get(fiche.get_absolute_url())
+
+
+@pytest.mark.django_db
+def test_fiche_detection_performances_with_document(client, django_assert_num_queries):
+    fiche = baker.make(FicheDetection)
+    client.get(fiche.get_absolute_url())
+
+    with django_assert_num_queries(BASE_NUM_QUERIES):
+        client.get(fiche.get_absolute_url())
+
+    baker.make(Document, content_object=fiche, _quantity=3, _create_files=True)
+    with django_assert_num_queries(BASE_NUM_QUERIES + 1):
+        client.get(fiche.get_absolute_url())
+
+
+@pytest.mark.django_db
+def test_fiche_detection_performances_with_prelevement(client, django_assert_num_queries):
+    fiche = baker.make(FicheDetection)
+    client.get(fiche.get_absolute_url())
+
+    with django_assert_num_queries(BASE_NUM_QUERIES):
+        client.get(fiche.get_absolute_url())
+
+    for _ in range(0, 3):
+        lieu = baker.make(Lieu, fiche_detection=fiche)
+        baker.make(Prelevement, lieu=lieu)
+
+    with django_assert_num_queries(BASE_NUM_QUERIES):
+        client.get(fiche.get_absolute_url())

--- a/sv/views.py
+++ b/sv/views.py
@@ -137,19 +137,23 @@ class FicheDetectionDetailView(
     DetailView,
 ):
     model = FicheDetection
+    queryset = FicheDetection.objects.select_related("statut_reglementaire", "etat", "numero", "contexte")
+
+    def get_object(self, queryset=None):
+        if hasattr(self, "object"):
+            return self.object
+
+        self.object = super().get_object(queryset)
+        return self.object
 
     def get_object_linked_to_document(self):
         return self.get_object()
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-
-        # Ajout des lieux associés à la fiche de détection
         context["lieux"] = Lieu.objects.filter(fiche_detection=self.get_object()).order_by("id")
-
-        # Ajout des prélèvements associés à chaque lieu
-        context["prelevements"] = Prelevement.objects.filter(lieu__fiche_detection=self.get_object())
-
+        prelevement = Prelevement.objects.filter(lieu__fiche_detection=self.get_object())
+        context["prelevements"] = prelevement.select_related("structure_preleveur", "lieu")
         return context
 
 


### PR DESCRIPTION
Le but de ce commit est de tester et d'améliorer les performances de la page de détails d'une fiche détection (et des autres types de fiche dans le futur pour les objects communs).

- Mise en place de tests pour vérifier la "scalabilité" de la page en termes de requêtes SQL face a l'accroissement du nombre d'objets
- Diverses améliorations de performances : prefetch related, select related et "cache" de l'objet courant dans la vue de détails.

En local sur une page test (plusieurs messages, documents, lieux, prélévements, etc.) on passe de 137 requêtes à 25 requêtes.