### PR TITLE
Modification libellé boutons sur formulaire fiche détection

### DIFF
--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -143,7 +143,7 @@
                 <div id="lieux">
                     <div id="lieux-header">
                         <h2>Lieux</h2>
-                        <button type="button" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line" data-fr-opened="false" aria-controls="modal-add-edit-lieu">Ajouter un lieu</button>
+                        <button type="button" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line" data-fr-opened="false" aria-controls="modal-add-edit-lieu">Ajouter</button>
                     </div>
                     <template x-if="lieux.length == 0">
                         <p>Aucun lieu.</p>
@@ -155,10 +155,10 @@
                     <div id="prelevements-header">
                         <h2>Prélèvements</h2>
                         <template x-if="lieux.length > 0">
-                            <button  type="button" @click="addPrelevementForm()" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line" data-fr-opened="false" aria-controls="modal-add-edit-prelevement">Ajouter un prélèvement</button>
+                            <button  type="button" @click="addPrelevementForm()" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line" data-fr-opened="false" aria-controls="modal-add-edit-prelevement">Ajouter</button>
                         </template>
                         <template x-if="lieux.length == 0">
-                            <button  type="button" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line" disabled>Ajouter un prélèvement</button>
+                            <button  type="button" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line" disabled>Ajouter</button>
                         </template>
                     </div>
                     <template x-if="lieux.length == 0">

--- a/sv/tests/test_utils.py
+++ b/sv/tests/test_utils.py
@@ -44,11 +44,11 @@ class FicheDetectionFormDomElements:
 
     @property
     def add_lieu_btn(self) -> Locator:
-        return self.page.get_by_role("button", name="Ajouter un lieu")
+        return self.page.locator("#lieux-header").get_by_role("button", name="Ajouter")
 
     @property
     def add_prelevement_btn(self) -> Locator:
-        return self.page.get_by_role("button", name="Ajouter un prélèvement")
+        return self.page.locator("#prelevements-header").get_by_role("button", name="Ajouter")
 
     @property
     def date_creation_label(self) -> Locator:


### PR DESCRIPTION
Sur le formulaire de la fiche détection, modification du libellé pour les boutons permettant d'ajouter un lieu et ajouter un prélèvement.