### PR TITLE
Affichage de nc. quand la commune du lieu est vide

### DIFF
--- a/sv/templates/sv/_fichedetection_synthese.html
+++ b/sv/templates/sv/_fichedetection_synthese.html
@@ -23,10 +23,10 @@
                         {% if lieux_count == 0 %}
                             nc.
                         {% else %}
-                            {{ lieux.0.commune }} <span aria-describedby="tooltip-2989">+{{ lieux_count|add:"-1" }}</span>
+                            {{ lieux.0.commune|default:"nc." }} <span aria-describedby="tooltip-2989">+{{ lieux_count|add:"-1" }}</span>
                             <span class="fr-tooltip fr-placement" id="tooltip-2989" role="tooltip" aria-hidden="true">
                                 {% for lieu in lieux|slice:"1:" %}
-                                    {{ lieu.commune }}{% if not forloop.last %}, {% endif %}
+                                    {{ lieu.commune|default:"nc." }}{% if not forloop.last %}, {% endif %}
                                 {% endfor %}
                             </span>
                         {% endif %}

--- a/sv/templates/sv/fichedetection_list.html
+++ b/sv/templates/sv/fichedetection_list.html
@@ -70,15 +70,15 @@
                                     <a href="{% url 'fiche-detection-vue-detaillee' fiche.pk %}" class="fiches__list-link">
                                         {% with fiche.lieux_list|length as num_lieux %}
                                             {% if num_lieux == 0 %}
-                                                {{ fiche.lieux_list|default:"nc." }}
+                                                nc.
                                             {% endif %}
                                             {% if num_lieux <= 3 %}
                                                 {% for lieu in fiche.lieux_list %}
-                                                    {{ lieu.commune }}{% if not forloop.last %}, {% endif %}
+                                                    {{ lieu.commune|default:"nc." }}{% if not forloop.last %}, {% endif %}
                                                 {% endfor %}
                                             {% else %}
                                                 {% for lieu in fiche.lieux_list|slice:":3" %}
-                                                    {{ lieu.commune }}{% if not forloop.last %}, {% endif %}
+                                                    {{ lieu.commune|default:"nc." }}{% if not forloop.last %}, {% endif %}
                                                 {% endfor %}
                                                 ... +{{ num_lieux|add:"-3" }}
                                             {% endif %}
@@ -97,68 +97,68 @@
                                 </td>
                             </tr>
                         {% endfor %}
-                    </tbody>
-                </table>
+                        <tbody>
+                        </table>
 
             <!--
             Utilisation du tag 'url_replace' pour maintenir les paramètres de recherche lors de la pagination.
             Ce tag est utilisé pour générer les URLs de pagination tout en conservant les filtres de recherche.
             -->
-                {% if page_obj.paginator.num_pages > 1 %}
-                    <nav role="navigation" class="fr-pagination" aria-label="Pagination" style="margin-top: 2rem;">
-                        <ul class="fr-pagination__list">
-                            <li>
-                                <a class="fr-pagination__link fr-pagination__link--first" href="?{% url_replace page='1' %}" role="link" aria-describedby="tooltip-first-page">
-                                    Première page
-                                </a>
-                                <span class="fr-tooltip fr-placement" id="tooltip-first-page" role="tooltip" aria-hidden="true">Première page</span>
-                            </li>
-
-                            <li>
-                                <a class="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
-                                   {% if page_obj.has_previous %}
-                                       href="?{% url_replace page=page_obj.previous_page_number %}"
-                                   {% endif %}
-                                   role="link"
-                                   aria-disabled="{{ page_obj.has_previous|yesno:'false,true' }}">
-                                    Page précédente
-                                </a>
-                            </li>
-
-                            {% for i in page_obj.paginator.page_range %}
-                                {% if page_obj.number == i %}
+                        {% if page_obj.paginator.num_pages > 1 %}
+                            <nav role="navigation" class="fr-pagination" aria-label="Pagination" style="margin-top: 2rem;">
+                                <ul class="fr-pagination__list">
                                     <li>
