### PR TITLE
Empêcher de lier une fiche Zone a elle-même

### DIFF
--- a/sv/forms.py
+++ b/sv/forms.py
@@ -95,6 +95,8 @@ class FicheZoneDelimiteeForm(DSFRForm, forms.ModelForm):
 
         qs_detection = FicheDetection.objects.all().get_fiches_user_can_view(self.user).select_related("numero")
         qs_zone = FicheZoneDelimitee.objects.all().get_fiches_user_can_view(self.user).select_related("numero")
+        if self.instance:
+            qs_zone = qs_zone.exclude(id=self.instance.id)
         self.fields["free_link"] = MultiModelChoiceField(
             required=False,
             label="Sélectionner un objet",
@@ -118,6 +120,11 @@ class FicheZoneDelimiteeForm(DSFRForm, forms.ModelForm):
 
     def clean_statut_reglementaire(self):
         return StatutReglementaire.objects.get(libelle=self.cleaned_data["statut_reglementaire"])
+
+    def clean_free_link(self):
+        if self.instance and self.instance in self.cleaned_data["free_link"]:
+            raise ValidationError("Vous ne pouvez pas lier une fiche a elle-même.")
+        return self.cleaned_data["free_link"]
 
     def clean(self):
         if duplicate_fiches_detection := self._get_duplicate_detections():

--- a/sv/views.py
+++ b/sv/views.py
@@ -165,6 +165,10 @@ class FicheDetectionContextMixin:
 
         content_type = ContentType.objects.get_for_model(FicheDetection)
         queryset = FicheDetection.objects.all().get_fiches_user_can_view(user).select_related("numero")
+        try:
+            queryset = queryset.exclude(pk=self.get_object().pk)
+        except AttributeError:
+            pass
         possible_links.append((content_type.pk, "Fiche Détection", queryset))
 
         content_type = ContentType.objects.get_for_model(FicheZoneDelimitee)


### PR DESCRIPTION
Ce commit empêche de lier une fiche zone a elle-même via les liens libres.
- Retire la fiche en cours de modification de la liste de choix autorisés
- Retourne une erreur de validation si cela venait tout de même à se produire

Fixes SEVES-11