### PR TITLE
Réutiliser choice_js_fill (fixture pytest) + corriger fail CI

### DIFF
--- a/sv/tests/conftest.py
+++ b/sv/tests/conftest.py
@@ -95,12 +95,11 @@ def document_recipe(fiche_detection_bakery, db):
 
 
 @pytest.fixture
-def fill_commune(db, page: Page):
+def fill_commune(db, page: Page, choice_js_fill):
     def _fill_commune(page):
-        page.query_selector(".fr-modal__content .choices__list--single").click()
-        page.wait_for_selector("*:focus", state="visible", timeout=2_000)
-        page.locator("*:focus").fill("Lille")
-        page.get_by_role("option", name="Lille (59)", exact=True).click()
+        choice_js_fill(
+            page, locator=".fr-modal__content .choices__list--single", fill_content="Lille", exact_name="Lille (59)"
+        )
 
     return _fill_commune
 

--- a/sv/tests/test_fichedetection_form.py
+++ b/sv/tests/test_fichedetection_form.py
@@ -35,6 +35,7 @@ def _add_new_lieu(
     page: Page,
     form_elements: FicheDetectionFormDomElements,
     lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
     extra_str="",
     extra_int=0,
 ):
@@ -45,10 +46,7 @@ def _add_new_lieu(
     lieu_form_elements.adresse_input.fill(f"une adresse{extra_str}")
 
     page.wait_for_timeout(100)
-    page.query_selector(".fr-modal__content .choices__list--single").click()
-    page.wait_for_selector("*:focus", state="visible", timeout=2_000)
-    page.locator("*:focus").fill("Lille")
-    page.get_by_role("option", name="Lille (59)", exact=True).click()
+    choice_js_fill(page, ".fr-modal__content .choices__list--single", "Lille", "Lille (59)")
 
     lieu_form_elements.coord_gps_lamber93_latitude_input.click()
     lieu_form_elements.coord_gps_lamber93_latitude_input.fill(str(6_000_000 + extra_int))
@@ -205,10 +203,14 @@ def test_add_lieu_to_list(
 
 
 def test_added_lieu_content_in_list(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que le contenu du lieu ajouté contient le nom du lieu, la commune et les boutons de suppression et de modification"""
-    _add_new_lieu(page, form_elements, lieu_form_elements)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
     expect(page.locator("#lieux").get_by_text("nom lieu")).to_be_visible()
     expect(page.locator("#lieux")).to_contain_text("nom lieu")
     expect(page.get_by_text("Lille")).to_be_visible()
@@ -219,10 +221,14 @@ def test_added_lieu_content_in_list(
 
 @pytest.mark.django_db
 def test_lieu_is_added_to_alpinejs_data(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que le lieu ajouté est bien ajouté dans le tableau de données alpinejs"""
-    _add_new_lieu(page, form_elements, lieu_form_elements)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
 
     lieux_json = page.get_by_test_id("lieux").input_value()
     lieux = json.loads(lieux_json)
@@ -262,12 +268,16 @@ def test_add_two_lieux_to_list(
 
 @pytest.mark.django_db
 def test_two_lieux_are_added_to_alpinejs_data(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que les lieux ajoutés sont bien ajoutés dans le tableau de données alpinejs"""
     # ajout du premier lieu
-    _add_new_lieu(page, form_elements, lieu_form_elements)
-    _add_new_lieu(page, form_elements, lieu_form_elements, extra_str=" 2")
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill, extra_str=" 2")
 
     lieux_json = page.get_by_test_id("lieux").input_value()
     lieux = json.loads(lieux_json)
@@ -296,10 +306,14 @@ def test_two_lieux_are_added_to_alpinejs_data(
 
 
 def test_edit_lieu_button_show_form_in_modal(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que le bouton Modifier le lieu affiche le formulaire de modification dans une modal"""
-    _add_new_lieu(page, form_elements, lieu_form_elements)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
 
     page.get_by_role("button", name="Modifier le lieu").click()
 
@@ -307,10 +321,14 @@ def test_edit_lieu_button_show_form_in_modal(
 
 
 def test_edit_lieu_modal_title_and_actions_btn(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que le titre de la modal de modification d'un lieu est bien 'Modifier le lieu'"""
-    _add_new_lieu(page, form_elements, lieu_form_elements)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
 
     page.get_by_role("button", name="Modifier le lieu").click()
 
@@ -345,10 +363,14 @@ def test_edit_lieu_form_with_only_nom_lieu(
 
 
 def test_edit_lieu_form_have_all_fields(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que le formulaire de modification d'un lieu contient bien les champs attendus et que ceux-ci sont pré-remplis avec les valeurs du lieu à modifier."""
-    _add_new_lieu(page, form_elements, lieu_form_elements)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
     # modification du lieu
     page.get_by_role("button", name="Modifier le lieu").click()
 
@@ -390,12 +412,16 @@ def test_edit_lieu_form_have_all_fields(
 
 @pytest.mark.django_db
 def test_edit_lieu_form_have_all_fields_with_multiple_lieux(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que le formulaire de modification d'un lieu contient bien les champs attendus
     et que ceux-ci sont pré-remplis avec les valeurs du lieu à modifier si plusieurs lieux sont présentent dans la liste"""
-    _add_new_lieu(page, form_elements, lieu_form_elements)
-    _add_new_lieu(page, form_elements, lieu_form_elements, extra_str=" 2", extra_int=2)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill, extra_str=" 2", extra_int=2)
 
     # vérification des valeurs du premier lieu
     page.get_by_role("button", name="Modifier le lieu").first.click()
@@ -434,7 +460,7 @@ def test_edit_lieu_is_updated_in_alpinejs_data(
 ):
     """Test que le lieu modifié est bien mis à jour dans le tableau de données alpinejs"""
     # ajout d'un lieu
-    _add_new_lieu(page, form_elements, lieu_form_elements)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
 
     # modification du lieu
     page.get_by_role("button", name="Modifier le lieu").click()
@@ -470,7 +496,7 @@ def test_add_lieu_form_is_empty_after_edit(
 ):
     """Test que le formulaire d'ajout d'un lieu est vide après la modification d'un lieu"""
     # ajout d'un lieu
-    _add_new_lieu(page, form_elements, lieu_form_elements)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
 
     # modification du lieu
     page.get_by_role("button", name="Modifier le lieu").click()
@@ -497,11 +523,15 @@ def test_add_lieu_form_is_empty_after_edit(
 
 
 def test_add_lieu_form_is_empty_after_close_edit_form_with_close_btn_without_save(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que si je quitte la modification d’un lieu sans enregistrer via le  bouton fermer,
     je dois trouver le formulaire d’ajout d’un lieu vide"""
-    _add_new_lieu(page, form_elements, lieu_form_elements)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
 
     page.get_by_role("button", name="Modifier le lieu").click()
     page.get_by_role("button", name="Fermer").click()
@@ -511,11 +541,15 @@ def test_add_lieu_form_is_empty_after_close_edit_form_with_close_btn_without_sav
 
 
 def test_add_lieu_form_is_empty_after_close_edit_form_with_cancel_btn_without_save(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que si je quitte la modification d’un lieu sans enregistrer via le bouton annuler,
     je dois trouver le formulaire d’ajout d’un lieu vide"""
-    _add_new_lieu(page, form_elements, lieu_form_elements)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
 
     page.get_by_role("button", name="Modifier le lieu").click()
     page.get_by_role("button", name="Annuler").click()
@@ -525,11 +559,15 @@ def test_add_lieu_form_is_empty_after_close_edit_form_with_cancel_btn_without_sa
 
 
 def test_add_lieu_form_is_empty_after_close_edit_form_with_esc_key_without_save(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que si je quitte la modification d’un lieu sans enregistrer via la touche echap du clavier,
     je dois trouver le formulaire d’ajout d’un lieu vide"""
-    _add_new_lieu(page, form_elements, lieu_form_elements)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
 
     page.get_by_role("button", name="Modifier le lieu").click()
     page.keyboard.press("Escape")
@@ -542,10 +580,14 @@ def test_add_lieu_form_is_empty_after_close_edit_form_with_esc_key_without_save(
 
 
 def test_delete_lieu_button_show_confirmation_modal(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test qu'une modal de confirmation est affichée lors de la suppression d'un lieu liée à aucun prélèvement"""
-    _add_new_lieu(page, form_elements, lieu_form_elements)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
 
     page.get_by_role("button", name="Supprimer le lieu").click()
 
@@ -553,10 +595,14 @@ def test_delete_lieu_button_show_confirmation_modal(
 
 
 def test_delete_lieu_from_list(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que le lieu est bien supprimée de la liste des lieux après confirmation"""
-    _add_new_lieu(page, form_elements, lieu_form_elements)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
 
     page.get_by_role("button", name="Supprimer le lieu").click()
     page.get_by_role("dialog", name="Supprimer").get_by_role("button", name="Supprimer").click()
@@ -687,9 +733,13 @@ def test_add_prelevement_btn_disabled_if_no_lieu(live_server, page: Page, form_e
 
 
 def test_add_prelevement_btn_is_visible_if_lieu_exists(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
 ):
     """Test que le bouton d'ajout d'un prélèvement est visible si au moins un lieu existe dans la liste"""
-    _add_new_lieu(page, form_elements, lieu_form_elements)
+    _add_new_lieu(page, form_elements, lieu_form_elements, choice_js_fill)
     expect(form_elements.add_prelevement_btn).to_be_visible()
     expect(form_elements.add_prelevement_btn).to_be_enabled()


### PR DESCRIPTION
Cette PR : 
- Refactorise la fixture `fill_commune` pour utiliser `choice_js_fill`, éliminant ainsi la duplication de code pour la manipulation des champs Choices.js. Maintien de la même interface pour `fill_commune`
- Utilisation de fixture choice_js_fill dans la fonction _add_new_lieu.
- Tente de corriger certains tests qui fail sur la CI. Exemple : 
```
FAILED sv/tests/test_fichedetection_form.py::test_add_lieu_form_is_empty_after_close_edit_form_with_close_btn_without_save - playwright._impl._errors.Error: Locator.fill: Error: Element is not an <input>, <textarea> or [contenteditable] element
```