### PR TITLE
Rendre plus clair le besoin de lieu pour un prélèvement

### DIFF
--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -135,6 +135,9 @@
                         <h2>Lieux</h2>
                         <button type="button" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line" data-fr-opened="false" aria-controls="modal-add-edit-lieu">Ajouter un lieu</button>
                     </div>
+                    <template x-if="lieux.length == 0">
+                        <p>Aucun lieu.</p>
+                    </template>
                     {% include 'sv/_fichedetection_form__lieux.html' %}
                 </div>
 
@@ -144,7 +147,14 @@
                         <template x-if="lieux.length > 0">
                             <button  type="button" @click="addPrelevementForm()" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line" data-fr-opened="false" aria-controls="modal-add-edit-prelevement">Ajouter un prélèvement</button>
                         </template>
+                        <template x-if="lieux.length == 0">
+                            <button  type="button" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line" disabled>Ajouter un prélèvement</button>
+                        </template>
                     </div>
+                    <template x-if="lieux.length == 0">
+                        <p>Aucun prélèvement. Pour ajouter une prélèvement vous devez avoir renseigné au moins un lieu.</p>
+                    </template>
+
                     {% include 'sv/_fichedetection_form__prelevements.html' %}
                 </div>
 

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -61,7 +61,7 @@ def test_new_fiche_detection_form_content(live_server, page: Page, form_elements
     expect(form_elements.mesures_gestion_title).to_be_visible()
     expect(form_elements.save_btn).to_be_visible()
     expect(form_elements.add_lieu_btn).to_be_visible()
-    expect(form_elements.add_prelevement_btn).to_be_hidden()
+    expect(form_elements.add_prelevement_btn).to_be_disabled()
 
     expect(form_elements.date_creation_label).to_be_visible()
     expect(form_elements.date_creation_input).to_be_disabled()
@@ -195,6 +195,7 @@ def test_create_fiche_detection_with_lieu(
     )
 
     page.goto(f"{live_server.url}{reverse('fiche-detection-creation')}")
+    expect(form_elements.add_prelevement_btn).to_be_disabled()
     form_elements.statut_evenement_input.select_option(label="Foyer")
     form_elements.add_lieu_btn.click()
     page.wait_for_timeout(200)
@@ -218,6 +219,7 @@ def test_create_fiche_detection_with_lieu(
         str(lieu.position_chaine_distribution_etablissement.id)
     )
     lieu_form_elements.save_btn.click()
+    expect(form_elements.add_prelevement_btn).to_be_enabled()
     form_elements.save_btn.click()
 
     page.wait_for_timeout(1000)

--- a/sv/tests/test_fichedetection_form.py
+++ b/sv/tests/test_fichedetection_form.py
@@ -682,9 +682,8 @@ def test_delete_lieu_is_not_possible_if_linked_to_prelevement(
 # Ajouter un prélèvement
 
 
-def test_no_add_prelevement_btn_if_no_lieu(live_server, page: Page, form_elements: FicheDetectionFormDomElements):
-    """Test que le bouton d'ajout d'un prélèvement n'est pas visible si aucun lieu dans la liste"""
-    expect(form_elements.add_prelevement_btn).not_to_be_visible()
+def test_add_prelevement_btn_disabled_if_no_lieu(live_server, page: Page, form_elements: FicheDetectionFormDomElements):
+    expect(form_elements.add_prelevement_btn).to_be_disabled()
 
 
 def test_add_prelevement_btn_is_visible_if_lieu_exists(
@@ -693,3 +692,4 @@ def test_add_prelevement_btn_is_visible_if_lieu_exists(
     """Test que le bouton d'ajout d'un prélèvement est visible si au moins un lieu existe dans la liste"""
     _add_new_lieu(page, form_elements, lieu_form_elements)
     expect(form_elements.add_prelevement_btn).to_be_visible()
+    expect(form_elements.add_prelevement_btn).to_be_enabled()


### PR DESCRIPTION
Ce commit permet de rendre plus explicite au niveau de l'interface le besoin d'avoir un lieu avant de pouvoir ajouter un prélèvement.
- Ajout du bouton grisé (disabled) tant qu'aucun lieu n'a été ajouté afin d'améliorer la découvrabilité de l'interface.
- Ajout d'un message explicite qui permet de débloquer la création de prélèvement via l'ajout d'un Lieu.

Fixes  #341