### PR TITLE
Corrige des redirections ouvertes sur paramètre POST

### DIFF
--- a/core/redirect.py
+++ b/core/redirect.py
@@ -1,0 +1,9 @@
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from django.utils.http import url_has_allowed_host_and_scheme
+
+
+def safe_redirect(url):
+    if not url_has_allowed_host_and_scheme(url, allowed_hosts=None):
+        url = reverse("index")
+    return HttpResponseRedirect(url)

--- a/core/views.py
+++ b/core/views.py
@@ -23,6 +23,8 @@ from .models import Document, Message, Contact, FinSuiviContact
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 
+from .redirect import safe_redirect
+
 
 class DocumentUploadView(FormView):
     form_class = DocumentUploadForm
@@ -36,10 +38,10 @@ class DocumentUploadView(FormView):
             document.created_by_structure = agent.structure
             document.save()
             messages.success(request, "Le document a été ajouté avec succès.", extra_tags="core documents")
-            return HttpResponseRedirect(self.request.POST.get("next") + "#tabpanel-documents-panel")
+            return safe_redirect(self.request.POST.get("next") + "#tabpanel-documents-panel")
 
         messages.error(request, "Une erreur s'est produite lors de l'ajout du document")
-        return HttpResponseRedirect(self.request.POST.get("next") + "#tabpanel-documents-panel")
+        return safe_redirect(self.request.POST.get("next") + "#tabpanel-documents-panel")
 
 
 class DocumentDeleteView(View):
@@ -49,7 +51,7 @@ class DocumentDeleteView(View):
         document.deleted_by = self.request.user.agent
         document.save()
         messages.success(request, "Le document a été marqué comme supprimé.", extra_tags="core documents")
-        return HttpResponseRedirect(request.POST.get("next") + "#tabpanel-documents-panel")
+        return safe_redirect(request.POST.get("next") + "#tabpanel-documents-panel")
 
 
 class DocumentUpdateView(UpdateView):
@@ -122,8 +124,7 @@ class ContactSelectionView(FormView):
         ) % {"count": len(contacts)}
         messages.success(self.request, message, extra_tags="core contacts")
 
-        redirect_url = self.request.POST.get("next") + "#tabpanel-contacts-panel"
-        return HttpResponseRedirect(redirect_url)
+        return safe_redirect(self.request.POST.get("next") + "#tabpanel-contacts-panel")
 
     def form_invalid(self, form):
         add_form = ContactAddForm(
@@ -153,7 +154,7 @@ class ContactDeleteView(View):
 
         fiche.contacts.remove(contact)
         messages.success(request, "Le contact a bien été supprimé de la fiche.", extra_tags="core contacts")
-        return HttpResponseRedirect(request.POST.get("next") + "#tabpanel-contacts-panel")
+        return safe_redirect(request.POST.get("next") + "#tabpanel-contacts-panel")
 
 
 class MessageCreateView(CreateView):
@@ -319,8 +320,7 @@ class StructureSelectionView(FormView):
         ) % {"count": len(contacts)}
         messages.success(self.request, message, extra_tags="core contacts")
 
-        redirect_url = self.request.POST.get("next") + "#tabpanel-contacts-panel"
-        return HttpResponseRedirect(redirect_url)
+        return safe_redirect(self.request.POST.get("next") + "#tabpanel-contacts-panel")
 
 
 class SoftDeleteView(View):
@@ -337,7 +337,7 @@ class SoftDeleteView(View):
         except AttributeError:
             messages.error(request, "Ce type d'objet ne peut pas être supprimé")
 
-        return HttpResponseRedirect(request.POST.get("next"))
+        return safe_redirect(request.POST.get("next"))
 
 
 class ACNotificationView(View):
@@ -356,4 +356,4 @@ class ACNotificationView(View):
         except ValidationError:
             messages.error(request, "Cet objet est déjà notifié à l'AC")
 
-        return HttpResponseRedirect(request.POST.get("next"))
+        return safe_redirect(request.POST.get("next"))

--- a/sv/views.py
+++ b/sv/views.py
@@ -29,6 +29,7 @@ from core.mixins import (
     WithContactListInContextMixin,
     WithFreeLinksListInContextMixin,
 )
+from core.redirect import safe_redirect
 from sv.forms import FreeLinkForm
 from .export import FicheDetectionExport
 from .models import (
@@ -558,16 +559,16 @@ class FreeLinkCreateView(FormView):
         form = FreeLinkForm(request.POST)
         if not form.is_valid():
             messages.error(request, "Ce lien existe déjà.")
-            return HttpResponseRedirect(self.request.POST.get("next"))
+            return safe_redirect(self.request.POST.get("next"))
 
         try:
             form.save()
         except IntegrityError:
             messages.error(request, "Vous ne pouvez pas lier un objet à lui même.")
-            return HttpResponseRedirect(self.request.POST.get("next"))
+            return safe_redirect(self.request.POST.get("next"))
 
         messages.success(request, "Le lien a été créé avec succès.")
-        return HttpResponseRedirect(self.request.POST.get("next"))
+        return safe_redirect(self.request.POST.get("next"))
 
 
 class FicheDetectionExportView(View):


### PR DESCRIPTION
Corrige quelques "open redirect" qui peuvent arriver au sein de l'outil si un utilisateur manipule le payload. Très peu probable car il faudrait forger le contenu du formulaire pour rediriger un utilisateur tiers.

Ca fera plaisir au bot.