### PR TITLE
Changer la redirection après notification à l'AC

### DIFF
--- a/sv/templates/sv/_action_navigation.html
+++ b/sv/templates/sv/_action_navigation.html
@@ -9,7 +9,7 @@
                         <form action="{% url 'notify-ac' %}" method="post">
                             <button class="fr-translate__language fr-nav__link" href="#" type="submit"><span class="fr-icon-notification-3-fill fr-mr-2v fr-icon--sm" aria-hidden="true">
                                 {% csrf_token %}
-                                <input type="hidden" value="{% url 'fiche-detection-list' %}" name="next">
+                                <input type="hidden" value="{{ fichedetection.get_absolute_url }}" name="next">
                                 <input type="hidden" value="{{ content_type.id }}" name="content_type_id">
                                 <input type="hidden" value="{{ fichedetection.pk }}" name="content_id">
                             </span>Déclarer à l'AC</button>

--- a/sv/tests/test_fichedetection_ac_notification.py
+++ b/sv/tests/test_fichedetection_ac_notification.py
@@ -14,7 +14,6 @@ def test_can_notify_ac(live_server, page: Page, fiche_detection: FicheDetection,
 
     expect(page.get_by_text("L'administration centrale a été notifiée avec succès")).to_be_visible()
 
-    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
     expect(page.get_by_text("Déclaré AC")).to_be_visible()
 
     cell_selector = f"#table-sm-row-key-1 td:nth-child({4}) a"


### PR DESCRIPTION
Redirige vers la fiche en question plutôt que vers la liste.

Corrige #294