### PR TITLE
Corrige l'ordre de la liste de fiche detection

### DIFF
--- a/sv/managers.py
+++ b/sv/managers.py
@@ -55,5 +55,8 @@ class FicheDetectionQuerySet(models.QuerySet):
     def optimized_for_list(self):
         return self.select_related("etat", "numero", "organisme_nuisible", "createur")
 
+    def order_by_numero_fiche(self):
+        return self.order_by("-numero__annee", "-numero__numero")
+
     def get_all_not_in_fiche_zone_delimitee(self):
         return self.filter(zone_infestee__isnull=True, hors_zone_infestee__isnull=True).order_by("numero")

--- a/sv/tests/test_fichedetection_search.py
+++ b/sv/tests/test_fichedetection_search.py
@@ -260,3 +260,34 @@ def test_search_without_filters(live_server, page: Page, mocked_authentification
     expect(page.get_by_role("cell", name=str(fiche1.numero))).to_be_visible()
     expect(page.get_by_role("cell", name=str(fiche2.numero))).to_be_visible()
     expect(page.locator("body")).to_contain_text("2 fiches au total")
+
+
+def test_list_is_ordered(live_server, page, fiche_detection_bakery):
+    fiche_1 = fiche_detection_bakery()
+    numero = fiche_1.numero
+    numero.annee = 2024
+    numero.numero = 30
+    numero.save()
+
+    fiche_2 = fiche_detection_bakery()
+    numero = fiche_2.numero
+    numero.annee = 2023
+    numero.numero = 7
+    numero.save()
+
+    fiche_3 = fiche_detection_bakery()
+    numero = fiche_3.numero
+    numero.annee = 2024
+    numero.numero = 31
+    numero.save()
+
+    page.goto(f"{live_server.url}{get_fiche_detection_search_form_url()}")
+
+    cell_selector = ".fiches__list-row:nth-child(1) td:nth-child(1) a"
+    assert page.text_content(cell_selector).strip() == "2024.31"
+
+    cell_selector = ".fiches__list-row:nth-child(2) td:nth-child(1) a"
+    assert page.text_content(cell_selector).strip() == "2024.30"
+
+    cell_selector = ".fiches__list-row:nth-child(3) td:nth-child(1) a"
+    assert page.text_content(cell_selector).strip() == "2023.7"

--- a/sv/views.py
+++ b/sv/views.py
@@ -63,13 +63,12 @@ from core.models import Visibilite
 
 class FicheDetectionListView(ListView):
     model = FicheDetection
-    ordering = ["-numero"]
     paginate_by = 100
     context_object_name = "fiches"
 
     def get_queryset(self):
         queryset = FicheDetection.objects.all().get_fiches_user_can_view(self.request.user)
-        queryset = queryset.with_list_of_lieux().with_first_region_name().optimized_for_list()
+        queryset = queryset.with_list_of_lieux().with_first_region_name().optimized_for_list().order_by_numero_fiche()
         self.filter = FicheDetectionFilter(self.request.GET, queryset=queryset)
         return self.filter.qs
 


### PR DESCRIPTION
Le but de ce commit est de s'assurer que l'ordre est bien respecté sur la vue de liste des fiches détection. Ce n'était pas le cas a cause de la redéfinition de la méthode get_queryset sur la classe. J'en ai profité pour préciser l'ordre précis sur le modèle Numéro afin d'éviter un ordre implicite qui ne corredpond pas a ce qui était voulu.