### PR TITLE
Fix erreur si plusieurs imports à la suite + libellé structure

### DIFF
--- a/core/management/commands/import_contacts.py
+++ b/core/management/commands/import_contacts.py
@@ -37,14 +37,14 @@ class Command(BaseCommand):
                 return
 
             structure, _ = Structure.objects.get_or_create(
-                niveau1=niveau1, niveau2=niveau2, defaults={"libelle": niveau2}
+                niveau1=niveau1, niveau2=niveau2, defaults={"libelle": niveau2 or niveau1}
             )
 
             Contact.objects.get_or_create(structure=structure)
 
             # Contact pour agent
             User = get_user_model()
-            user, _ = User.objects.update_or_create(username=row["Mail"], is_active=False)
+            user, _ = User.objects.get_or_create(username=row["Mail"], defaults={"is_active": False})
 
             agent, _ = Agent.objects.update_or_create(
                 user=user,

--- a/core/tests/test_import_contacts.py
+++ b/core/tests/test_import_contacts.py
@@ -2,6 +2,7 @@ import pytest
 from io import StringIO
 from django.core.management import call_command
 from django.core.exceptions import ObjectDoesNotExist
+from django.contrib.auth import get_user_model
 
 from core.models import Contact, Agent, Structure
 
@@ -95,3 +96,14 @@ def test_ignore_unknown_email(mock_csv_data):
     assert Contact.objects.filter(agent__isnull=False).count() == 2
     with pytest.raises(ObjectDoesNotExist):
         Contact.objects.get(email="inconnu")
+
+
+def test_import_contacts_twice_with_user_activation(mock_csv_data):
+    """Test pour s'assurer que deux importations des contacts fonctionnent en ayant activé un user entre les deux"""
+    _reset_contacts()
+    call_command("import_contacts", mock_csv_data)
+    User = get_user_model()
+    user = User.objects.get(username="test@example.com")
+    user.is_active = True
+    user.save()
+    call_command("import_contacts", mock_csv_data)


### PR DESCRIPTION
WIP: il manque l'ajout de test pour l'erreur IntegrityError générée

Cette PR : 

- Corrige l'erreur IntegrityError si plusieurs imports à la suite sont effectués.
Lorsque qu'un import est effectué, qu'un user est activé, un second import est effectué, il y une erreur de type IntegrityError. Pour corriger cette erreur, remplacement de get_or_create par update_or_create.
- Ajoute le niveau 1 dans le libellé de la structure si le niveau 2 est vide.