### PR TITLE
Ajout structure à la liste des contacts lors de la création d'une fiche détection

### DIFF
--- a/sv/views.py
+++ b/sv/views.py
@@ -314,6 +314,7 @@ class FicheDetectionCreateView(FicheDetectionContextMixin, CreateView):
         )
         fiche.save()
         fiche.contacts.add(self.request.user.agent.contact_set.get())
+        fiche.contacts.add(self.request.user.agent.structure.contact_set.get())
         return fiche
 
     def create_lieux(self, lieux, fiche):


### PR DESCRIPTION
Cette PR permet d'ajouter la structure de l'agent créateur de la fiche détection à la liste des contacts de la fiche détection.
Actuellement, seul l'agent est ajouté dans la liste des contacts.