### PR TITLE
Améliorer la page de gestion des droits

### DIFF
--- a/account/static/account/base.css
+++ b/account/static/account/base.css
@@ -1,5 +1,5 @@
 .user-permissions--container {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    grid-gap: 10px;
+    grid-gap: 10px 40px;
 }

--- a/account/templatetags/groups.py
+++ b/account/templatetags/groups.py
@@ -1,0 +1,12 @@
+from django import template
+from django.contrib.auth.models import Group
+
+register = template.Library()
+
+
+@register.filter(name="has_group")
+def has_group(user, group_name):
+    group = Group.objects.filter(name=group_name).first()
+    if not group:
+        return False
+    return group in user.groups.all()

--- a/account/tests/test_handle_permission_view.py
+++ b/account/tests/test_handle_permission_view.py
@@ -15,6 +15,14 @@ def test_need_group_to_add_permission(live_server, page, mocked_authentification
 
 
 @pytest.mark.django_db
+def test_user_can_see_navigation_without_group(live_server, page, mocked_authentification_user):
+    page.goto(f"{live_server.url}")
+    page.locator(".fr-icon-account-circle-line").click()
+    page.wait_for_timeout(200)
+    expect(page.get_by_text("Gestion des droits d'accès")).not_to_be_visible()
+
+
+@pytest.mark.django_db
 def test_can_add_permissions(live_server, page, mocked_authentification_user):
     structure = mocked_authentification_user.agent.structure
     group = Group.objects.create(name="access_admin")

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load groups %}
 
 <!doctype html>
 <html lang="fr">
@@ -65,7 +66,9 @@
                                                 <input type="submit" value="Se déconnecter" class="fr-nav__link">
                                             </form>
                                         </li>
-                                        <li class="fr-nav__link"><a href="{% url 'handle-permissions' %}" >Gestion des droits d'accès</a></li>
+                                        {% if request.user|has_group:"access_admin" %}
+                                            <li class="fr-nav__link"><a href="{% url 'handle-permissions' %}" >Gestion des droits d'accès</a></li>
+                                        {% endif %}
                                     </ul>
                                 </div>
                             {% endif %}

--- a/sv/tests/test_fichedetection_performances.py
+++ b/sv/tests/test_fichedetection_performances.py
@@ -4,7 +4,7 @@ from model_bakery import baker
 from core.models import Message, Document, Structure, Contact
 from sv.models import FicheDetection, Lieu, Prelevement
 
-BASE_NUM_QUERIES = 12  # Please note a first call is made without assertion to warm up any possible cache
+BASE_NUM_QUERIES = 13  # Please note a first call is made without assertion to warm up any possible cache
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
- Cacher le menu si l'utilisateur n'a pas les droits pour consulter la page.
- Améliorer la lisibilité en augmentant les marges dans la grille.