### PR TITLE
Tenter de corriger les problèmes de tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -16,3 +16,4 @@ env =
     OIDC_RP_USER_ENDPOINT=
     OIDC_RP_JWKS_ENDPOINT=
     OIDC_RP_LOGOUT_ENDPOINT=
+    CACHE_CLASS=django.core.cache.backends.dummy.DummyCache

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -97,6 +97,12 @@ DATABASES = {
     "default": env.db(),
 }
 
+CACHES = {
+    "default": {
+        "BACKEND": env("CACHE_CLASS", default="django.core.cache.backends.locmem.LocMemCache"),
+    }
+}
+
 
 # Password validation
 # https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators


### PR DESCRIPTION
Nous avons régulierement des tests qui échouent de manière occasionnelle, avec comme erreur un message comme:

test_can_filter_documents_by_type_on_fiche_detection - django.db.utils.IntegrityError: insert or update on table "core_document" violates foreign key constraint "core_document_content_type_id_f051a534_fk_django_co"

Le même test peut réussir au lancement suivant et réussir quand il est lancé individuellement. En creusant je me suis rendu compte que `get_for_model` qui est utilisé dans la fixture `document_recipe` utilise du cache pour le content type. Le fait de ne pas mettre de vrai backend de cache dans les settings de test semble corriger le problème.