### PR TITLE
Supprime listes déroulantes JS par template django (formulaire fiche détection)

### DIFF
--- a/sv/static/sv/fichedetection_form.js
+++ b/sv/static/sv/fichedetection_form.js
@@ -1,20 +1,20 @@
 function fetchCommunes(query) {
-  return fetch(`https://geo.api.gouv.fr/communes?nom=${query}&fields=departement&boost=population&limit=15`)
-    .then(response => response.json())
-    .then(data => {
-      return data.map(item => ({
-        value: item.nom,
-        label: `${item.nom} (${item.departement.code})` ,
-        customProperties: {
-            "departementNom": item.departement.nom,
-            "inseeCode": item.code
-        }
-      }))
-    })
-    .catch(error => {
-      console.error('Erreur lors de la récupération des données:', error);
-      return []
-    });
+    return fetch(`https://geo.api.gouv.fr/communes?nom=${query}&fields=departement&boost=population&limit=15`)
+        .then(response => response.json())
+        .then(data => {
+            return data.map(item => ({
+                value: item.nom,
+                label: `${item.nom} (${item.departement.code})` ,
+                customProperties: {
+                    "departementNom": item.departement.nom,
+                    "inseeCode": item.code
+                }
+            }))
+        })
+        .catch(error => {
+            console.error('Erreur lors de la récupération des données:', error);
+            return []
+        });
 }
 document.addEventListener('DOMContentLoaded', function() {
     const element = document.getElementById('organisme-nuisible-input');
@@ -33,22 +33,8 @@ document.addEventListener('alpine:init', () => {
 
     Alpine.data('app', () => ({
 
-		// Données de référence pour les listes déroulantes
-        departements: JSON.parse(document.getElementById('departements').textContent),
-        structures: JSON.parse(document.getElementById('structures').textContent),
-        statutsEvenement: JSON.parse(document.getElementById('statuts-evenement').textContent),
-        organismesNuisibles: JSON.parse(document.getElementById('organismes-nuisibles').textContent),
-        statutsReglementaires: JSON.parse(document.getElementById('statuts-reglementaires').textContent),
-        contextes: JSON.parse(document.getElementById('contextes').textContent),
         structuresPreleveurs: JSON.parse(document.getElementById('structures-preleveurs').textContent),
         sitesInspections: JSON.parse(document.getElementById('sites-inspections').textContent),
-        matricesPrelevees: JSON.parse(document.getElementById('matrices-prelevees').textContent),
-        especesEchantillon: JSON.parse(document.getElementById('especes-echantillon').textContent),
-        laboratoiresAgrees: JSON.parse(document.getElementById('laboratoires-agrees').textContent),
-        laboratoiresConfirmationOfficielle: JSON.parse(document.getElementById('laboratoires-confirmation-officielle').textContent),
-        resultatsPrelevement: JSON.parse(document.getElementById('resultats-prelevement').textContent),
-        typesEtablissement: JSON.parse(document.getElementById('types-etablissement').textContent),
-        positionsEtablissement: JSON.parse(document.getElementById('positions-etablissement').textContent),
 
 		// Données du formulaire de la fiche détection (champs fiche détection et listes des lieux et prélèvements)
         ficheDetection: {

--- a/sv/templates/sv/_fichedetection_form__lieux_form.html
+++ b/sv/templates/sv/_fichedetection_form__lieux_form.html
@@ -87,18 +87,18 @@
                                     <label class="fr-label" for="type-etablissement">Type</label>
                                     <select x-model="lieuForm.typeEtablissementId" class="fr-select" data-testid="lieu-form-type-etablissement" id="type-etablissement">
                                         <option value="">----</option>
-                                        <template x-for="typeEtablissement in typesEtablissement" :key="typeEtablissement.id">
-                                            <option :value="typeEtablissement.id" x-text="typeEtablissement.libelle"></option>
-                                        </template>
+                                        {% for type_etablissement in types_etablissement %}
+                                            <option value="{{ type_etablissement.id }}">{{ type_etablissement.libelle }}</option>
+                                        {% endfor %}
                                     </select>
                                 </p>
                                 <p>
                                     <label class="fr-label" for="position-etablissement">Position</label>
                                     <select x-model="lieuForm.positionEtablissementId" class="fr-select" data-testid="lieu-form-position-etablissement" id="position-etablissement">
                                         <option value="">----</option>
-                                        <template x-for="positionEtablissement in positionsEtablissement" :key="positionEtablissement.id">
-                                            <option :value="positionEtablissement.id" x-text="positionEtablissement.libelle"></option>
-                                        </template>
+                                        {% for position_etablissement in positions_chaine_distribution %}
+                                            <option value="{{ position_etablissement.id }}">{{ position_etablissement.libelle }}</option>
+                                        {% endfor %}
                                     </select>
                                 </p>
                             </div>

--- a/sv/templates/sv/_fichedetection_form__prelevements_form.html
+++ b/sv/templates/sv/_fichedetection_form__prelevements_form.html
@@ -23,9 +23,9 @@
                                 <label class="fr-label">Structure</label>
                                 <select x-model="formPrelevement.structurePreleveurId" class="fr-select" required data-testid="prelevement-form-structure">
                                     <option value="">----</option>
-                                    <template x-for="structure in structuresPreleveurs" :key="structure.id">
-                                        <option :value="structure.id" x-text="structure.nom"></option>
-                                    </template>
+                                    {% for structure in structures_preleveurs %}
+                                        <option value="{{ structure.id }}">{{ structure.nom }}</option>
+                                    {% endfor %}
                                 </select>
                             </div>
                             <p id="numero-echantillon">
@@ -40,40 +40,40 @@
                                 <label class="fr-label">Site d'inspection</label>
                                 <select x-model="formPrelevement.siteInspectionId" class="fr-select" data-testid="prelevement-form-site-inspection">
                                     <option value="">----</option>
-                                    <template x-for="site in sitesInspections" :key="site.id">
-                                        <option :value="site.id" x-text="site.nom"></option>
-                                    </template>
+                                    {% for site in sites_inspections %}
+                                        <option value="{{ site.id }}">{{ site.nom }}</option>
+                                    {% endfor %}
                                 </select>
                             </p>
                             <p id="matrice-prelevee">
                                 <label class="fr-label">Matrice prélevée</label>
                                 <select x-model="formPrelevement.matricePreleveeId" class="fr-select" data-testid="prelevement-form-matrice-prelevee">
                                     <option value="">----</option>
-                                    <template x-for="matrice in matricesPrelevees" :key="matrice.id">
-                                        <option :value="matrice.id" x-text="matrice.libelle"></option>
-                                    </template>
+                                    {% for matrice in matrices_prelevees %}
+                                        <option value="{{ matrice.id }}">{{ matrice.libelle }}</option>
+                                    {% endfor %}
                                 </select>
                             </p>
                             <p id="espece-echantillon">
                                 <label class="fr-label">Espèce de l'echantillon</label>
                                 <select x-model="formPrelevement.especeEchantillonId" class="fr-select" data-testid="prelevement-form-espece-echantillon">
                                     <option value="">----</option>
-                                    <template x-for="espece in especesEchantillon" :key="espece.id">
-                                        <option :value="espece.id" x-text="espece.libelle"></option>
-                                    </template>
+                                    {% for espece in especes_echantillon %}
+                                        <option value="{{ espece.id }}">{{ espece.libelle }}</option>
+                                    {% endfor %}
                                 </select>
                             </p>
                             <div id="resultat">
                                 <label class="fr-label" style="flex:0.65">Résultat</label>
                                 <fieldset class="fr-fieldset" id="radio-inline" aria-labelledby="radio-inline-legend radio-inline-messages">
-                                    <template x-for="resultat in resultatsPrelevement" :key="resultat[0]">
+                                    {% for resultat_value, resultat_label in resultats_prelevement %}
                                         <div class="fr-fieldset__element fr-fieldset__element--inline fr-mt-4v fr-mb-0-5v">
                                             <div class="fr-radio-group">
-                                                <input x-model="formPrelevement.resultat" type="radio" :id="resultat[0] + '-id'" name="resultat" :value="resultat[0]" required />
-                                                <label class="fr-label" :for="resultat[0] + '-id'" x-text="resultat[1]" :data-testid="'prelevement-form-resultat-'+resultat[0]"></label>
+                                                <input x-model="formPrelevement.resultat" type="radio" id="{{ resultat_value }}-id" name="resultat" value="{{ resultat_value }}" required />
+                                                <label class="fr-label" for="{{ resultat_value }}-id" data-testid="prelevement-form-resultat-{{ resultat_value }}">{{ resultat_label }}</label>
                                             </div>
                                         </div>
-                                    </template>
+                                    {% endfor %}
                                 </fieldset>
                             </div>
                             <p>
@@ -101,18 +101,18 @@
                                     <label class="fr-label">Laboratoire agrée</label>
                                     <select x-model="formPrelevement.laboratoireAgreeId" class="fr-select" data-testid="prelevement-form-laboratoire-agree">
                                         <option value="">----</option>
-                                        <template x-for="laboratoire_agree in laboratoiresAgrees" :key="laboratoire_agree.id">
-                                            <option :value="laboratoire_agree.id" x-text="laboratoire_agree.nom"></option>
-                                        </template>
+                                        {% for laboratoire_agree in laboratoires_agrees %}
+                                            <option value="{{ laboratoire_agree.id }}">{{ laboratoire_agree.nom }}</option>
+                                        {% endfor %}
                                     </select>
                                 </p>
                                 <p id="laboratoire-confirmation">
                                     <label class="fr-label">Laboratoire de confirmation</label>
                                     <select x-model="formPrelevement.laboratoireConfirmationOfficielleId" class="fr-select" data-testid="prelevement-form-laboratoire-confirmation">
                                         <option value="">----</option>
-                                        <template x-for="laboratoire_confirmation_officielle in laboratoiresConfirmationOfficielle" :key="laboratoire_confirmation_officielle.id">
-                                            <option :value="laboratoire_confirmation_officielle.id" x-text="laboratoire_confirmation_officielle.nom"></option>
-                                        </template>
+                                        {% for laboratoire_confirmation_officielle in laboratoires_confirmation_officielle %}
+                                            <option value="{{ laboratoire_confirmation_officielle.id }}">{{ laboratoire_confirmation_officielle.nom }}</option>
+                                        {% endfor %}
                                     </select>
                                 </p>
                             </div>

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -33,21 +33,8 @@
         <input type="hidden" id="mesures-surveillance-specifique" value="{{ form.instance.mesures_surveillance_specifique }}">
         {{ lieux|json_script:"lieux-json" }}
         {{ prelevements|json_script:"prelevements" }}
-        {{ departements|json_script:"departements" }}
-        {{ structures|json_script:"structures" }}
-        {{ statuts_evenement|json_script:"statuts-evenement" }}
-        {{ organismes_nuisibles|json_script:"organismes-nuisibles" }}
-        {{ statuts_reglementaires|json_script:"statuts-reglementaires" }}
-        {{ contextes|json_script:"contextes" }}
         {{ structures_preleveurs|json_script:"structures-preleveurs" }}
         {{ sites_inspections|json_script:"sites-inspections" }}
-        {{ matrices_prelevees|json_script:"matrices-prelevees" }}
-        {{ especes_echantillon|json_script:"especes-echantillon" }}
-        {{ laboratoires_agrees|json_script:"laboratoires-agrees" }}
-        {{ laboratoires_confirmation_officielle|json_script:"laboratoires-confirmation-officielle" }}
-        {{ resultats_prelevement|json_script:"resultats-prelevement"}}
-        {{ types_etablissement|json_script:"types-etablissement" }}
-        {{ positions_chaine_distribution|json_script:"positions-etablissement" }}
 
         <form x-ref="fichedetectionForm" @submit.prevent="saveFicheDetection($event)">
 
@@ -96,12 +83,9 @@
                             <label class="fr-label" for="statut-evenement-input">Statut évènement</label>
                             <select x-model="ficheDetection.statutEvenementId" id="statut-evenement-input" class="fr-select">
                                 <option value="">----</option>
-                                <template x-for="statutEvenement in statutsEvenement" :key="statutEvenement.id">
-                                    <option
-                                        :value="statutEvenement.id"
-                                        x-text="statutEvenement.libelle"
-                                        :selected="statutEvenement.id == ficheDetection.statutEvenementId"></option>
-                                </template>
+                                {% for statut_evenement in statuts_evenement %}
+                                    <option value="{{ statut_evenement.id }}">{{ statut_evenement.libelle }}</option>
+                                {% endfor %}
                             </select>
                         </p>
                     </div>
@@ -113,36 +97,27 @@
                         <label class="fr-label" for="organisme-nuisible-input">Organisme nuisible</label>
                         <select x-model="ficheDetection.organismeNuisibleId" id="organisme-nuisible-input">
                             <option value="">----</option>
-                            <template x-for="organismeNuisible in organismesNuisibles" :key="organismeNuisible.id">
-                                <option
-                                    :value="organismeNuisible.id"
-                                    x-text="organismeNuisible.libelle_court"
-                                    :selected="organismeNuisible.id == ficheDetection.organismeNuisibleId"></option>
-                            </template>
+                            {% for organisme_nuisible in organismes_nuisibles %}
+                                <option value="{{ organisme_nuisible.id }}">{{ organisme_nuisible.libelle_court }}</option>
+                            {% endfor %}
                         </select>
                     </p>
                     <p id="statut-reglementaire">
                         <label class="fr-label" for="statut-reglementaire-input">Statut règlementaire</label>
                         <select x-model="ficheDetection.statutReglementaireId" id="statut-reglementaire-input" class="fr-select">
                             <option value="">----</option>
-                            <template x-for="statutReglementaire in statutsReglementaires" :key="statutReglementaire.id">
-                                <option
-                                    :value="statutReglementaire.id"
-                                    x-text="statutReglementaire.libelle"
-                                    :selected="statutReglementaire.id == ficheDetection.statutReglementaireId"></option>
-                            </template>
+                            {% for statut_reglementaire in statuts_reglementaires %}
+                                <option value="{{ statut_reglementaire.id }}">{{ statut_reglementaire.libelle }}</option>
+                            {% endfor %}
                         </select>
                     </p>
                     <p id="contexte">
                         <label class="fr-label" for="contexte-input">Contexte</label>
                         <select x-model="ficheDetection.contexteId" id="contexte-input" class="fr-select">
                             <option value="">----</option>
-                            <template x-for="contexte in contextes" :key="contexte.id">
-                                <option
-                                    :value="contexte.id"
-                                    x-text="contexte.nom"
-                                    :selected="contexte.id == ficheDetection.contexteId"></option>
-                            </template>
+                            {% for contexte in contextes %}
+                                <option value="{{ contexte.id }}">{{ contexte.nom }}</option>
+                            {% endfor %}
                         </select>
                     </p>
                     <p id="date-1er-signalement">

--- a/sv/views.py
+++ b/sv/views.py
@@ -55,7 +55,7 @@ from .models import (
     PositionChaineDistribution,
 )
 from core.forms import DSFRForm
-from core.models import Structure, Visibilite
+from core.models import Visibilite
 
 
 class FicheDetectionSearchForm(forms.Form, DSFRForm):
@@ -197,24 +197,21 @@ class FicheDetectionDetailView(
 class FicheDetectionContextMixin:
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["structures"] = list(Structure.objects.values("id", "libelle"))
-        context["statuts_evenement"] = list(StatutEvenement.objects.values("id", "libelle"))
-        context["organismes_nuisibles"] = list(OrganismeNuisible.objects.values("id", "libelle_court"))
-        context["statuts_reglementaires"] = list(StatutReglementaire.objects.values("id", "libelle"))
-        context["contextes"] = list(Contexte.objects.values("id", "nom"))
+        context["statuts_evenement"] = StatutEvenement.objects.all()
+        context["organismes_nuisibles"] = OrganismeNuisible.objects.all()
+        context["statuts_reglementaires"] = StatutReglementaire.objects.all()
+        context["contextes"] = Contexte.objects.all()
         context["structures_preleveurs"] = list(StructurePreleveur.objects.values("id", "nom").order_by("nom"))
         context["sites_inspections"] = list(SiteInspection.objects.values("id", "nom").order_by("nom"))
-        context["matrices_prelevees"] = list(MatricePrelevee.objects.values("id", "libelle").order_by("libelle"))
+        context["matrices_prelevees"] = MatricePrelevee.objects.all().order_by("libelle")
         context["especes_echantillon"] = list(EspeceEchantillon.objects.values("id", "libelle").order_by("libelle"))
-        context["laboratoires_agrees"] = list(LaboratoireAgree.objects.values("id", "nom").order_by("nom"))
-        context["laboratoires_confirmation_officielle"] = list(
-            LaboratoireConfirmationOfficielle.objects.values("id", "nom").order_by("nom")
+        context["laboratoires_agrees"] = LaboratoireAgree.objects.all().order_by("nom")
+        context["laboratoires_confirmation_officielle"] = LaboratoireConfirmationOfficielle.objects.all().order_by(
+            "nom"
         )
         context["resultats_prelevement"] = Prelevement.Resultat.choices
-        context["types_etablissement"] = list(TypeExploitant.objects.values("id", "libelle").order_by("libelle"))
-        context["positions_chaine_distribution"] = list(
-            PositionChaineDistribution.objects.values("id", "libelle").order_by("libelle")
-        )
+        context["types_etablissement"] = TypeExploitant.objects.all().order_by("libelle")
+        context["positions_chaine_distribution"] = PositionChaineDistribution.objects.all().order_by("libelle")
         return context
 
 


### PR DESCRIPTION
Le but de cette PR refactorise la manière dont les données des listes déroulantes sont passées au template dans le formulaire d'une fiche détection. 
La modification principale consiste à remplacer les boucles JavaScript/AlpineJS par des balises de template Django (`for`).
Seule deux listes sont gardées (`structuresPreleveurs` et `sitesInspections`) car utilisées pour afficher le libellé/nom à partir de l'id (cf. `sv/static/sv/fichedetection_form.js`)

### Refactorisation des templates:
Remplacement des boucles JavaScript/AlpineJS par des balises de template Django pour :
* [`sv/templates/sv/_fichedetection_form__lieux_form.html`](diffhunk://#diff-c39b37f9b81d89db0607193cb0d181005e6a15813df26bcaa926c94b292a20a3L90-R101): `types_etablissement` et `positions_chaine_distribution`
* [`sv/templates/sv/_fichedetection_form__prelevements_form.html`](diffhunk://#diff-e9512d72623e7523ad840202d77813867057c18593a26e39d5fbd847bdc86418L26-R28): `structures_preleveurs`, `sites_inspections`, `matrices_prelevees`, `especes_echantillon`, `resultats_prelevement`, `laboratoires_agrees`, et `laboratoires_confirmation_officielle`  
[[1]](diffhunk://#diff-e9512d72623e7523ad840202d77813867057c18593a26e39d5fbd847bdc86418L26-R28) [[2]](diffhunk://#diff-e9512d72623e7523ad840202d77813867057c18593a26e39d5fbd847bdc86418L43-R76) [[3]](diffhunk://#diff-e9512d72623e7523ad840202d77813867057c18593a26e39d5fbd847bdc86418L104-R115)

### Suppression des données des templates:
* [`sv/templates/sv/fichedetection_form.html`](diffhunk://#diff-a79a0058d344e2e7ae7ac4bf1281d78e937407d0ddbc1d7b331b5826e944e55bL36-L50): Suppression des balises script JSON pour les données désormais directement rendues dans les templates à l'aide de balises de template Django..

### JavaScript:
* [`sv/static/sv/fichedetection_form.js`](diffhunk://#diff-51c238c0ede35bb516112252a2acde315ed733c64bdb7f20ec3b76dce13af863L36-L51): Suppression du parsing JSON inutile pour plusieurs listes déroulantes.

### Mise à jour des données du contexte:
* [`sv/views.py`](diffhunk://#diff-6b0552543f0848b971a994ad425b46adcc4d08ca875cfceff9a090e11e56ec19L200-R214): Mise à jour du `FicheDetectionContextMixin` pour passer directement des Django QuerySets au contexte, au lieu de listes de dictionnaires.

