### PR TITLE
Limiter les résultats de l'export pour l'utilisateur

### DIFF
--- a/sv/export.py
+++ b/sv/export.py
@@ -47,9 +47,19 @@ class FicheDetectionExport:
     def _clean_field_name(self, field):
         return field.replace("_", " ").title()
 
-    def get_queryset(self):
-        queryset = FicheDetection.objects.select_related("etat", "numero")
-        queryset = queryset.prefetch_related("lieux", "lieux__prelevements", "lieux__prelevements__structure_preleveur")
+    def get_queryset(self, user):
+        queryset = FicheDetection.objects.all().get_fiches_user_can_view(user).optimized_for_details()
+        queryset = queryset.prefetch_related(
+            "lieux",
+            "lieux__prelevements",
+            "lieux__departement",
+            "lieux__prelevements__structure_preleveur",
+            "lieux__prelevements__espece_echantillon",
+            "lieux__prelevements__matrice_prelevee",
+            "lieux__prelevements__site_inspection",
+            "lieux__prelevements__laboratoire_agree",
+            "lieux__prelevements__laboratoire_confirmation_officielle",
+        )
         return queryset
 
     def get_fieldnames(self):
@@ -86,8 +96,8 @@ class FicheDetectionExport:
         else:
             yield self.get_fiche_data(fiche_detection)
 
-    def export(self, stream):
-        queryset = self.get_queryset()
+    def export(self, stream, user):
+        queryset = self.get_queryset(user)
         writer = csv.DictWriter(stream, fieldnames=self.get_fieldnames())
         writer.writeheader()
 

--- a/sv/managers.py
+++ b/sv/managers.py
@@ -63,5 +63,10 @@ class FicheDetectionQuerySet(models.QuerySet):
     def order_by_numero_fiche(self):
         return self.order_by("-numero__annee", "-numero__numero")
 
+    def optimized_for_details(self):
+        return self.select_related(
+            "statut_reglementaire", "etat", "numero", "contexte", "createur", "statut_evenement", "organisme_nuisible"
+        )
+
     def get_all_not_in_fiche_zone_delimitee(self):
         return self.filter(zone_infestee__isnull=True, hors_zone_infestee__isnull=True).order_by("numero")

--- a/sv/views.py
+++ b/sv/views.py
@@ -89,9 +89,7 @@ class FicheDetectionDetailView(
     DetailView,
 ):
     model = FicheDetection
-    queryset = FicheDetection.objects.select_related(
-        "statut_reglementaire", "etat", "numero", "contexte", "createur", "statut_evenement", "organisme_nuisible"
-    )
+    queryset = FicheDetection.objects.all().optimized_for_details()
 
     def get_object(self, queryset=None):
         if hasattr(self, "object"):
@@ -593,7 +591,7 @@ class FicheDetectionExportView(View):
 
     def post(self, request):
         response = HttpResponse(content_type="text/csv")
-        FicheDetectionExport().export(stream=response)
+        FicheDetectionExport().export(stream=response, user=request.user)
         response["Content-Disposition"] = "attachment; filename=export_fiche_detection.csv"
         return response
 


### PR DESCRIPTION
Le but de ce commit est de limiter les fiches exportables par un utilisateur/utilisatrice donné à ce qui est effectivement visible dans l'outil. Ainsi la prise en compte des règles de visibilité empéche un agent de voir dans l'export des fiches qu'il ne verrait pas dans l'outil.

Au cours de mes tests je me suis rendu compte que l'export était relativement lent même pour une base relativement petite (~800 lignes dans le fichier CSV). J'ai optimisé et rendu les tests plus réalistes avec l'utilisation de _fill_optional.

Fixes #299 