### PR TITLE
Permettre de sélectionner un destinataire - Compte rendu

### DIFF
--- a/core/fields.py
+++ b/core/fields.py
@@ -19,3 +19,7 @@ class MultiModelChoiceField(forms.ChoiceField):
             return model_class.objects.get(id=object_id)
         except model_class.DoesNotExist:
             raise forms.ValidationError("L'objet sélectionné n'existe pas.")
+
+
+class DSFRCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
+    option_template_name = "forms/dsfr_checkbox_option.html"

--- a/core/managers.py
+++ b/core/managers.py
@@ -26,3 +26,9 @@ class DocumentQueryset(QuerySet):
 class ContactQueryset(QuerySet):
     def with_structure_and_agent(self):
         return self.select_related("structure", "agent")
+
+    def get_mus(self):
+        return self.get(structure__niveau2="MUS")
+
+    def get_bsv(self):
+        return self.get(structure__niveau2="SAS/SDSPV/BSV")

--- a/core/models.py
+++ b/core/models.py
@@ -129,6 +129,7 @@ class Message(models.Model):
     )
     TYPES_TO_FEMINIZE = (NOTE, DEMANDE_INTERVENTION, FIN_INTERVENTION)
     TYPES_WITHOUT_RECIPIENTS = (NOTE, POINT_DE_SITUATION, FIN_INTERVENTION)
+    TYPES_WITH_LIMITED_RECIPIENTS = COMPTE_RENDU
 
     message_type = models.CharField(max_length=100, choices=MESSAGE_TYPE_CHOICES)
     title = models.CharField(max_length=512, verbose_name="Titre")

--- a/core/templates/core/_fil-de-suivi.html
+++ b/core/templates/core/_fil-de-suivi.html
@@ -15,7 +15,7 @@
                     <li><a class="fr-translate__language fr-nav__link" href="{{ fiche.add_note_url }}">Note</a></li>
                     <li><a class="fr-translate__language fr-nav__link" href="{{ fiche.add_point_de_suivi_url }}">Point de situation</a></li>
                     <li><a class="fr-translate__language fr-nav__link" href="{{ fiche.add_demande_intervention_url }}">Demande d'intervention</a></li>
-                    <li><a class="fr-translate__language fr-nav__link" href="{{ fiche.add_compte_rendu_url }}">Compte rendu sur demande d'intervention</a></li>
+                    <li><a class="fr-translate__language fr-nav__link" href="{{ fiche.add_compte_rendu_url }}" data-testid="fildesuivi-actions-compte-rendu">Compte rendu sur demande d'intervention</a></li>
                     <li><a class="fr-translate__language fr-nav__link" href="{{ fiche.add_fin_intervention_url }}">Fin d'intervention</a></li>
                 </ul>
             </div>

--- a/core/templates/forms/dsfr_checkbox_option.html
+++ b/core/templates/forms/dsfr_checkbox_option.html
@@ -1,0 +1,2 @@
+{% include "django/forms/widgets/input.html" %}
+{% if widget.wrap_label %}<label{% if widget.attrs.id %} for="{{ widget.attrs.id }}"{% endif %} class="fr-mb-2v">{{ widget.label }}</label>{% endif %}

--- a/sv/tests/test_fiche_detection_message.py
+++ b/sv/tests/test_fiche_detection_message.py
@@ -1,6 +1,6 @@
 from model_bakery import baker
 from playwright.sync_api import Page, expect
-from core.models import Message, Contact, Agent
+from core.models import Message, Contact, Agent, Structure
 from ..models import FicheDetection
 
 
@@ -198,3 +198,52 @@ def test_can_add_and_see_note_without_document(live_server, page: Page, fiche_de
 
     expect(page.get_by_role("heading", name="Title of the message")).to_be_visible()
     assert "My content <br> with a line return" in page.get_by_test_id("message-content").inner_html()
+
+
+def test_can_add_and_see_compte_rendu(live_server, page: Page, fiche_detection: FicheDetection):
+    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
+
+    Contact.objects.create(structure=Structure.objects.create(niveau1="MUS", niveau2="MUS", libelle="MUS"))
+    structure = Structure.objects.create(niveau1="SAS/SDSPV/BSV", niveau2="SAS/SDSPV/BSV", libelle="BSV")
+    Contact.objects.create(structure=structure)
+    page.get_by_test_id("element-actions").click()
+    page.get_by_test_id("fildesuivi-actions-compte-rendu").click()
+
+    page.wait_for_url(f"**{fiche_detection.add_compte_rendu_url}")
+    page.get_by_text("MUS").click()
+    page.get_by_text("BSV").click()
+    page.locator("#id_title").fill("Title of the message")
+    page.locator("#id_content").fill("My content \n with a line return")
+    page.get_by_test_id("fildesuivi-add-submit").click()
+
+    page.wait_for_url(f"**{fiche_detection.get_absolute_url()}#tabpanel-messages-panel")
+
+    cell_selector = f"#table-sm-row-key-1 td:nth-child({2}) a"
+    assert page.text_content(cell_selector) == "Structure Test"
+
+    cell_selector = f"#table-sm-row-key-1 td:nth-child({3}) a"
+    assert page.text_content(cell_selector).strip() == "MUS et 1 autres"
+
+    cell_selector = f"#table-sm-row-key-1 td:nth-child({4}) a"
+    assert page.text_content(cell_selector) == "Title of the message"
+
+    cell_selector = f"#table-sm-row-key-1 td:nth-child({6}) a"
+    assert page.text_content(cell_selector) == "Compte Rendu Sur Demande D'Intervention"
+
+
+def test_cant_add_compte_rendu_without_recipient(live_server, page: Page, fiche_detection: FicheDetection):
+    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
+
+    Contact.objects.create(structure=Structure.objects.create(niveau1="MUS", niveau2="MUS", libelle="MUS"))
+    structure = Structure.objects.create(niveau1="SAS/SDSPV/BSV", niveau2="SAS/SDSPV/BSV", libelle="BSV")
+    Contact.objects.create(structure=structure)
+    page.get_by_test_id("element-actions").click()
+    page.get_by_test_id("fildesuivi-actions-compte-rendu").click()
+
+    page.wait_for_url(f"**{fiche_detection.add_compte_rendu_url}")
+    page.locator("#id_title").fill("Title of the message")
+    page.locator("#id_content").fill("My content \n with a line return")
+    page.get_by_test_id("fildesuivi-add-submit").click()
+
+    page.wait_for_url(f"**{fiche_detection.add_compte_rendu_url}")
+    expect(page.get_by_text("Au moins un destinataire doit être sélectionné.")).to_be_visible()


### PR DESCRIPTION
Pour les compte rendus sur DI permet de sélectionner un destinataire au choix entre la MUS ou le BSV (ou les deux) et envoi le message au bon destinataire.
Ajout d'un champ de formulaire pour les checkbox DSFR.