### PR TITLE
Modification du cron d'envoi des emails

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -4,7 +4,7 @@
 		"command": "0 0,5 * * * python manage.py update_fichedetection_etat"
 	  },
 	  {
-		"command": "* * * * * python manage.py send_queued_mail"
+		"command": "*/10 * * * * python manage.py send_queued_mail"
 	  }
 	]
   }


### PR DESCRIPTION
Modification du cron d'envoi des emails (exécution toutes les 10 minutes) pour respecter la contrainte du Scheduler Scalingo.

> Limitations
> The smallest scheduling interval is set to 10 minutes. For example, the Scalingo Scheduler won’t let you set up a task to run every 5 minutes (the deployment will fail).
https://doc.scalingo.com/platform/app/task-scheduling/scalingo-scheduler