### PR TITLE
Corriger l'affichage des sites d'inspection

### DIFF
--- a/sv/static/sv/fichedetection_detail.css
+++ b/sv/static/sv/fichedetection_detail.css
@@ -98,7 +98,7 @@ main{
 .detail-lieu__label--adresse-etablissement,
 .detail-lieu__label--siret-etablissement,
 .detail-lieu__label--code-inpp-etablissement,
-.detail-lieu__label--type-etablissement,
+.detail-lieu__label--site-inspection,
 .detail-lieu__label--position-etablissement {
     font-weight: bold;
 }

--- a/sv/templates/sv/_fichedetection_form__lieux_form.html
+++ b/sv/templates/sv/_fichedetection_form__lieux_form.html
@@ -33,7 +33,7 @@
                                 <select x-model="lieuForm.siteInspectionId" class="fr-select" data-testid="lieu-form-type-etablissement" id="site-inspection">
                                     <option value="">----</option>
                                     {% for site_inspection in sites_inspections %}
-                                        <option value="{{ site_inspection.id }}">{{ site_inspection.libelle }}</option>
+                                        <option value="{{ site_inspection.id }}">{{ site_inspection.nom }}</option>
                                     {% endfor %}
                                 </select>
                             </p>

--- a/sv/templates/sv/fichedetection_detail_lieu.html
+++ b/sv/templates/sv/fichedetection_detail_lieu.html
@@ -22,6 +22,11 @@
                         </div>
                         <div class="fr-grid-row fr-mb-2w">
                             <div class="fr-col-offset-2"></div>
+                            <div class="fr-col-4 detail-lieu__label--site-inspection">Site d'inspection</div>
+                            <div class="fr-col-6">{{lieu.site_inspection.nom|default:"nc."}}</div>
+                        </div>
+                        <div class="fr-grid-row fr-mb-2w">
+                            <div class="fr-col-offset-2"></div>
                             <div class="fr-col-4 detail-lieu__label--code-insee">Code INSEE</div>
                             <div class="fr-col-6" data-testid="lieu-{{lieu_index}}-code-insee">{{lieu.code_insee|default:"nc."}}</div>
                         </div>
@@ -104,11 +109,6 @@
                                 <div class="fr-col-offset-2"></div>
                                 <div class="fr-col-4 detail-lieu__label--code-inpp-etablissement">Code INPP</div>
                                 <div class="fr-col-6" data-testid="lieu-{{lieu_index}}-code-inpp-etablissement">{{lieu.code_inpp_etablissement|default:"nc."}}</div>
-                            </div>
-                            <div class="fr-grid-row fr-mb-2w">
-                                <div class="fr-col-offset-2"></div>
-                                <div class="fr-col-4 detail-lieu__label--type-etablissement">Type</div>
-                                <div class="fr-col-6" data-testid="lieu-{{lieu_index}}-type-etablissement">{{lieu.type_exploitant_etablissement.libelle|default:"nc."}}</div>
                             </div>
                             <div class="fr-grid-row fr-mb-2w">
                                 <div class="fr-col-offset-2"></div>

--- a/sv/views.py
+++ b/sv/views.py
@@ -121,7 +121,9 @@ class FicheDetectionDetailView(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["lieux"] = (
-            Lieu.objects.filter(fiche_detection=self.get_object()).order_by("id").select_related("departement__region")
+            Lieu.objects.filter(fiche_detection=self.get_object())
+            .order_by("id")
+            .select_related("departement__region", "site_inspection")
         )
         prelevement = Prelevement.objects.filter(lieu__fiche_detection=self.get_object())
         context["prelevements"] = prelevement.select_related(
@@ -536,6 +538,7 @@ class FicheDetectionUpdateView(FicheDetectionContextMixin, UpdateView):
             )
             lieu.adresse_lieu_dit = loc["adresseLieuDit"]
             lieu.commune = loc.get("commune")
+            lieu.site_inspection_id = loc["siteInspectionId"]
             lieu.code_insee = loc.get("codeINSEE")
             lieu.departement = departement
             lieu.is_etablissement = loc["isEtablissement"]
@@ -547,7 +550,6 @@ class FicheDetectionUpdateView(FicheDetectionContextMixin, UpdateView):
                 lieu.adresse_etablissement = loc["adresseEtablissement"]
                 lieu.siret_etablissement = loc["siretEtablissement"]
                 lieu.code_inpp_etablissement = loc["codeInppEtablissement"]
-                lieu.site_inspection_id = loc["siteInspectionId"]
                 lieu.position_chaine_distribution_etablissement_id = loc["positionEtablissementId"]
             else:
                 lieu.nom_etablissement = ""
@@ -556,7 +558,6 @@ class FicheDetectionUpdateView(FicheDetectionContextMixin, UpdateView):
                 lieu.raison_sociale_etablissement = ""
                 lieu.adresse_etablissement = ""
                 lieu.siret_etablissement = ""
-                lieu.site_inspection_id = None
                 lieu.position_chaine_distribution_etablissement_id = None
             lieu.save()
             loc["lieu_pk"] = lieu.pk


### PR DESCRIPTION
Affiche le nom et pas le libellé, deplace l'affichage dans la bonne section.