### PR TITLE
Lier des fiches Zone et Détection

### DIFF
--- a/sv/forms.py
+++ b/sv/forms.py
@@ -12,10 +12,9 @@ from django.db.models import TextChoices
 
 
 from core.models import LienLibre
-from sv.models import FicheDetection
 from core.models import Visibilite
 from core.fields import DSFRRadioButton, DSFRCheckboxInput
-from sv.models import FicheZoneDelimitee, ZoneInfestee, OrganismeNuisible, StatutReglementaire
+from sv.models import FicheZoneDelimitee, ZoneInfestee, OrganismeNuisible, StatutReglementaire, FicheDetection
 
 
 class FreeLinkForm(DSFRForm, WithNextUrlMixin, forms.ModelForm):
@@ -33,7 +32,10 @@ class FreeLinkForm(DSFRForm, WithNextUrlMixin, forms.ModelForm):
         super().__init__(*args, **kwargs)
         self.fields["object_choice"] = MultiModelChoiceField(
             label="Sélectioner un objet",
-            model_choices=[("FicheDetection", FicheDetection.objects.select_related("numero"))],
+            model_choices=[
+                ("Fiche Detection", FicheDetection.objects.select_related("numero")),
+                ("Fiche Zone Delimitee", FicheZoneDelimitee.objects.select_related("numero")),
+            ],
         )
         self.add_next_field(next)
         self.fields["object_id_1"].initial = object_id_1

--- a/sv/models.py
+++ b/sv/models.py
@@ -691,3 +691,6 @@ class FicheZoneDelimitee(models.Model):
 
     def get_absolute_url(self):
         return reverse("fiche-zone-delimitee-detail", kwargs={"pk": self.pk})
+
+    def __str__(self):
+        return str(self.numero)

--- a/sv/static/sv/fichedetection_detail.js
+++ b/sv/static/sv/fichedetection_detail.js
@@ -22,4 +22,10 @@ document.addEventListener('DOMContentLoaded', function() {
     detailElement.classList.remove(hiddenClass);
     syntheseElement.classList.add(hiddenClass);
 
+    new Choices(document.getElementById('id_object_choice'), {
+        classNames: {
+            containerInner: 'fr-select',
+        },
+        itemSelectText: ''
+    });
 });

--- a/sv/templates/sv/_lienlibre_modal.html
+++ b/sv/templates/sv/_lienlibre_modal.html
@@ -3,7 +3,7 @@
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
-                <div class="fr-modal__body">
+                <div class="fr-modal__body fr-pb-16w">
                     <div class="fr-modal__header">
                         <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-freelink">Fermer</button>
                     </div>

--- a/sv/tests/test_fichedetection_liens.py
+++ b/sv/tests/test_fichedetection_liens.py
@@ -1,18 +1,27 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
+from model_bakery import baker
 
 from core.models import LienLibre
 from playwright.sync_api import expect
 
+from sv.models import FicheZoneDelimitee
+
 
 @pytest.mark.django_db
-def test_can_add_free_link(live_server, page, fiche_detection, fiche_detection_bakery):
+def test_can_add_free_link(live_server, page, fiche_detection, fiche_detection_bakery, choice_js_fill):
     other_fiche = fiche_detection_bakery()
     page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
 
     page.get_by_role("button", name="Actions").click()
     page.get_by_role("link", name="Ajouter un lien libre").click()
-    page.locator("#id_object_choice").select_option(label=f"FicheDetection: {str(other_fiche.numero)}")
+    page.wait_for_selector("#fr-modal-freelink .choices__list--single")
+    choice_js_fill(
+        page,
+        "#fr-modal-freelink .choices__list--single",
+        f"Fiche Detection: {str(other_fiche.numero)}",
+        f"Fiche Detection: {str(other_fiche.numero)}",
+    )
     page.get_by_test_id("submit-freelink").click()
 
     expect(page.get_by_text("Le lien a été créé avec succès.")).to_be_visible()
