### PR TITLE
Améliorer la notification à l'AC

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -96,7 +96,7 @@ class AllowACNotificationMixin(models.Model):
 
     @property
     def can_notifiy(self):
-        return not self.is_ac_notified
+        return not self.is_ac_notified and not self.is_draft
 
     def notify_ac(self, sender):
         if not self.can_notifiy:

--- a/sv/models.py
+++ b/sv/models.py
@@ -504,6 +504,10 @@ class FicheDetection(AllowsSoftDeleteMixin, AllowACNotificationMixin, AllowVisib
     def is_already_cloturer(self):
         return self.etat.is_cloture()
 
+    @property
+    def is_draft(self):
+        return self.visibilite == Visibilite.BROUILLON
+
     def can_update_visibilite(self, user):
         """Vérifie si l'utilisateur peut modifier la visibilité de la fiche de détection."""
         match self.visibilite:

--- a/sv/templates/sv/fichedetection_detail.html
+++ b/sv/templates/sv/fichedetection_detail.html
@@ -20,7 +20,7 @@
                 <h1 class="fiche-header__title">Fiche détection n° {{ fichedetection.numero }}</h1>
                 <p class="fr-badge fr-badge--{{fichedetection.etat.libelle|etat_fiche_detection_color}} fr-badge--no-icon">{{ fichedetection.etat }}</p>
                 {% if fichedetection.is_ac_notified %}
-                    <p class="fr-badge fr-ml-2w"><span class="fr-icon-notification-3-line fr-mr-2v fr-icon--sm" aria-hidden="true"> Déclaré AC</p>
+                    <p class="fr-badge fr-ml-2w"><span class="fr-icon-notification-3-line fr-mr-2v fr-icon--sm" aria-hidden="true"></span> Déclaré AC</p>
                 {% endif %}
                 <p class="fr-badge fr-badge--no-icon">{{ fichedetection.visibilite }}</p>
             </div>

--- a/sv/templates/sv/fichedetection_list.html
+++ b/sv/templates/sv/fichedetection_list.html
@@ -103,9 +103,9 @@
                                 </td>
                                 <td>
                                     <a href="{% url 'fiche-detection-vue-detaillee' fiche.pk %}" class="fiches__list-link">
-                                        <span class="fr-badge">{{ fiche.visibilite }}</span>
-                                    </a>
-                                </tr>
+                                        <span class="fr-badge">{{ fiche.visibilite }}{% if fiche.is_ac_notified %}<span class="fr-icon-notification-3-line fr-ml-2v fr-icon--sm" aria-hidden="true"></span>{% endif %}
+                                        </a>
+                                    </tr>
                         {% endfor %}
                         <tbody>
                         </table>


### PR DESCRIPTION
- Ajout de l'icône sur la vue de liste si la fiche est déclarée à l'AC
- Empecher de notifier l'AC sur une fiche en brouillon

Fixes https://github.com/betagouv/seves/issues/296