### PR TITLE
Corriger le nombre de requêtes pour accéder aux groupes

### DIFF
--- a/account/templatetags/groups.py
+++ b/account/templatetags/groups.py
@@ -1,12 +1,8 @@
 from django import template
-from django.contrib.auth.models import Group
 
 register = template.Library()
 
 
 @register.filter(name="has_group")
 def has_group(user, group_name):
-    group = Group.objects.filter(name=group_name).first()
-    if not group:
-        return False
-    return group in user.groups.all()
+    return group_name in [group.name for group in user.groups.all()]


### PR DESCRIPTION
Dans le commit `6f6fd6c6ab9c023d244f01697bcb72ab30f43ad8` nous avons ajouté le groupe dans une migration, ce qui fait que le groupe est présent lors des tests.
Cela ajoutait une requête SQL dans les tests de performances en biaisant le résultat (le code que l'on veut tester ne fait pas plus de requêtes mais la page au global oui).
Reécriture du template tags pour qu'il ne fasse plus qu'une seule requête, peut importe la configuration des groupes. Idéalement il faudrait déplacer ça dans un contexte processors, si nous utilisons cette logique a plusieurs endroits.