@@ -27,13 +36,45 @@ def test_can_add_free_link(live_server, page, fiche_detection, fiche_detection_b
 
 
 @pytest.mark.django_db
-def test_cant_link_to_self(live_server, page, fiche_detection):
+def test_can_add_free_link_to_fiche_zone(live_server, page, fiche_detection, fiche_detection_bakery, choice_js_fill):
+    zone = baker.make(FicheZoneDelimitee)
     page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
 
     page.get_by_role("button", name="Actions").click()
     page.get_by_role("link", name="Ajouter un lien libre").click()
-    page.wait_for_selector("#id_object_choice")
-    page.locator("#id_object_choice").select_option(label=f"FicheDetection: {str(fiche_detection.numero)}")
+    page.wait_for_selector("#fr-modal-freelink .choices__list--single")
+    choice_js_fill(
+        page,
+        "#fr-modal-freelink .choices__list--single",
+        f"Fiche Zone Delimitee: {str(zone.numero)}",
+        f"Fiche Zone Delimitee: {str(zone.numero)}",
+    )
+    page.get_by_test_id("submit-freelink").click()
+
+    expect(page.get_by_text("Le lien a été créé avec succès.")).to_be_visible()
+
+    link = LienLibre.objects.get()
+    assert link.content_type_1 == ContentType.objects.get_for_model(fiche_detection)
+    assert link.content_type_2 == ContentType.objects.get_for_model(zone)
+    assert link.object_id_1 == fiche_detection.pk
+    assert link.object_id_2 == zone.pk
+
+    expect(page.get_by_role("link", name=str(zone.numero))).to_be_visible()
+
+
+@pytest.mark.django_db
+def test_cant_link_to_self(live_server, page, fiche_detection, choice_js_fill):
+    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
+
+    page.get_by_role("button", name="Actions").click()
+    page.get_by_role("link", name="Ajouter un lien libre").click()
+    page.wait_for_selector("#fr-modal-freelink .choices__list--single")
+    choice_js_fill(
+        page,
+        "#fr-modal-freelink .choices__list--single",
+        f"Fiche Detection: {str(fiche_detection.numero)}",
+        f"Fiche Detection: {str(fiche_detection.numero)}",
+    )
     page.get_by_test_id("submit-freelink").click()
 
     expect(page.get_by_text("Vous ne pouvez pas lier un objet à lui même.")).to_be_visible()
@@ -42,7 +83,7 @@ def test_cant_link_to_self(live_server, page, fiche_detection):
 
 
 @pytest.mark.django_db
-def test_cant_link_if_links_exists(live_server, page, fiche_detection, fiche_detection_bakery):
+def test_cant_link_if_links_exists(live_server, page, fiche_detection, fiche_detection_bakery, choice_js_fill):
     other_fiche = fiche_detection_bakery()
     content_type = ContentType.objects.get_for_model(other_fiche)
     LienLibre.objects.create(
@@ -56,8 +97,13 @@ def test_cant_link_if_links_exists(live_server, page, fiche_detection, fiche_det
 
     page.get_by_role("button", name="Actions").click()
     page.get_by_role("link", name="Ajouter un lien libre").click()
-    page.wait_for_selector("#id_object_choice")
-    page.locator("#id_object_choice").select_option(label=f"FicheDetection: {str(other_fiche.numero)}")
+    page.wait_for_selector("#fr-modal-freelink .choices__list--single")
+    choice_js_fill(
+        page,
+        "#fr-modal-freelink .choices__list--single",
+        f"Fiche Detection: {str(other_fiche.numero)}",
+        f"Fiche Detection: {str(other_fiche.numero)}",
+    )
     page.get_by_test_id("submit-freelink").click()
 
     expect(page.get_by_text("Ce lien existe déjà.")).to_be_visible()

--- a/sv/tests/test_fichedetection_performances.py
+++ b/sv/tests/test_fichedetection_performances.py
@@ -4,7 +4,7 @@ from model_bakery import baker
 from core.models import Message, Document, Structure, Contact
 from sv.models import FicheDetection, Lieu, Prelevement
 
-BASE_NUM_QUERIES = 14  # Please note a first call is made without assertion to warm up any possible cache
+BASE_NUM_QUERIES = 15  # Please note a first call is made without assertion to warm up any possible cache
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Permet d'utiliser les liens libres entre les fiches zones et les fiche détection.
Ajout de la bibliothèque ChoicesJs pour permettre une recherche dans le champ de liste des fiches.

Fixes #295

En attente de la vue de détail d'une zone @alanzirek 