### PR TITLE
Simplifier l'inclusion du template de bloc commun

### DIFF
--- a/core/templates/core/_contacts.html
+++ b/core/templates/core/_contacts.html
@@ -1,8 +1,8 @@
 <div class="fr-btns-group--right fr-mb-3w">
-    <a href="{% url 'structure-selection-add-form'%}?fiche_id={{fichedetection.pk}}&content_type_id={{content_type_id}}&next={{redirect_url}}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line">
+    <a href="{% url 'structure-selection-add-form'%}?fiche_id={{fiche.pk}}&content_type_id={{fiche.get_content_type_id}}&next={{fiche.get_absolute_url}}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line">
         Ajouter une structure
     </a>
-    <a href="{% url 'contact-add-form'%}?fiche_id={{fichedetection.pk}}&content_type_id={{content_type_id}}&next={{redirect_url}}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line">
+    <a href="{% url 'contact-add-form'%}?fiche_id={{fiche.pk}}&content_type_id={{fiche.get_content_type_id}}&next={{fiche.get_absolute_url}}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line">
         Ajouter un agent
     </a>
 </div>

--- a/core/templates/core/_modale_edition_document.html
+++ b/core/templates/core/_modale_edition_document.html
@@ -17,7 +17,7 @@
 
                                 {% csrf_token %}
                                 <input type="hidden" value="{{ document.pk }}" name="pk">
-                                <input type="hidden" value="{{ redirect_url }}" name="next">
+                                <input type="hidden" value="{{ fiche.get_absolute_url }}" name="next">
                                 <button type="submit" class="fr-btn" data-testid="documents-edit-{{ document.pk }}">Enregistrer les modifications</button>
 
                             </div>

--- a/core/templates/core/_modale_suppression_contact.html
+++ b/core/templates/core/_modale_suppression_contact.html
@@ -19,7 +19,7 @@
                                 <input type="hidden" value="{{ fiche.pk }}" name="fiche_pk">
                                 <input type="hidden" value="{{ content_type.pk }}" name="content_type_pk">
                                 <input type="hidden" value="{{ contact.pk }}" name="pk">
-                                <input type="hidden" value="{{ redirect_url }}" name="next">
+                                <input type="hidden" value="{{ fiche.get_absolute_url }}" name="next">
                                 <button type="submit" class="fr-btn" data-testid="contact-delete-{{ contact.pk }}">Oui, je supprime</button>
                             </form>
                         </div>

--- a/core/templates/core/_modale_suppression_document.html
+++ b/core/templates/core/_modale_suppression_document.html
@@ -17,7 +17,7 @@
                             <form action="{% url 'document-delete' document.pk %}" method="POST">
                                 {% csrf_token %}
                                 <input type="hidden" value="{{ document.pk }}" name="pk">
-                                <input type="hidden" value="{{ redirect_url }}" name="next">
+                                <input type="hidden" value="{{ fiche.get_absolute_url }}" name="next">
                                 <button type="submit" class="fr-btn" data-testid="documents-delete-{{ document.pk }}">Supprimer le document</button>
                             </form>
                         </div>

--- a/sv/templates/sv/fichedetection_detail.html
+++ b/sv/templates/sv/fichedetection_detail.html
@@ -222,7 +222,7 @@
         {% include "sv/_fichedetection_synthese.html" %}
 
 
-        {% include "core/_fiche_bloc_commun.html" with redirect_url=fichedetection.get_absolute_url fiche=fichedetection pk=fichedetection.pk content_type_id=fichedetection.get_content_type_id %}
+        {% include "core/_fiche_bloc_commun.html" with fiche=fichedetection %}
     </main>
 
 {% endblock %}


### PR DESCRIPTION
Voir ticket #161, le but est de rendre le tout plus cohérent, le bloc commun demande juste un objet de type fiche qui possède quelques méthodes / attributs (.pk, get_absolute_url, etc.).