### PR TITLE
Permettre d'extraire les fiches détection en CSV

### DIFF
--- a/sv/static/sv/fichedetection_list.css
+++ b/sv/static/sv/fichedetection_list.css
@@ -28,6 +28,10 @@ body{
 .fiches__list-container {
     margin: 2rem;
 }
+.fiches__list-header {
+    display: flex;
+    justify-content: space-between;
+}
 .fiches__count {
     font-weight: bold;
 }

--- a/sv/templates/sv/_extract_modal.html
+++ b/sv/templates/sv/_extract_modal.html
@@ -1,0 +1,26 @@
+<dialog aria-labelledby="fr-modal-title-extract-1" role="dialog" id="fr-modal-extract" class="fr-modal">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-extract">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 id="fr-modal-extract-modal-1" class="fr-modal__title"><span class="fr-icon-arrow-right-line fr-icon--lg"></span>Extraction</h1>
+                        <p>La version actuelle de Sèves permet uniquement d'extraire la totalité des fiches, l'extraction et le téléchargement démarreront automatiquement après confirmation via le bouton "extraire" ci-dessous.</p>
+                        <div class="fr-btns-group fr-btns-group--center fr-btns-group--inline-lg">
+                            <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-extract">Annuler</button>
+                            <form method="post" action="{% url 'fiche-detection-export' %}">
+                                {% csrf_token %}
+                                <button type="submit" class="fr-btn" data-testid="extract-submit">Extraire</button>
+                            </form>
+                        </div>
+                    </div>
+
+                </div>
+
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/sv/templates/sv/fichedetection_list.html
+++ b/sv/templates/sv/fichedetection_list.html
@@ -14,6 +14,8 @@
 {% block highlight_menu_fiches %}menu__item--active{% endblock %}
 
 {% block content %}
+    {% include "sv/_extract_modal.html" %}
+
     <div class="fiches__header">
         <h2 class="fiches__title">Rechercher une fiche</h2>
         <form id="search-form" method="get" class="fiches__search-form">
@@ -32,9 +34,12 @@
 
     <div class="fiches__list-container">
         <h2>Liste des fiches</h2>
-        <p>
+        <div class="fiches__list-header">
             <span class="fiches__count">{{ page_obj.paginator.count }} fiche{{ fichedetection_list.count|pluralize }} au total</span>
-        </p>
+            <button class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-file-add-line" data-fr-opened="false" data-testid="extract-open" aria-controls="fr-modal-extract">
+                Extraire
+            </button>
+        </div>
         {% if fichedetection_list.count %}
             <div class="fr-table fr-table--no-caption fr-table--layout-fixed">
                 <table class="fiches__list-table">

--- a/sv/tests/test_fichedetection_export.py
+++ b/sv/tests/test_fichedetection_export.py
@@ -1,0 +1,15 @@
+from django.urls import reverse
+from playwright.sync_api import expect
+
+
+def test_can_download_export_fiche_detection(live_server, page, fiche_detection):
+    page.goto(f"{live_server.url}{reverse('fiche-detection-list')}")
+
+    page.get_by_test_id("extract-open").click()
+    expect(page.get_by_test_id("extract-submit")).to_be_visible()
+
+    with page.expect_download() as download_info:
+        page.get_by_test_id("extract-submit").click()
+
+    download = download_info.value
+    assert download.suggested_filename == "export_fiche_detection.csv"

--- a/sv/urls.py
+++ b/sv/urls.py
@@ -5,6 +5,7 @@ from .views import (
     FicheDetectionCreateView,
     FicheDetectionUpdateView,
     FreeLinkCreateView,
+    FicheDetectionExportView,
 )
 
 urlpatterns = [
@@ -22,6 +23,11 @@ urlpatterns = [
         "fiches-detection/creation/",
         FicheDetectionCreateView.as_view(),
         name="fiche-detection-creation",
+    ),
+    path(
+        "fiches-detection/export/",
+        FicheDetectionExportView.as_view(),
+        name="fiche-detection-export",
     ),
     path(
         "fiches-detection/<int:pk>/modification/",

--- a/sv/views.py
+++ b/sv/views.py
@@ -6,6 +6,7 @@ import uuid
 from django.contrib.contenttypes.models import ContentType
 from django.utils import timezone
 from django.shortcuts import redirect
+from django.views import View
 from django.views.generic import (
     ListView,
     DetailView,
@@ -15,8 +16,8 @@ from django.views.generic import (
 )
 from django.urls import reverse
 from django.db.models import OuterRef, Subquery, Prefetch
-from django.http import HttpResponseBadRequest, HttpResponseRedirect
 from django.db import transaction, IntegrityError
+from django.http import HttpResponseBadRequest, HttpResponseRedirect, HttpResponse
 from django.core.exceptions import ValidationError
 from django.contrib import messages
 from django import forms
@@ -29,6 +30,7 @@ from core.mixins import (
     WithFreeLinksListInContextMixin,
 )
 from sv.forms import FreeLinkForm
+from .export import FicheDetectionExport
 from .models import (
     FicheDetection,
     Lieu,
@@ -562,3 +564,13 @@ class FreeLinkCreateView(FormView):
 
         messages.success(request, "Le lien a été créé avec succès.")
         return HttpResponseRedirect(self.request.POST.get("next"))
+
+
+class FicheDetectionExportView(View):
+    http_method_names = ["post"]
+
+    def post(self, request):
+        response = HttpResponse(content_type="text/csv")
+        FicheDetectionExport().export(stream=response)
+        response["Content-Disposition"] = "attachment; filename=export_fiche_detection.csv"
+        return response


### PR DESCRIPTION
Fait juste le branchement entre l'interface et le code existant pour permettre les téléchargement de toute les fiches.