### PR TITLE
Permettre de choisir l'espèce dans une liste

### DIFF
--- a/sv/api_views.py
+++ b/sv/api_views.py
@@ -1,0 +1,15 @@
+from django.http import JsonResponse
+from django.views.decorators.http import require_http_methods
+
+from sv.models import EspeceEchantillon
+
+
+@require_http_methods(["GET"])
+def search_espece_echantillon(request):
+    search_term = request.GET.get("q", "")
+    if not search_term:
+        return JsonResponse({"results": []})
+
+    especes = EspeceEchantillon.objects.filter(libelle__icontains=search_term)
+    results = [{"id": espece.id, "name": espece.libelle} for espece in especes]
+    return JsonResponse({"results": results})

--- a/sv/static/sv/fichedetection_form.css
+++ b/sv/static/sv/fichedetection_form.css
@@ -192,7 +192,7 @@ main {
 #prelevement-form select {
     flex: 1.15;
 }
-#prelevement-form input {
+#prelevement-form input, #prelevement-form .choices {
     flex: 1.25;
 }
 

--- a/sv/templates/sv/_fichedetection_form__prelevements_form.html
+++ b/sv/templates/sv/_fichedetection_form__prelevements_form.html
@@ -55,13 +55,8 @@
                                 </select>
                             </p>
                             <p id="espece-echantillon" class="prelevement-form--fieldset">
-                                <label class="fr-label">Espèce de l'echantillon</label>
-                                <select x-model="formPrelevement.especeEchantillonId" class="fr-select" data-testid="prelevement-form-espece-echantillon">
-                                    <option value="">----</option>
-                                    {% for espece in especes_echantillon %}
-                                        <option value="{{ espece.id }}">{{ espece.libelle }}</option>
-                                    {% endfor %}
-                                </select>
+                                <label class="fr-label" for="commune">Espèce de l'echantillon</label>
+                                <select id="espece-echantillon-input" class="fr-input"></select>
                             </p>
                             <div id="resultat" class="prelevement-form--fieldset">
                                 <label class="fr-label" style="flex:0.65">Résultat</label>

--- a/sv/tests/test_api_views.py
+++ b/sv/tests/test_api_views.py
@@ -1,0 +1,19 @@
+import pytest
+from django.urls import reverse
+from sv.models import EspeceEchantillon
+
+
+@pytest.mark.django_db
+def test_api_view_espece_echantillon(client):
+    url = reverse("api-search-espece")
+    EspeceEchantillon.objects.create(libelle="foo", code_oepp="A")
+    EspeceEchantillon.objects.create(libelle="FOO", code_oepp="B")
+    EspeceEchantillon.objects.create(libelle="FOOL", code_oepp="C")
+    EspeceEchantillon.objects.create(libelle="Bar", code_oepp="D")
+
+    response = client.get(url + "?q=FOO")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "results": [{"id": 1, "name": "foo"}, {"id": 2, "name": "FOO"}, {"id": 3, "name": "FOOL"}]
+    }

--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -530,6 +530,7 @@ def test_add_new_prelevement_non_officiel(
     fiche_detection_with_one_lieu: FicheDetection,
     form_elements: FicheDetectionFormDomElements,
     prelevement_form_elements: PrelevementFormDomElements,
+    choice_js_fill,
 ):
     """Test que l'ajout d'un nouveau prelevement non officiel est bien enregistré en base de données."""
     lieu = baker.make(Lieu, fiche_detection=fiche_detection_with_one_lieu, _fill_optional=True)
