### PR TITLE
Ajouter les structures en un clic au message

### DIFF
--- a/core/static/core/message.css
+++ b/core/static/core/message.css
@@ -67,3 +67,8 @@
     display: flex;
     justify-content: end;
 }
+label[for=id_recipients], label[for=id_recipients_copy]
+{
+    display: flex;
+    justify-content: space-between;
+}

--- a/core/static/core/message_form.js
+++ b/core/static/core/message_form.js
@@ -1,3 +1,4 @@
+
 function cloneDocumentInput(input, currentID, destination){
     let newFileInput = input.cloneNode()
     newFileInput.setAttribute("id", `document_file_${currentID}`)
@@ -46,6 +47,11 @@ function allowToValidateWhenDocumentIsSelected(typeInput, fileInput,messageAddDo
     })
 }
 
+function addStructuresToRecipients(event, choiceElement){
+    event.preventDefault()
+    choiceElement.setChoiceByValue(event.target.getAttribute("data-structures").split(","))
+}
+
 document.addEventListener('DOMContentLoaded', function () {
     let currentID = 0
     const messageAddDocumentButton = document.getElementById("message-add-document")
@@ -74,9 +80,7 @@ document.addEventListener('DOMContentLoaded', function () {
         currentID += 1;
 
     });
-});
 
-document.addEventListener('DOMContentLoaded', function() {
     const choicesRecipients = new Choices(document.getElementById('id_recipients'), {
         removeItemButton: true,
         classNames: {containerInner: 'fr-select'},
@@ -87,4 +91,7 @@ document.addEventListener('DOMContentLoaded', function() {
         classNames: {containerInner: 'fr-select'},
         itemSelectText: ''
     });
+
+    document.querySelector(".destinataires-shortcut").addEventListener("click", event => addStructuresToRecipients(event, choicesRecipients))
+    document.querySelector(".copie-shortcut").addEventListener("click", event => addStructuresToRecipients(event, choicesCopy))
 });

--- a/core/templates/core/_contact_add_form.html
+++ b/core/templates/core/_contact_add_form.html
@@ -4,10 +4,6 @@
 
 {% block extrahead %}
     <link rel="stylesheet" href="{% static 'core/contact_add_form.css' %}">
-
-    <!-- choicesjs (autocompletion pour select) -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/styles/choices.min.css" />
-    <script src="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/scripts/choices.min.js"></script>
 {% endblock %}
 
 {% block scripts %}
@@ -15,11 +11,11 @@
         document.addEventListener('DOMContentLoaded', function() {
             const element = document.getElementById('id_structure');
             const choices = new Choices(element, {
-                searchResultLimit: 500,
+                itemSelectText: '',
                 classNames: {
                     containerInner: 'fr-select fr-mt-1w',
                 },
-                itemSelectText: ''
+                searchResultLimit: 500,
             });
         });
     </script>


### PR DESCRIPTION
Permet d'ajouter toutes les structures d'une fiche en tant que destinataire et/ou copie en un seul clic.

Embarque une mise à jour de la bibliothèque pour bénéficier de l'amélioration drastique des performances sur les listes longues (ce qui est notre cas): https://github.com/Choices-js/Choices/issues/816 .