### PR TITLE
Améliorer le rendu du tableau sur petit écran

### DIFF
--- a/sv/static/sv/fiche_list.css
+++ b/sv/static/sv/fiche_list.css
@@ -83,3 +83,6 @@ body{
     padding-bottom: 0.50rem !important;
     background-image: none !important;
 }
+.fiches__list-link-no-wrap {
+    text-wrap: nowrap;
+}

--- a/sv/templates/sv/fiche_list.html
+++ b/sv/templates/sv/fiche_list.html
@@ -53,12 +53,12 @@
                         {% for fiche in fiches %}
                             <tr class="fiches__list-row">
                                 <td>
-                                    <a href="{{ fiche.get_absolute_url }}" class="fiches__list-link">
+                                    <a href="{{ fiche.get_absolute_url }}" class="fiches__list-link fiches__list-link-no-wrap">
                                         {{ fiche.type }}
                                     </a>
                                 </td>
                                 <td>
-                                    <a href="{{ fiche.get_absolute_url }}" class="fiches__list-link">
+                                    <a href="{{ fiche.get_absolute_url }}" class="fiches__list-link fiches__list-link-no-wrap">
                                         {{ fiche.numero|default:"nc." }}
                                     </a>
                                 </td>
@@ -68,7 +68,7 @@
                                     </a>
                                 </td>
                                 <td>
-                                    <a href="{{ fiche.get_absolute_url }}" class="fiches__list-link">
+                                    <a href="{{ fiche.get_absolute_url }}" class="fiches__list-link fiches__list-link-no-wrap">
                                         {{ fiche.date_creation }}
                                     </a>
                                 </td>


### PR DESCRIPTION
Améliore le tableau de liste sur des petits écrans d'ordinateur. L'affichage est toujours mauvais quand la largeur est faible mais améliore la situation dans la zone 1000px à 1400px de large.