### PR TITLE
Utiliser Django Filters pour la recherche de fiche

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 User = get_user_model()
 
 
-class DSFRForm(forms.BaseForm):
+class DSFRForm(forms.Form):
     input_to_class = defaultdict(lambda: "fr-input")
     input_to_class["ClearableFileInput"] = "fr-upload"
     input_to_class["Select"] = "fr-select"

--- a/sv/filters.py
+++ b/sv/filters.py
@@ -1,0 +1,43 @@
+import django_filters
+
+from core.forms import DSFRForm
+from .models import FicheDetection, Region, OrganismeNuisible, Etat
+from django.forms.widgets import DateInput, TextInput
+
+
+class FicheDetectionFilter(django_filters.FilterSet):
+    numero_input = TextInput(attrs={"pattern": "^[0-9]{4}\\.[0-9]+$", "title": "Format attendu : ANNEE.NUMERO"})
+    numero = django_filters.CharFilter(method="filter_numero", label="Numéro", widget=numero_input)
+    lieux__departement__region = django_filters.ModelChoiceFilter(label="Région", queryset=Region.objects.all())
+    organisme_nuisible = django_filters.ModelChoiceFilter(label="Organisme", queryset=OrganismeNuisible.objects.all())
+    start_date = django_filters.DateFilter(
+        field_name="date_creation__date",
+        lookup_expr="gte",
+        label="Période du",
+        widget=DateInput(attrs={"type": "date"}),
+    )
+    end_date = django_filters.DateFilter(
+        field_name="date_creation__date", lookup_expr="lte", label="Au", widget=DateInput(attrs={"type": "date"})
+    )
+    etat = django_filters.ModelChoiceFilter(label="État", queryset=Etat.objects.all())
+
+    class Meta:
+        model = FicheDetection
+        fields = ["numero", "lieux__departement__region", "organisme_nuisible", "start_date", "end_date", "etat"]
+        form = DSFRForm
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.data.get("numero"):
+            try:
+                _annee, _numero = map(int, self.data.get("numero").split("."))
+            except ValueError:
+                errors = self.errors.get("numero", [])
+                errors.append("Format 'numero' invalide. Il devrait être 'annee.numero'")
+                self.errors["numero"] = errors
+
+    def filter_numero(self, queryset, name, value):
+        if self.errors.get("numero") or not value:
+            return queryset
+        annee, numero = map(int, value.split("."))
+        return queryset.filter(numero__annee=annee, numero__numero=numero)

--- a/sv/static/sv/fichedetection_list.css
+++ b/sv/static/sv/fichedetection_list.css
@@ -16,8 +16,11 @@ body{
     gap: 2rem;
     margin-right: 2rem;
 }
