### PR TITLE
Corriger un bug lors de l'édition de la fiche détection

### DIFF
--- a/sv/static/sv/fichedetection_form.js
+++ b/sv/static/sv/fichedetection_form.js
@@ -502,8 +502,9 @@ document.addEventListener('alpine:init', () => {
             }
 
             let formData = new FormData();
+            const organismeNuisibleId = this.ficheDetection.organismeNuisibleId.value ? this.ficheDetection.organismeNuisibleId.value : this.ficheDetection.organismeNuisibleId
             formData.append('statutEvenementId', this.ficheDetection.statutEvenementId);
-            formData.append('organismeNuisibleId', this.ficheDetection.organismeNuisibleId.value ? this.ficheDetection.organismeNuisibleId.value : '');
+            formData.append('organismeNuisibleId', organismeNuisibleId);
             formData.append('statutReglementaireId', this.ficheDetection.statutReglementaireId);
             formData.append('contexteId', this.ficheDetection.contexteId);
             formData.append('datePremierSignalement', this.ficheDetection.datePremierSignalement);

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -20,7 +20,6 @@
 
 {% block content %}
     <main x-data="app">
-
         <input type="hidden" id="numeroFiche" value="{{ form.instance.numero }}">
         <input type="hidden" id="statut-evenement-id" value="{{ form.instance.statut_evenement_id|default:'' }}">
         <input type="hidden" id="organisme-nuisible-id" value="{{ form.instance.organisme_nuisible_id|default:'' }}">


### PR DESCRIPTION
Lorsqu'on valide une fiche détection sans changer la valeur de l'organisme nuisible celle-ci est perdue. Dans le code on mélange pour le moment deux type de valeur, des entiers et des objets en fonction de si le select a été utilisé par l'utilisateur ou non.