### PR TITLE
Ajouter les numéros Rasff et Europhyt au formulaire

### DIFF
--- a/sv/static/sv/fichedetection_form.css
+++ b/sv/static/sv/fichedetection_form.css
@@ -46,11 +46,13 @@ main {
 #informations-content {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
-    grid-gap: 4rem;
-
+    column-gap: 4rem;
+    row-gap: 1rem;
 }
 #date-creation,
-#statut-evenement {
+#statut-evenement,
+#numero-europhyt,
+#numero-rasff {
     display: flex;
     align-items: center;
 }
@@ -60,10 +62,22 @@ main {
 #date-creation-input {
     flex: 1.35;
 }
+#numero-rasff label {
+    flex: 0.65;
+}
+#numero-rasff-input {
+    flex: 1.35;
+}
 #statut-evenement label {
     flex: 0.75;
 }
 #statut-evenement-input {
+    flex: 1.25;
+}
+#numero-europhyt label {
+    flex: 0.75;
+}
+#numero-europhyt-input {
     flex: 1.25;
 }
 

--- a/sv/static/sv/fichedetection_form.js
+++ b/sv/static/sv/fichedetection_form.js
@@ -77,6 +77,8 @@ document.addEventListener('alpine:init', () => {
         ficheDetection: {
             numero: '',
             statutEvenementId: '',
+            numeroRasff: '',
+            numeroEurophyt: '',
             organismeNuisibleId: '',
             statutReglementaireId: '',
             contexteId: '',
@@ -176,6 +178,8 @@ document.addEventListener('alpine:init', () => {
 
             this.ficheDetection = {
                 numero: this.getValueById('numeroFiche'),
+                numeroEurophyt: this.getValueById('numeroEurophyt'),
+                numeroRasff: this.getValueById('numeroRasff'),
                 statutEvenementId: this.getValueById('statut-evenement-id'),
                 organismeNuisibleId: this.getValueById('organisme-nuisible-id'),
                 statutReglementaireId: this.getValueById('statut-reglementaire-id'),
@@ -552,6 +556,8 @@ document.addEventListener('alpine:init', () => {
             let formData = new FormData();
             const organismeNuisibleId = this.ficheDetection.organismeNuisibleId.value ? this.ficheDetection.organismeNuisibleId.value : this.ficheDetection.organismeNuisibleId
             formData.append('statutEvenementId', this.ficheDetection.statutEvenementId);
+            formData.append('numeroRasff', this.ficheDetection.numeroRasff);
+            formData.append('numeroEurophyt', this.ficheDetection.numeroEurophyt);
             formData.append('organismeNuisibleId', organismeNuisibleId);
             formData.append('statutReglementaireId', this.ficheDetection.statutReglementaireId);
             formData.append('contexteId', this.ficheDetection.contexteId);

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -21,6 +21,8 @@
 {% block content %}
     <main x-data="app">
         <input type="hidden" id="numeroFiche" value="{{ form.instance.numero }}">
+        <input type="hidden" id="numeroEurophyt" value="{{ form.instance.numero_europhyt }}">
+        <input type="hidden" id="numeroRasff" value="{{ form.instance.numero_rasff }}">
         <input type="hidden" id="statut-evenement-id" value="{{ form.instance.statut_evenement_id|default:'' }}">
         <input type="hidden" id="organisme-nuisible-id" value="{{ form.instance.organisme_nuisible_id|default:'' }}">
         <input type="hidden" id="statut-reglementaire-id" value="{{ form.instance.statut_reglementaire_id|default:'' }}">
@@ -75,11 +77,11 @@
                 <div id="informations">
                     <h2>Informations</h2>
                     <div id="informations-content">
-                        <p id="date-creation">
+                        <div id="date-creation">
                             <label class="fr-label" for="date-creation-input">Date de création</label>
                             <input type="text" id="date-creation-input" class="fr-input" value="{% now 'd/m/Y' %}" disabled>
-                        </p>
-                        <p id="statut-evenement">
+                        </div>
+                        <div id="statut-evenement">
                             <label class="fr-label" for="statut-evenement-input">Statut évènement</label>
                             <select x-model="ficheDetection.statutEvenementId" id="statut-evenement-input" class="fr-select">
                                 <option value="">----</option>
@@ -87,7 +89,15 @@
                                     <option value="{{ statut_evenement.id }}">{{ statut_evenement.libelle }}</option>
                                 {% endfor %}
                             </select>
-                        </p>
+                        </div>
+                        <div id="numero-europhyt">
+                            <label class="fr-label" for="numero-europhyt-input">Numéro Europhyt</label>
+                            <input x-model="ficheDetection.numeroEurophyt" id="numero-europhyt-input" class="fr-input" maxlength="8">
+                        </div>
+                        <div id="numero-rasff">
+                            <label class="fr-label" for="numero-rasff-input">Numéro Rasff</label>
+                            <input x-model="ficheDetection.numeroRasff" id="numero-rasff-input" class="fr-input" maxlength="9">
+                        </div>
                     </div>
                 </div>
 

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -68,6 +68,10 @@ def test_new_fiche_detection_form_content(live_server, page: Page, form_elements
 
     expect(form_elements.statut_evenement_label).to_be_visible()
     expect(form_elements.statut_evenement_input).to_be_visible()
+    expect(form_elements.numero_europhyt_label).to_be_visible()
+    expect(form_elements.numero_europhyt_input).to_be_visible()
+    expect(form_elements.numero_rasff_label).to_be_visible()
+    expect(form_elements.numero_rasff_input).to_be_visible()
     expect(form_elements.statut_evenement_input).to_contain_text("----")
     expect(form_elements.statut_evenement_input).to_have_value("")
     statuts_evenement = list(StatutEvenement.objects.values_list("libelle", flat=True))
@@ -137,6 +141,8 @@ def test_fiche_detection_create_without_lieux_and_prelevement(
     page.get_by_label("----").fill("xylela")
     page.get_by_role("option", name=organisme_nuisible.libelle_court).click()
     page.get_by_label("Statut règlementaire").select_option(value=str(statut_reglementaire.id))
+    page.get_by_label("Numéro Europhyt").fill("1" * 8)
+    page.get_by_label("Numéro Rasff").fill("2" * 9)
     page.get_by_label("Contexte").select_option(value=str(contexte.id))
     page.get_by_label("Date 1er signalement").fill("2024-04-21")
     page.get_by_label("Commentaire").click()
@@ -155,6 +161,8 @@ def test_fiche_detection_create_without_lieux_and_prelevement(
 
     fiche_detection = FicheDetection.objects.get()
     assert fiche_detection.createur == mocked_authentification_user.agent.structure
+    assert fiche_detection.numero_europhyt == "11111111"
+    assert fiche_detection.numero_rasff == "222222222"
     assert fiche_detection.statut_evenement.libelle == statut_evenement.libelle
     assert fiche_detection.organisme_nuisible.libelle_court == organisme_nuisible.libelle_court
     assert fiche_detection.statut_reglementaire.id == statut_reglementaire.id

--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -159,6 +159,8 @@ def test_fiche_detection_update_without_lieux_and_prelevement(
 
     choice_js_fill(page, "#organisme-nuisible .choices__list--single", organisme.libelle_court, organisme.libelle_court)
 
+    form_elements.numero_rasff_input.fill(str(new_fiche_detection.numero_rasff))
+    form_elements.numero_europhyt_input.fill(str(new_fiche_detection.numero_europhyt))
     form_elements.statut_reglementaire_input.select_option(str(new_fiche_detection.statut_reglementaire.id))
     form_elements.contexte_input.select_option(str(new_fiche_detection.contexte.id))
     form_elements.date_1er_signalement_input.fill(new_fiche_detection.date_premier_signalement.strftime("%Y-%m-%d"))
@@ -175,6 +177,8 @@ def test_fiche_detection_update_without_lieux_and_prelevement(
         fiche_detection_updated.createur == fiche_detection.createur
     )  # le createur ne doit pas changer lors d'une modification
     assert fiche_detection_updated.statut_evenement == new_fiche_detection.statut_evenement
+    assert fiche_detection_updated.numero_europhyt == new_fiche_detection.numero_europhyt
+    assert fiche_detection_updated.numero_rasff == new_fiche_detection.numero_rasff
     assert fiche_detection_updated.organisme_nuisible == organisme
     assert fiche_detection_updated.statut_reglementaire == new_fiche_detection.statut_reglementaire
     assert fiche_detection_updated.contexte == new_fiche_detection.contexte

--- a/sv/tests/test_utils.py
+++ b/sv/tests/test_utils.py
@@ -66,6 +66,22 @@ class FicheDetectionFormDomElements:
         return self.page.get_by_label("Statut évènement")
 
     @property
+    def numero_europhyt_label(self) -> Locator:
+        return self.page.get_by_text("Numéro Europhyt")
+
+    @property
+    def numero_europhyt_input(self) -> Locator:
+        return self.page.get_by_label("Numéro Europhyt")
+
+    @property
+    def numero_rasff_label(self) -> Locator:
+        return self.page.get_by_text("Numéro Rasff")
+
+    @property
+    def numero_rasff_input(self) -> Locator:
+        return self.page.get_by_label("Numéro Rasff")
+
+    @property
     def organisme_nuisible_label(self) -> Locator:
         return self.page.get_by_text("Organisme nuisible", exact=True)
 

--- a/sv/views.py
+++ b/sv/views.py
@@ -281,6 +281,8 @@ class FicheDetectionCreateView(FicheDetectionContextMixin, CreateView):
             numero=NumeroFiche.get_next_numero(),
             createur=user_structure,
             statut_evenement_id=data["statutEvenementId"],
+            numero_europhyt=data["numeroEurophyt"],
+            numero_rasff=data["numeroRasff"],
             organisme_nuisible_id=data["organismeNuisibleId"],
             statut_reglementaire_id=data["statutReglementaireId"],
             contexte_id=data["contexteId"],
@@ -443,6 +445,8 @@ class FicheDetectionUpdateView(FicheDetectionContextMixin, UpdateView):
 
         # Mise à jour des champs de l'objet FicheDetection
         fiche_detection.statut_evenement_id = data.get("statutEvenementId")
+        fiche_detection.numero_europhyt = data.get("numeroEurophyt")
+        fiche_detection.numero_rasff = data.get("numeroRasff")
         fiche_detection.organisme_nuisible_id = data.get("organismeNuisibleId")
         fiche_detection.statut_reglementaire_id = data.get("statutReglementaireId")
         fiche_detection.contexte_id = data.get("contexteId")


### PR DESCRIPTION
Ajout des champs pour les numéros Rasff et Europhyt au formulaire de création et d'édition de fiche Détection.