### PR TITLE
Ne pas envoyer les notifications si fin de suivi

### DIFF
--- a/core/notifications.py
+++ b/core/notifications.py
@@ -1,7 +1,8 @@
+from django.contrib.contenttypes.models import ContentType
 from post_office.mail import send
 
 from core.constants import MUS_STRUCTURE
-from core.models import Message, Contact
+from core.models import Message, Contact, FinSuiviContact
 from django.conf import settings
 
 
@@ -22,32 +23,40 @@ def notify_message(instance: Message):
     if instance.message_type == Message.MESSAGE:
         subject = instance.title
         message = f"Bonjour,\n Vous avez reçu un message sur SEVES dont voici le contenu : \n {instance.content}"
-        recipients = [r.email for r in instance.recipients.all()]
-        copy = [r.email for r in instance.recipients_copy.all()]
+        recipients = instance.recipients.all()
+        copy = instance.recipients_copy.all()
     elif instance.message_type == Message.COMPTE_RENDU:
         subject = instance.title
         message = f"Bonjour,\n Vous avez reçu un compte rendu sur demande d'intervention sur SEVES dont voici le contenu : \n {instance.content}"
-        recipients = [r.email for r in instance.recipients.all()]
+        recipients = instance.recipients.all()
     elif instance.message_type == Message.DEMANDE_INTERVENTION:
         subject = instance.title
         message = "Bonjour,\n Vous avez reçu un message sur SEVES."
-        recipients = [r.email for r in instance.recipients.structures_only()]
-        copy = [r.email for r in instance.recipients_copy.structures_only()]
+        recipients = instance.recipients.structures_only()
+        copy = instance.recipients_copy.structures_only()
     elif instance.message_type == Message.POINT_DE_SITUATION:
         subject = instance.title
         message = "Bonjour,\n Vous avez reçu un nouveau point de suivi sur SEVES."
-        recipients = [c.email for c in instance.content_object.contacts.agents_only()]
+        recipients = instance.content_object.contacts.agents_only()
     elif instance.message_type == Message.FIN_SUIVI:
         subject = instance.title
         message = "Bonjour,\n Vous avez reçu un nouveau point de suivi sur SEVES."
         recipients = instance.content_object.contacts.agents_only().filter(agent__structure__niveau2=MUS_STRUCTURE)
-        recipients = [r.email for r in recipients]
     elif instance.message_type == Message.NOTIFICATION_AC:
         subject = instance.title
         message = (
             f"Bonjour,\n une personne a déclarée la fiche {instance.content_object.numero} à l'administration centrale."
         )
-        recipients = [Contact.objects.get_mus().email, Contact.objects.get_bsv().email]
+        recipients = [Contact.objects.get_mus(), Contact.objects.get_bsv()]
+
+    fiche = instance.content_object
+    content_type = ContentType.objects.get_for_model(fiche)
+    fin_de_suivi = FinSuiviContact.objects.filter(object_id=fiche.id, content_type=content_type).select_related(
+        "contact"
+    )
+    contact_fin_de_suivi = [f.contact for f in fin_de_suivi]
+    recipients = [r.email for r in recipients if (r.agent or (r.structure and r not in contact_fin_de_suivi))]
+    copy = [c.email for c in copy if (c.agent or (c.structure and c not in contact_fin_de_suivi))]
 
     if recipients and message:
         _send_message(recipients, copy, subject=subject, message=message, instance=instance)


### PR DESCRIPTION
Ne pas envoyer les notifications aux structures ayant déclarées le fin de suivi.

Corrige #291 