### PR TITLE
Factoriser la sélection d'une option avec ChoiceJS

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -37,3 +37,14 @@ def mocked_authentification_user(db):
 
     with patch("seves.middlewares.LoginRequiredMiddleware.__call__", mocked):
         yield user
+
+
+@pytest.fixture
+def choice_js_fill(db, page):
+    def _choice_js_fill(page, locator, fill_content, exact_name):
+        page.query_selector(locator).click()
+        page.wait_for_selector("*:focus", state="visible", timeout=2_000)
+        page.locator("*:focus").fill(fill_content)
+        page.get_by_role("option", name=exact_name, exact=True).click()
+
+    return _choice_js_fill

--- a/sv/tests/test_fiche_detection_message.py
+++ b/sv/tests/test_fiche_detection_message.py
@@ -4,7 +4,9 @@ from core.models import Message, Contact, Agent, Structure
 from ..models import FicheDetection
 
 
-def test_can_add_and_see_message_without_document(live_server, page: Page, fiche_detection: FicheDetection):
+def test_can_add_and_see_message_without_document(
+    live_server, page: Page, fiche_detection: FicheDetection, choice_js_fill
+):
     agent = baker.make(Agent)
     baker.make(Contact, agent=agent)
     page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
@@ -13,9 +15,7 @@ def test_can_add_and_see_message_without_document(live_server, page: Page, fiche
 
     page.wait_for_url(f"**{fiche_detection.add_message_url}")
 
-    page.query_selector(".choices__input--cloned:first-of-type").click()
-    page.locator("*:focus").fill(agent.nom)
-    page.get_by_role("option", name=str(agent)).click()
+    choice_js_fill(page, ".choices__input--cloned:first-of-type", agent.nom, str(agent))
     page.locator("#id_title").fill("Title of the message")
     page.locator("#id_content").fill("My content \n with a line return")
     page.get_by_test_id("fildesuivi-add-submit").click()
@@ -42,7 +42,9 @@ def test_can_add_and_see_message_without_document(live_server, page: Page, fiche
     assert "My content <br> with a line return" in page.get_by_test_id("message-content").inner_html()
 
 
-def test_can_add_and_see_message_multiple_documents(live_server, page: Page, fiche_detection: FicheDetection):
+def test_can_add_and_see_message_multiple_documents(
+    live_server, page: Page, fiche_detection: FicheDetection, choice_js_fill
+):
     agent = baker.make(Agent)
     baker.make(Contact, agent=agent)
     page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
@@ -51,9 +53,7 @@ def test_can_add_and_see_message_multiple_documents(live_server, page: Page, fic
 
     page.wait_for_url(f"**{fiche_detection.add_message_url}")
 
-    page.query_selector(".choices__input--cloned:first-of-type").click()
-    page.locator("*:focus").fill(agent.nom)
-    page.get_by_role("option", name=str(agent)).click()
+    choice_js_fill(page, ".choices__input--cloned:first-of-type", agent.nom, str(agent))
     page.locator("#id_title").fill("Title of the message")
     page.locator("#id_content").fill("My content \n with a line return")
 
@@ -100,7 +100,7 @@ def test_can_add_and_see_message_multiple_documents(live_server, page: Page, fic
 
 
 def test_can_add_and_see_message_with_multiple_recipients_and_copies(
-    live_server, page: Page, fiche_detection: FicheDetection
+    live_server, page: Page, fiche_detection: FicheDetection, choice_js_fill
 ):
     agents = []
     for _ in range(4):
@@ -115,20 +115,12 @@ def test_can_add_and_see_message_with_multiple_recipients_and_copies(
     page.wait_for_url(f"**{fiche_detection.add_message_url}")
 
     # Add multiple recipients
-    page.query_selector(".choices__input--cloned:first-of-type").click()
-    page.locator("*:focus").fill(agents[0].nom)
-    page.get_by_role("option", name=str(agents[0])).click()
-    page.query_selector(".choices__input--cloned:first-of-type").click()
-    page.locator("*:focus").fill(agents[1].nom)
-    page.get_by_role("option", name=str(agents[1])).click()
+    choice_js_fill(page, ".choices__input--cloned:first-of-type", agents[0].nom, str(agents[0]))
+    choice_js_fill(page, ".choices__input--cloned:first-of-type", agents[1].nom, str(agents[1]))
 
     # Add multiples recipients as copy
-    page.query_selector(".choices__input--cloned:last-of-type").click()
-    page.locator("*:focus").fill(agents[2].nom)
-    page.get_by_role("option", name=str(agents[2])).click()
-    page.query_selector(".choices__input--cloned:last-of-type").click()
-    page.locator("*:focus").fill(agents[3].nom)
-    page.get_by_role("option", name=str(agents[3])).click()
+    choice_js_fill(page, ".choices__input--cloned:first-of-type", agents[2].nom, str(agents[2]))
+    choice_js_fill(page, ".choices__input--cloned:first-of-type", agents[3].nom, str(agents[3]))
 
     page.locator("#id_title").fill("Title of the message")
     page.locator("#id_content").fill("My content \n with a line return")

--- a/sv/tests/test_fichedetection_form.py
+++ b/sv/tests/test_fichedetection_form.py
@@ -2,6 +2,7 @@ import json
 import pytest
 from playwright.sync_api import Page, expect
 from django.urls import reverse
+
 from .test_utils import FicheDetectionFormDomElements, LieuFormDomElements, PrelevementFormDomElements
 from ..models import (
     Departement,
@@ -24,7 +25,7 @@ def create_fixtures_if_needed(db):
 
 
 @pytest.fixture(autouse=True)
-def test_goto_fiche_detection_creation_url(live_server, page: Page):
+def test_goto_fiche_detection_creation_url(live_server, page: Page, choice_js_fill):
     """Ouvre la page de création d'une fiche de détection"""
     add_fiche_detection_form_url = reverse("fiche-detection-creation")
     return page.goto(f"{live_server.url}{add_fiche_detection_form_url}")
@@ -425,7 +426,11 @@ def test_edit_lieu_form_have_all_fields_with_multiple_lieux(
 
 @pytest.mark.django_db
 def test_edit_lieu_is_updated_in_alpinejs_data(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que le lieu modifié est bien mis à jour dans le tableau de données alpinejs"""
     # ajout d'un lieu
@@ -435,9 +440,7 @@ def test_edit_lieu_is_updated_in_alpinejs_data(
     page.get_by_role("button", name="Modifier le lieu").click()
     lieu_form_elements.nom_input.fill("nom lieu modifié")
     lieu_form_elements.adresse_input.fill("une adresse modifiée")
-    page.query_selector(".fr-modal__content .choices__list--single").click()
-    page.locator("*:focus").fill("Paris")
-    page.get_by_role("option", name="Paris (75)", exact=True).click()
+    choice_js_fill(page, ".fr-modal__content .choices__list--single", "Paris", "Paris (75)")
     lieu_form_elements.coord_gps_lamber93_latitude_input.fill("6000001")
     lieu_form_elements.coord_gps_lamber93_longitude_input.fill("200001")
     lieu_form_elements.coord_gps_wgs84_latitude_input.fill("11")
@@ -459,7 +462,11 @@ def test_edit_lieu_is_updated_in_alpinejs_data(
 
 
 def test_add_lieu_form_is_empty_after_edit(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que le formulaire d'ajout d'un lieu est vide après la modification d'un lieu"""
     # ajout d'un lieu
@@ -469,10 +476,7 @@ def test_add_lieu_form_is_empty_after_edit(
     page.get_by_role("button", name="Modifier le lieu").click()
     lieu_form_elements.nom_input.fill("nom lieu modifié")
     lieu_form_elements.adresse_input.fill("une adresse modifiée")
-    page.query_selector(".fr-modal__content .choices__list--single").click()
-    page.wait_for_selector("*:focus", state="visible", timeout=2_000)
-    page.locator("*:focus").fill("Paris")
-    page.get_by_role("option", name="Paris (75)", exact=True).click()
+    choice_js_fill(page, ".fr-modal__content .choices__list--single", "Paris", "Paris (75)")
     lieu_form_elements.coord_gps_lamber93_latitude_input.fill("6000001")
     lieu_form_elements.coord_gps_lamber93_longitude_input.fill("200001")
     lieu_form_elements.coord_gps_wgs84_latitude_input.fill("11")

--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -143,6 +143,7 @@ def test_fiche_detection_update_without_lieux_and_prelevement(
     fiche_detection: FicheDetection,
     fiche_detection_bakery,
     mocked_authentification_user,
+    choice_js_fill,
 ):
     """Test que les modifications des informations, objet de l'évènement et mesures de gestion sont bien enregistrées en base de données apès modification."""
     organisme = baker.make(OrganismeNuisible)
@@ -153,10 +154,7 @@ def test_fiche_detection_update_without_lieux_and_prelevement(
     page.goto(f"{live_server.url}{get_fiche_detection_update_form_url(fiche_detection)}")
     form_elements.statut_evenement_input.select_option(str(new_fiche_detection.statut_evenement.id))
 
-    page.query_selector("#organisme-nuisible .choices__list--single").click()
-    page.wait_for_selector("*:focus", state="visible", timeout=2_000)
-    page.locator("*:focus").fill(organisme.libelle_court)
-    page.get_by_role("option", name=organisme.libelle_court).click()
+    choice_js_fill(page, "#organisme-nuisible .choices__list--single", organisme.libelle_court, organisme.libelle_court)
 
     form_elements.statut_reglementaire_input.select_option(str(new_fiche_detection.statut_reglementaire.id))
     form_elements.contexte_input.select_option(str(new_fiche_detection.contexte.id))
@@ -417,6 +415,7 @@ def test_update_two_lieux(
     fiche_detection_with_two_lieux: FicheDetection,
     form_elements: FicheDetectionFormDomElements,
     lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que les modifications des descripteurs de plusieurs lieux existants sont bien enregistrées en base de données."""
     new_lieux = baker.prepare(
@@ -439,14 +438,10 @@ def test_update_two_lieux(
             page.get_by_role("button", name="Modifier le lieu").nth(index).click()
         lieu_form_elements.nom_input.fill(new_lieu.nom)
         lieu_form_elements.adresse_input.fill(new_lieu.adresse_lieu_dit)
-        page.query_selector(".fr-modal__content .choices__list--single").click()
-        page.wait_for_selector("*:focus", state="visible", timeout=2_000)
         if index == 0:
-            page.locator("*:focus").fill("Lille")
-            page.get_by_role("option", name="Lille (59)", exact=True).click()
+            choice_js_fill(page, ".fr-modal__content .choices__list--single", "Lille", "Lille (59)")
         else:
-            page.locator("*:focus").fill("Paris")
-            page.get_by_role("option", name="Paris (75)", exact=True).click()
+            choice_js_fill(page, ".fr-modal__content .choices__list--single", "Paris", "Paris (75)")
         lieu_form_elements.coord_gps_lamber93_latitude_input.fill(str(new_lieu.lambert93_latitude))
         lieu_form_elements.coord_gps_lamber93_longitude_input.fill(str(new_lieu.lambert93_longitude))
         lieu_form_elements.coord_gps_wgs84_latitude_input.fill(str(new_lieu.wgs84_latitude))


### PR DESCRIPTION
Permet de factoriser dans les tests les méthodes de sélection d'une option avec ChoiceJS. Cela permet de s'assurer que tous les tests utilisent `timeout=2_000` pour attendre que le sélecteur soit disponible.

Je n'ai jamais le problème de sélecteur en local avec n=auto (16 sur ma configuration), mais j'arrive a reproduire le problème avec n=4 qui correspond à la configuration de la CI.