### PR TITLE
Supprime retour à la ligne avant affichage des structures sur liste contacts

### DIFF
--- a/core/templates/core/_contacts.html
+++ b/core/templates/core/_contacts.html
@@ -13,8 +13,6 @@
                 {% include "core/_carte_resume_contact.html" %}
             </div>
         {% endfor %}
-    </div>
-    <div class="fr-grid-row fr-grid-row--gutters">
         {% for contact in contacts_structures %}
             <div class="fr-col-3 fr-col-xl-3">
                 {% include "core/_carte_resume_contact.html" %}


### PR DESCRIPTION
Supprime le retour à la ligne lors de l'affichage des structures dans la liste des contacts (cf. https://github.com/betagouv/seves/issues/275#issuecomment-2386267853)