### PR TITLE
Tenter de corriger la CI

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -43,7 +43,7 @@ def mocked_authentification_user(db):
 def choice_js_fill(db, page):
     def _choice_js_fill(page, locator, fill_content, exact_name):
         page.query_selector(locator).click()
-        page.wait_for_selector("*:focus", state="visible", timeout=2_000)
+        page.wait_for_selector("input:focus", state="visible", timeout=2_000)
         page.locator("*:focus").fill(fill_content)
         page.get_by_role("option", name=exact_name, exact=True).click()
 


### PR DESCRIPTION
Par exemple:
```
FAILED sv/tests/test_fichedetection_form.py::test_add_lieu_form_is_empty_after_edit - playwright._impl._errors.Error: Locator.fill: Error: Element is not an <input>, <textarea> or [contenteditable] element
```