### PR TITLE
Améliorer les performances de la fiche zone

### DIFF
--- a/sv/tests/test_fichezonedelimitee_performances.py
+++ b/sv/tests/test_fichezonedelimitee_performances.py
@@ -1,7 +1,7 @@
 from model_bakery import baker
 from sv.models import FicheZoneDelimitee, FicheDetection, ZoneInfestee
 
-BASE_NUM_QUERIES = 6
+BASE_NUM_QUERIES = 4
 
 
 def test_empty_fiche_zone_delimitee_performances(client, django_assert_num_queries, mocked_authentification_user):
@@ -36,7 +36,7 @@ def test_fiche_zone_delimitee_with_one_zone_infestee(client, django_assert_num_q
     zone_infestee = baker.make(ZoneInfestee, fiche_zone_delimitee=fiche)
     baker.make(FicheDetection, zone_infestee=zone_infestee)
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 2):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 1):
         client.get(fiche.get_absolute_url())
 
 
@@ -48,5 +48,5 @@ def test_fiche_zone_delimitee_with_multiple_zone_infestee(
     for zone_infestee in zones_infestees:
         baker.make(FicheDetection, zone_infestee=zone_infestee)
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 2):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 1):
         client.get(fiche.get_absolute_url())

--- a/sv/views.py
+++ b/sv/views.py
@@ -755,6 +755,13 @@ class FicheZoneDelimiteeDetailView(DetailView):
     model = FicheZoneDelimitee
     context_object_name = "fiche"
 
+    def get_object(self, queryset=None):
+        if hasattr(self, "object"):
+            return self.object
+
+        self.object = super().get_object(queryset)
+        return self.object
+
     def get_queryset(self):
         zone_infestee_detections_prefetch = Prefetch(
             "fichedetection_set", queryset=FicheDetection.objects.select_related("numero")


### PR DESCRIPTION
Utilisation d'un attribut de la classe comme "cache" local pour éviter de réaliser plusieurs fois l'opération. Sera d'autant plus utile que l'on réalise souvent get_object dans les mixins.