### PR TITLE
Corriger les tests sur le status réglementaire

### DIFF
--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -367,13 +367,14 @@ def test_fiche_detection_numero_fiche_is_null_when_save_with_visibilite_brouillo
 def test_fiche_detection_status_reglementaire_is_pre_selected(
     live_server, page: Page, form_elements: FicheDetectionFormDomElements, choice_js_fill
 ):
+    statut = StatutReglementaire.objects.get(code="OQ")
     organisme_nuisible, _ = OrganismeNuisible.objects.get_or_create(code_oepp="OE_XYLEFM")
     organisme_nuisible.libelle_court = "Mon ON"
     organisme_nuisible.save()
 
     page.goto(f"{live_server.url}{reverse('fiche-detection-creation')}")
     choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
-    expect(form_elements.statut_reglementaire_input).to_have_value("2")
+    expect(form_elements.statut_reglementaire_input).to_have_value(str(statut.id))
     page.get_by_role("button", name="Enregistrer").click()
 
     page.wait_for_timeout(600)
@@ -387,6 +388,7 @@ def test_fiche_detection_status_reglementaire_is_pre_selected(
 def test_fiche_detection_status_reglementaire_is_emptied_when_unknown(
     live_server, page: Page, form_elements: FicheDetectionFormDomElements, choice_js_fill
 ):
+    statut = StatutReglementaire.objects.get(code="OQ")
     organisme_nuisible, _ = OrganismeNuisible.objects.get_or_create(code_oepp="OE_XYLEFM")
     organisme_nuisible.libelle_court = "Mon ON"
     organisme_nuisible.save()
@@ -397,7 +399,7 @@ def test_fiche_detection_status_reglementaire_is_emptied_when_unknown(
 
     page.goto(f"{live_server.url}{reverse('fiche-detection-creation')}")
     choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
-    expect(form_elements.statut_reglementaire_input).to_have_value("2")
+    expect(form_elements.statut_reglementaire_input).to_have_value(str(statut.id))
     choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Pas mon ON", "Pas mon ON")
     expect(form_elements.statut_reglementaire_input).to_have_value("")
     page.get_by_role("button", name="Enregistrer").click()


### PR DESCRIPTION
Etre sur que l'on utilise toujours l'ID du bon objet pour la comparaison