-.form-search__field {
-    flex: 1;
+.fiches__search-form .fr-fieldset__element{
+    flex: 1 !important;
+}
+.fiches__search-form input, .fiches__search-form select {
+    margin-top: .5rem;
 }
 .choices__list--single{
     overflow: hidden;

--- a/sv/static/sv/fichedetection_list.js
+++ b/sv/static/sv/fichedetection_list.js
@@ -2,10 +2,10 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('search-form').addEventListener('reset', function (e) {
         e.preventDefault();
         this.elements['numero'].value = '';
-        this.elements['region'].value = '';
+        this.elements['lieux__departement__region'].value = '';
         this.elements['organisme_nuisible'].value = '';
-        this.elements['date_debut'].value = '';
-        this.elements['date_fin'].value = '';
+        this.elements['start_date'].value = '';
+        this.elements['end_date'].value = '';
         this.elements['etat'].value = '';
     });
 

--- a/sv/templates/sv/fichedetection_list.html
+++ b/sv/templates/sv/fichedetection_list.html
@@ -19,28 +19,23 @@
     <div class="fiches__header">
         <h2 class="fiches__title">Rechercher une fiche</h2>
         <form id="search-form" method="get" class="fiches__search-form">
-            {% for field in form %}
-                <p class="form-search__field">
-                    <label for="{{ field.id_for_label }}" class="fr-label"> {{ field.label }}</label>
-                    {{ field }}
-                </p>
-            {% endfor %}
-            <p>
+            {{ filter.form.as_dsfr_div }}
+            <div class="fr-fieldset__element">
                 <button type="reset" class="fr-btn fr-btn--secondary">Effacer</button>
                 <button type="submit" class="fr-btn">Rechercher</button>
-            </p>
+            </div>
         </form>
     </div>
 
     <div class="fiches__list-container">
         <h2>Liste des fiches</h2>
         <div class="fiches__list-header">
-            <span class="fiches__count">{{ page_obj.paginator.count }} fiche{{ fichedetection_list.count|pluralize }} au total</span>
+            <span class="fiches__count">{{ page_obj.paginator.count }} fiche{{ page_obj.paginator.count|pluralize }} au total</span>
             <button class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-file-add-line" data-fr-opened="false" data-testid="extract-open" aria-controls="fr-modal-extract">
                 Extraire
             </button>
         </div>
-        {% if fichedetection_list.count %}
+        {% if fiches.count %}
             <div class="fr-table fr-table--no-caption fr-table--layout-fixed">
                 <table class="fiches__list-table">
                     <thead>
@@ -55,7 +50,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for fiche in fichedetection_list %}
+                        {% for fiche in fiches %}
                             <tr class="fiches__list-row">
                                 <td>
                                     <a href="{% url 'fiche-detection-vue-detaillee' fiche.pk %}" class="fiches__list-link">

--- a/sv/tests/test_fichedetection_list_performances.py
+++ b/sv/tests/test_fichedetection_list_performances.py
@@ -7,11 +7,11 @@ def test_list_performance(client, django_assert_num_queries, mocked_authentifica
     fiche_detection_bakery()
     client.get(reverse("fiche-detection-list"))
 
-    with django_assert_num_queries(9):
+    with django_assert_num_queries(8):
         client.get(reverse("fiche-detection-list"))
 
     for _ in range(0, 5):
         fiche_detection_bakery()
 
-    with django_assert_num_queries(9):
+    with django_assert_num_queries(8):
         client.get(reverse("fiche-detection-list"))

--- a/sv/tests/test_fichedetection_search.py
+++ b/sv/tests/test_fichedetection_search.py
@@ -30,13 +30,13 @@ def test_search_form_have_all_fields(live_server, page: Page) -> None:
     expect(page.locator("#search-form").get_by_text("Région")).to_be_visible()
     expect(page.get_by_label("Région")).to_be_visible()
     expect(page.get_by_label("Région")).to_contain_text("---------")
-    expect(page.get_by_text("Organisme", exact=True)).to_be_visible()
+    expect(page.get_by_text("Organisme :", exact=True)).to_be_visible()
     expect(page.locator(".choices__list--single .choices__placeholder")).to_be_visible()
     expect(page.locator(".choices__list--single .choices__placeholder")).to_contain_text("---------")
     expect(page.get_by_text("Période du")).to_be_visible()
     expect(page.get_by_label("Période du")).to_be_visible()
     expect(page.get_by_label("Période du")).to_be_empty()
-    expect(page.get_by_text("Au", exact=True)).to_be_visible()
+    expect(page.get_by_text("Au :", exact=True)).to_be_visible()
     expect(page.get_by_label("Au")).to_be_visible()
     expect(page.get_by_label("Au")).to_be_empty()
     expect(page.locator("#search-form").get_by_text("État")).to_be_visible()
@@ -150,7 +150,7 @@ def test_search_with_organisme_nuisible(live_server, page: Page, mocked_authenti
 
     assert (
         page.url
-        == f"{live_server.url}{reverse('fiche-detection-list')}?numero=&region=&organisme_nuisible={organisme1.id}&date_debut=&date_fin=&etat="
+        == f"{live_server.url}{reverse('fiche-detection-list')}?numero=&lieux__departement__region=&organisme_nuisible={organisme1.id}&start_date=&end_date=&etat="
     )
 
     expect(page.get_by_role("cell", name=organisme1.libelle_court)).to_be_visible()


### PR DESCRIPTION
Ce commit permet d'utiliser Django Filters dans la rechercher des fiches détection afin de rendre plus simple la mise en place de la recherche sur les fiches Zone delimitées.