### PR TITLE
Améliorer les performances de la vue de liste

### DIFF
--- a/sv/managers.py
+++ b/sv/managers.py
@@ -1,12 +1,14 @@
 from django.db import models
-from django.db.models import Q
+from django.db.models import Q, Prefetch, OuterRef, Subquery
 from core.models import Visibilite
 
 
 class FicheDetectionManager(models.Manager):
     def get_queryset(self):
-        return super().get_queryset().filter(is_deleted=False)
+        return FicheDetectionQuerySet(self.model, using=self._db).filter(is_deleted=False)
 
+
+class FicheDetectionQuerySet(models.QuerySet):
     def get_contacts_structures_not_in_fin_suivi(self, fiche_detection):
         contacts_structure_fiche = fiche_detection.contacts.exclude(structure__isnull=True).select_related("structure")
         fin_suivi_contacts_ids = fiche_detection.fin_suivi.values_list("contact", flat=True)
@@ -16,14 +18,29 @@ class FicheDetectionManager(models.Manager):
     def get_fiches_user_can_view(self, user):
         """Renvoi les fiches (queryset) que l'utilisateur peut voir en fonction de sa structure et de la visibilité de la fiche"""
         if user.agent.structure.is_mus_or_bsv:
-            return self.get_queryset().filter(
+            return self.filter(
                 Q(visibilite__in=[Visibilite.LOCAL, Visibilite.NATIONAL])
                 | Q(visibilite=Visibilite.BROUILLON, createur=user.agent.structure)
             )
-        return self.get_queryset().filter(
+        return self.filter(
             Q(visibilite=Visibilite.NATIONAL)
             | Q(
                 visibilite__in=[Visibilite.BROUILLON, Visibilite.LOCAL],
                 createur=user.agent.structure,
             )
         )
+
+    def with_list_of_lieux(self):
+        from sv.models import Lieu
+
+        lieux_prefetch = Prefetch("lieux", queryset=Lieu.objects.order_by("id"), to_attr="lieux_list")
+        return self.prefetch_related(lieux_prefetch)
+
+    def with_first_region_name(self):
+        from sv.models import Lieu
+
+        first_lieu = Lieu.objects.filter(fiche_detection=OuterRef("pk")).order_by("id")
+        return self.annotate(region=Subquery(first_lieu.values("departement__region__nom")[:1]))
+
+    def optimized_for_list(self):
+        return self.select_related("etat", "numero", "organisme_nuisible", "createur")

--- a/sv/tests/test_fichedetection_list_performances.py
+++ b/sv/tests/test_fichedetection_list_performances.py
@@ -1,0 +1,17 @@
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_list_performance(client, django_assert_num_queries, mocked_authentification_user, fiche_detection_bakery):
+    fiche_detection_bakery()
+    client.get(reverse("fiche-detection-list"))
+
+    with django_assert_num_queries(9):
+        client.get(reverse("fiche-detection-list"))
+
+    for _ in range(0, 5):
+        fiche_detection_bakery()
+
+    with django_assert_num_queries(9):
+        client.get(reverse("fiche-detection-list"))


### PR DESCRIPTION
Avec toutes les FK depuis le modèle fiche détection beaucoup de queries étaient faistes vers la base de données.