@@ -543,7 +544,12 @@ def test_add_new_prelevement_non_officiel(
     prelevement_form_elements.date_prelevement_input.fill(prelevement.date_prelevement.strftime("%Y-%m-%d"))
     prelevement_form_elements.site_inspection_input.select_option(str(prelevement.site_inspection.id))
     prelevement_form_elements.matrice_prelevee_input.select_option(str(prelevement.matrice_prelevee.id))
-    prelevement_form_elements.espece_echantillon_input.select_option(str(prelevement.espece_echantillon.id))
+    choice_js_fill(
+        page,
+        "#espece-echantillon .choices__list--single",
+        prelevement.espece_echantillon.libelle,
+        prelevement.espece_echantillon.libelle,
+    )
     prelevement_form_elements.resultat_input(prelevement.resultat).click()
     prelevement_form_elements.save_btn.click()
     form_elements.save_btn.click()
@@ -572,6 +578,7 @@ def test_add_new_prelevement_officiel(
     fiche_detection_with_one_lieu: FicheDetection,
     form_elements: FicheDetectionFormDomElements,
     prelevement_form_elements: PrelevementFormDomElements,
+    choice_js_fill,
 ):
     """Test que l'ajout d'un nouveau prelevement non officiel est bien enregistré en base de données."""
     lieu = baker.make(Lieu, fiche_detection=fiche_detection_with_one_lieu, _fill_optional=True)
@@ -585,7 +592,12 @@ def test_add_new_prelevement_officiel(
     prelevement_form_elements.date_prelevement_input.fill(prelevement.date_prelevement.strftime("%Y-%m-%d"))
     prelevement_form_elements.site_inspection_input.select_option(str(prelevement.site_inspection.id))
     prelevement_form_elements.matrice_prelevee_input.select_option(str(prelevement.matrice_prelevee.id))
-    prelevement_form_elements.espece_echantillon_input.select_option(str(prelevement.espece_echantillon.id))
+    choice_js_fill(
+        page,
+        "#espece-echantillon .choices__list--single",
+        prelevement.espece_echantillon.libelle,
+        prelevement.espece_echantillon.libelle,
+    )
     prelevement_form_elements.resultat_input(prelevement.resultat).click()
     prelevement_form_elements.prelevement_officiel_checkbox.click()
     prelevement_form_elements.numero_phytopass_input.fill(prelevement.numero_phytopass)
@@ -623,6 +635,7 @@ def test_add_multiple_prelevements(
     fiche_detection_with_one_lieu: FicheDetection,
     form_elements: FicheDetectionFormDomElements,
     prelevement_form_elements: PrelevementFormDomElements,
+    choice_js_fill,
 ):
     """Test que l'ajout de plusieurs prelevements lié à un même lieu est bien enregistré en base de données."""
     lieu = baker.make(Lieu, fiche_detection=fiche_detection_with_one_lieu, _fill_optional=True)
@@ -637,7 +650,12 @@ def test_add_multiple_prelevements(
         prelevement_form_elements.date_prelevement_input.fill(prelevement.date_prelevement.strftime("%Y-%m-%d"))
         prelevement_form_elements.site_inspection_input.select_option(str(prelevement.site_inspection.id))
         prelevement_form_elements.matrice_prelevee_input.select_option(str(prelevement.matrice_prelevee.id))
-        prelevement_form_elements.espece_echantillon_input.select_option(str(prelevement.espece_echantillon.id))
+        choice_js_fill(
+            page,
+            "#espece-echantillon .choices__list--single",
+            prelevement.espece_echantillon.libelle,
+            prelevement.espece_echantillon.libelle,
+        )
         prelevement_form_elements.resultat_input(prelevement.resultat).click()
         prelevement_form_elements.save_btn.click()
 
@@ -663,6 +681,7 @@ def test_update_prelevement(
     fiche_detection_with_one_lieu_and_one_prelevement: FicheDetection,
     form_elements: FicheDetectionFormDomElements,
     prelevement_form_elements: PrelevementFormDomElements,
+    choice_js_fill,
 ):
     """Test que les modifications des descripteurs d'un prelevement existant sont bien enregistrées en base de données."""
     new_lieu = baker.make(Lieu, fiche_detection=fiche_detection_with_one_lieu_and_one_prelevement, _fill_optional=True)
@@ -678,7 +697,12 @@ def test_update_prelevement(
     prelevement_form_elements.date_prelevement_input.fill(new_prelevement.date_prelevement.strftime("%Y-%m-%d"))
     prelevement_form_elements.site_inspection_input.select_option(str(new_prelevement.site_inspection.id))
     prelevement_form_elements.matrice_prelevee_input.select_option(str(new_prelevement.matrice_prelevee.id))
-    prelevement_form_elements.espece_echantillon_input.select_option(str(new_prelevement.espece_echantillon.id))
+    choice_js_fill(
+        page,
+        "#espece-echantillon .choices__list--single",
+        new_prelevement.espece_echantillon.libelle,
+        new_prelevement.espece_echantillon.libelle,
+    )
     prelevement_form_elements.resultat_input(new_prelevement.resultat).click()
     prelevement_form_elements.save_btn.click()
     form_elements.save_btn.click()
@@ -702,6 +726,7 @@ def test_update_multiple_prelevements(
     fiche_detection: FicheDetection,
     form_elements: FicheDetectionFormDomElements,
     prelevement_form_elements: PrelevementFormDomElements,
+    choice_js_fill,
 ):
     """Test que les modifications des descripteurs de plusieurs prelevements existants sont bien enregistrées en base de données."""
     lieu1, lieu2 = baker.make(Lieu, fiche_detection=fiche_detection, _fill_optional=True, _quantity=2)
@@ -723,8 +748,11 @@ def test_update_multiple_prelevements(
         prelevement_form_elements.date_prelevement_input.fill(new_prelevement.date_prelevement.strftime("%Y-%m-%d"))
         prelevement_form_elements.site_inspection_input.select_option(value=str(new_prelevement.site_inspection.id))
         prelevement_form_elements.matrice_prelevee_input.select_option(value=str(new_prelevement.matrice_prelevee.id))
-        prelevement_form_elements.espece_echantillon_input.select_option(
-            value=str(new_prelevement.espece_echantillon.id)
+        choice_js_fill(
+            page,
+            "#espece-echantillon .choices__list--single",
+            new_prelevement.espece_echantillon.libelle,
+            new_prelevement.espece_echantillon.libelle,
         )
         prelevement_form_elements.resultat_input(new_prelevement.resultat).click()
         prelevement_form_elements.save_btn.click()

--- a/sv/urls.py
+++ b/sv/urls.py
@@ -1,4 +1,6 @@
 from django.urls import path
+
+from .api_views import search_espece_echantillon
 from .views import (
     FicheDetectionListView,
     FicheDetectionDetailView,
@@ -50,5 +52,10 @@ urlpatterns = [
         "lien/ajout/",
         FreeLinkCreateView.as_view(),
         name="free-link-add",
+    ),
+    path(
+        "api/espece/recherche/",
+        search_espece_echantillon,
+        name="api-search-espece",
     ),
 ]

--- a/sv/views.py
+++ b/sv/views.py
@@ -44,7 +44,6 @@ from .models import (
     StructurePreleveur,
     SiteInspection,
     MatricePrelevee,
-    EspeceEchantillon,
     LaboratoireAgree,
     LaboratoireConfirmationOfficielle,
     NumeroFiche,
@@ -195,7 +194,6 @@ class FicheDetectionContextMixin:
         context["structures_preleveurs"] = list(StructurePreleveur.objects.values("id", "nom").order_by("nom"))
         context["sites_inspections"] = list(SiteInspection.objects.values("id", "nom").order_by("nom"))
         context["matrices_prelevees"] = MatricePrelevee.objects.all().order_by("libelle")
-        context["especes_echantillon"] = list(EspeceEchantillon.objects.values("id", "libelle").order_by("libelle"))
         context["laboratoires_agrees"] = LaboratoireAgree.objects.all().order_by("nom")
         context["laboratoires_confirmation_officielle"] = LaboratoireConfirmationOfficielle.objects.all().order_by(
             "nom"
@@ -425,7 +423,11 @@ class FicheDetectionUpdateView(FicheDetectionContextMixin, UpdateView):
         )
 
         # Prélèvements associés à chaque lieu
-        prelevements = Prelevement.objects.filter(lieu__fiche_detection=self.object).values()
+        prelevements = (
+            Prelevement.objects.filter(lieu__fiche_detection=self.object)
+            .values()
+            .annotate(espece_echantillon_name=F("espece_echantillon__libelle"))
+        )
         for prelevement in prelevements:
             prelevement["uuid"] = str(uuid.uuid4())
 


### PR DESCRIPTION
Ce commit va permettre de choisir l'espèce de l'échantillon dans une liste déroulante avec recherche / complétion.
L'ajout de ChoiceJs sur le champ ne suffit pas car la librairie mets alors plusieurs secondes a initialiser le champ et le rendre réellement interactif.
J'ai du ajouter une petite API qui permet une recherche simple pour contourner ce problème. La page charge plus rapidement car pas de liste d'option a générer en HTML et est aussi interactive rapidement (très peu de JS a exécuter pour la liste déroulante).

Fixes #293