### PR TITLE
Permettre de sélectionner automatiquement le statut

### DIFF
--- a/sv/constants.py
+++ b/sv/constants.py
@@ -154,3 +154,46 @@ CONTEXTES = [
     "notification rasff",
     "autre (à préciser dans le fil de suivi)",
 ]
+
+KNOWN_OEPP_CODES_FOR_STATUS_REGLEMENTAIRES = {
+    "OQ": [
+        "OE_XYLEFM",
+        "OE_POCZSH",
+        "OE_XYLOCH",
+        "OE_PSDMS2",
+        "OE_HETDPA",
+        "OE_RALSSL",
+        "OE_HETDRO",
+        "OE_MELGCH",
+        "OE_MELGFA",
+        "OE_PHYP64",
+        "OE_CERAFP",
+        "OE_RHIOHI",
+        "OE_ALECSN",
+        "OE_PITOJU",
+        "OE_TOLCND",
+        "OE_GEOHMO",
+        "OE_SCITDO",
+        "OE_DACULA",
+        "OE_MELGMY",
+        "OE_XIPHRI",
+        "OE_1BCTRG",
+        "OE_CORBFL",
+        "OE_PHYPAE",
+        "OE_PHYTRA",
+    ],
+    "OQZP": ["OE_BNYVV0", "OE_RHYCFE"],
+    "OQP": [
+        "OE_GUIGCI",
+        "OE_DACUDO",
+        "OE_POPIJA",
+        "OE_DACUZO",
+        "OE_BURSXY",
+        "OE_ANOLCN",
+        "OE_XYLEFA",
+        "OE_TOBRFV",
+        "OE_1POMAG",
+    ],
+}
+
+KNOWN_OEPPS = [oepp for oepp_list in KNOWN_OEPP_CODES_FOR_STATUS_REGLEMENTAIRES.values() for oepp in oepp_list]

--- a/sv/static/sv/fichedetection_form.js
+++ b/sv/static/sv/fichedetection_form.js
@@ -54,6 +54,7 @@ function addChoicesEspeceEchantillon(){
     return choicesEspece
 }
 document.addEventListener('DOMContentLoaded', function() {
+    const statusToNuisibleId =  JSON.parse(document.getElementById('status-to-organisme-nuisible-id').textContent)
     const element = document.getElementById('organisme-nuisible-input');
     const choices = new Choices(element, {
         classNames: {
@@ -61,6 +62,17 @@ document.addEventListener('DOMContentLoaded', function() {
         },
         itemSelectText: ''
     });
+
+    choices.passedElement.element.addEventListener("choice", (event)=> {
+        statusToNuisibleId.forEach((line) =>{
+            if (line.nuisibleIds.includes(parseInt(event.detail.choice.value)))
+            {
+                document.getElementById('statut-reglementaire-input').value=line.statusID
+                document.getElementById('statut-reglementaire-input').dispatchEvent(new Event('change'));
+            }
+        })
+
+    })
 });
 
 document.addEventListener('alpine:init', () => {

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -37,6 +37,7 @@
         {{ prelevements|json_script:"prelevements" }}
         {{ structures_preleveurs|json_script:"structures-preleveurs" }}
         {{ sites_inspections|json_script:"sites-inspections" }}
+        {{ status_to_organisme_nuisible|json_script:"status-to-organisme-nuisible-id" }}
 
         <form x-ref="fichedetectionForm" @submit.prevent="saveFicheDetection($event)">
 

--- a/sv/tests/conftest.py
+++ b/sv/tests/conftest.py
@@ -7,7 +7,7 @@ from .test_utils import FicheDetectionFormDomElements, LieuFormDomElements, Prel
 from playwright.sync_api import Page
 from model_bakery import baker
 from model_bakery.recipe import Recipe, foreign_key
-from sv.models import Etat, FicheDetection, FicheZoneDelimitee
+from sv.models import Etat, FicheDetection, FicheZoneDelimitee, StatutReglementaire
 
 User = get_user_model()
 
@@ -42,6 +42,18 @@ def add_basic_etat_objects():
     Etat.objects.get_or_create(libelle="nouveau")
     Etat.objects.get_or_create(libelle="en cours")
     Etat.objects.get_or_create(libelle="clôturé")
+
+
+@pytest.fixture(autouse=True)
+def add_status_reglementaire_objects():
+    status = {
+        "OQP": "organisme quarantaine prioritaire",
+        "OQ": "organisme quarantaine",
+        "OQZP": "organisme quarantaine zone protégée",
+        "ORNQ": "organisme réglementée non quarantaine",
+    }
+    for code, libelle in status.items():
+        StatutReglementaire.objects.get_or_create(code=code, libelle=libelle)
 
 
 @pytest.fixture

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -322,6 +322,26 @@ def test_fiche_detection_numero_fiche_is_null_when_save_with_visibilite_brouillo
     assert fiche_detection.visibilite == Visibilite.BROUILLON
 
 
+@pytest.mark.django_db
+def test_fiche_detection_status_reglementaire_is_pre_selected(
+    live_server, page: Page, form_elements: FicheDetectionFormDomElements, choice_js_fill
+):
+    organisme_nuisible, _ = OrganismeNuisible.objects.get_or_create(code_oepp="OE_XYLEFM")
+    organisme_nuisible.libelle_court = "Mon ON"
+    organisme_nuisible.save()
+
+    page.goto(f"{live_server.url}{reverse('fiche-detection-creation')}")
+    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    expect(form_elements.statut_reglementaire_input).to_contain_text("----")
+    page.get_by_role("button", name="Enregistrer").click()
+
+    page.wait_for_timeout(600)
+
+    fiche_detection = FicheDetection.objects.get()
+    assert fiche_detection.organisme_nuisible == organisme_nuisible
+    assert fiche_detection.statut_reglementaire.code == "OQ"
+
+
 def test_prelevements_are_always_linked_to_lieu(
     live_server,
     page: Page,


### PR DESCRIPTION
Ce commit va permettre dans certains cas (les plus courants) de sélectionner le statut réglementaire associé à un organisme nuisible (via son code OEPP).
Introduction d'un mapping dans le code qui servira aussi pour la reprise d'historique.