### PR TITLE
Permettre l'édition RASFF et Europhyt uniquement par l'AC

### DIFF
--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -90,11 +90,11 @@
                                 {% endfor %}
                             </select>
                         </div>
-                        <div id="numero-europhyt">
+                        <div id="numero-europhyt" {% if not user.agent.structure.is_ac %}class="fr-hidden"{% endif %}>
                             <label class="fr-label" for="numero-europhyt-input">Numéro Europhyt</label>
                             <input x-model="ficheDetection.numeroEurophyt" id="numero-europhyt-input" class="fr-input" maxlength="8">
                         </div>
-                        <div id="numero-rasff">
+                        <div id="numero-rasff" {% if not user.agent.structure.is_ac %}class="fr-hidden"{% endif %}>
                             <label class="fr-label" for="numero-rasff-input">Numéro Rasff</label>
                             <input x-model="ficheDetection.numeroRasff" id="numero-rasff-input" class="fr-input" maxlength="9">
                         </div>

--- a/sv/views.py
+++ b/sv/views.py
@@ -288,12 +288,17 @@ class FicheDetectionCreateView(FicheDetectionContextMixin, CreateView):
         except ValueError:
             date_premier_signalement = None
 
-        # Création de la fiche de détection en base de données
+        additionnal_data = {}
+        if self.request.user.agent.structure.is_ac:
+            additionnal_data = {
+                "numero_europhyt": data["numeroEurophyt"],
+                "numero_rasff": data["numeroRasff"],
+            }
+
         fiche = FicheDetection(
             createur=user_structure,
             statut_evenement_id=data["statutEvenementId"],
-            numero_europhyt=data["numeroEurophyt"],
-            numero_rasff=data["numeroRasff"],
+            **additionnal_data,
             organisme_nuisible_id=data["organismeNuisibleId"],
             statut_reglementaire_id=data["statutReglementaireId"],
             contexte_id=data["contexteId"],
@@ -456,8 +461,6 @@ class FicheDetectionUpdateView(FicheDetectionContextMixin, UpdateView):
 
         # Mise à jour des champs de l'objet FicheDetection
         fiche_detection.statut_evenement_id = data.get("statutEvenementId")
-        fiche_detection.numero_europhyt = data.get("numeroEurophyt")
-        fiche_detection.numero_rasff = data.get("numeroRasff")
         fiche_detection.organisme_nuisible_id = data.get("organismeNuisibleId")
         fiche_detection.statut_reglementaire_id = data.get("statutReglementaireId")
         fiche_detection.contexte_id = data.get("contexteId")
@@ -467,6 +470,9 @@ class FicheDetectionUpdateView(FicheDetectionContextMixin, UpdateView):
         fiche_detection.mesures_consignation = data.get("mesuresConsignation")
         fiche_detection.mesures_phytosanitaires = data.get("mesuresPhytosanitaires")
         fiche_detection.mesures_surveillance_specifique = data.get("mesuresSurveillanceSpecifique")
+        if self.request.user.agent.structure.is_ac:
+            fiche_detection.numero_europhyt = data.get("numeroEurophyt")
+            fiche_detection.numero_rasff = data.get("numeroRasff")
 
         try:
             fiche_detection.full_clean()


### PR DESCRIPTION
Le but de ce commit est de ne permettre l'édition des numéros RASFF et Europhyt que par l'administration centrale que cela soit pour la création ou la modification de fiches détection.
On masque les champs dans le HTML pour ne pas permettre l'édition, mais on ajoute aussi une sécurité backend pour éviter qu'une personne puisse tout de même éditer les valeurs sans en avoir le droit.

Dans les tests j'utilise `evaluate` à la place de `force=True` pour deux raisons:
- Cela correspond mieux au cas d'usage que l'on veut simuler (afficher la case puis la remplir)
- L'option force ne semble pas déclencher l'exécution du JavaScript au niveau d'AlpineJs et les nouvelles valeurs ne sont donc pas envoyées.

Fixes #403