### PR TITLE
Modification de l'emplacement du champ végétaux infestés sur le formulaire de la fiche détection

### DIFF
--- a/sv/static/sv/fichedetection_form.css
+++ b/sv/static/sv/fichedetection_form.css
@@ -21,7 +21,7 @@ main {
 }
 #lieux, #prelevements {
     overflow-y: auto;
-    max-height: 40rem;
+    max-height: 805px;
 }
 
 

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -137,12 +137,12 @@
                         <input x-text="ficheDetection.datePremierSignalement" x-model="ficheDetection.datePremierSignalement" type="date" id="date-1er-signalement-input" class="fr-input" max="{% now "Y-m-d" %}">
                     </p>
                     <p>
-                        <label class="fr-label" for="commentaire-input">Commentaire</label>
-                        <textarea x-model="ficheDetection.commentaire" id="commentaire-input" class="fr-input" maxlength="500"></textarea>
-                    </p>
-                    <p>
                         <label class="fr-label" for="vegetaux-infestes-input">Végétaux inféstés</label>
                         <textarea x-model="ficheDetection.vegetauxInfestes" id="vegetaux-infestes-input" class="fr-input" maxlength="500"></textarea>
+                    </p>
+                    <p>
+                        <label class="fr-label" for="commentaire-input">Commentaire</label>
+                        <textarea x-model="ficheDetection.commentaire" id="commentaire-input" class="fr-input" maxlength="500"></textarea>
                     </p>
                 </div>
 


### PR DESCRIPTION
Modification de l'emplacement du champ végétaux infestés sur le formulaire de la fiche détection.

Réajustement de la hauteur des bloc lieu et prélèvement : 
Avant:
![image](https://github.com/user-attachments/assets/40b7f829-0d91-4702-903d-7c98fc7955f9)


Après:
![Capture d’écran 2024-11-15 à 09 14 09](https://github.com/user-attachments/assets/2f341908-bb8d-4733-8f03-e0fb74ee2b90)