-                                        <a class="fr-pagination__link" aria-current="page" title="Page {{ i }}">
-                                            {{ i }}
+                                        <a class="fr-pagination__link fr-pagination__link--first" href="?{% url_replace page='1' %}" role="link" aria-describedby="tooltip-first-page">
+                                            Première page
+                                        </a>
+                                        <span class="fr-tooltip fr-placement" id="tooltip-first-page" role="tooltip" aria-hidden="true">Première page</span>
+                                    </li>
+
+                                    <li>
+                                        <a class="fr-pagination__link fr-pagination__link--prev fr-pagination__link--lg-label"
+                                           {% if page_obj.has_previous %}
+                                               href="?{% url_replace page=page_obj.previous_page_number %}"
+                                           {% endif %}
+                                           role="link"
+                                           aria-disabled="{{ page_obj.has_previous|yesno:'false,true' }}">
+                                            Page précédente
                                         </a>
                                     </li>
-                                {% elif i > page_obj.number|add:"-3" and i < page_obj.number|add:"3" %}
+
+                                    {% for i in page_obj.paginator.page_range %}
+                                        {% if page_obj.number == i %}
+                                            <li>
+                                                <a class="fr-pagination__link" aria-current="page" title="Page {{ i }}">
+                                                    {{ i }}
+                                                </a>
+                                            </li>
+                                        {% elif i > page_obj.number|add:"-3" and i < page_obj.number|add:"3" %}
+                                            <li>
+                                                <a class="fr-pagination__link" href="?{% url_replace page=i %}" title="Page {{ i }}">
+                                                    {{ i }}
+                                                </a>
+                                            </li>
+                                        {% endif %}
+                                    {% endfor %}
+
                                     <li>
-                                        <a class="fr-pagination__link" href="?{% url_replace page=i %}" title="Page {{ i }}">
-                                            {{ i }}
+                                        <a class="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
+                                           {% if page_obj.has_next %}href="?{% url_replace page=page_obj.next_page_number %}"{% endif %}
+                                           aria-disabled="{{ page_obj.has_next|yesno:'false,true' }}">
+                                            Page suivante
                                         </a>
                                     </li>
-                                {% endif %}
-                            {% endfor %}
 
-                            <li>
-                                <a class="fr-pagination__link fr-pagination__link--next fr-pagination__link--lg-label"
-                                   {% if page_obj.has_next %}href="?{% url_replace page=page_obj.next_page_number %}"{% endif %}
-                                   aria-disabled="{{ page_obj.has_next|yesno:'false,true' }}">
-                                    Page suivante
-                                </a>
-                            </li>
-
-                            <li>
-                                <a class="fr-pagination__link fr-pagination__link--last" href="?{% url_replace page=page_obj.paginator.num_pages %}" role="link" aria-describedby="tooltip-last-page">
-                                    Dernière page
-                                </a>
-                                <span class="fr-tooltip fr-placement" id="tooltip-last-page" role="tooltip" aria-hidden="true">Dernière page</span>
-                            </li>
-                        </ul>
-                    </nav>
-                {% endif %}
-            </div>
+                                    <li>
+                                        <a class="fr-pagination__link fr-pagination__link--last" href="?{% url_replace page=page_obj.paginator.num_pages %}" role="link" aria-describedby="tooltip-last-page">
+                                            Dernière page
+                                        </a>
+                                        <span class="fr-tooltip fr-placement" id="tooltip-last-page" role="tooltip" aria-hidden="true">Dernière page</span>
+                                    </li>
+                                </ul>
+                            </nav>
+                        {% endif %}
+                    </div>
         {% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION
Cette PR corrige l'affichage des communes d'un lieu lié à une fiche détection.
Actuellement, lorsqu'un lieu est enregistré dans une fiche détection mais que celui-ci ne possède de commune, voici l'affichage sur la liste des fiches et le détail de la fiche : 
![image](https://github.com/user-attachments/assets/0482369f-65d4-4015-9134-7f28e074fc27)
![image](https://github.com/user-attachments/assets/41599b8e-dc59-4327-bc36-5f36bd3bab35)

