### PR TITLE
Fix erreur notification AC si adresses mails de la MUS et/ou BSV sont vides

### DIFF
--- a/sv/tests/test_fichedetection_ac_notification.py
+++ b/sv/tests/test_fichedetection_ac_notification.py
@@ -2,15 +2,16 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from playwright.sync_api import Page, expect
 
-from core.models import Structure, Contact, Visibilite
+from core.models import Structure, Contact, Visibilite, Message
+from core.constants import MUS_STRUCTURE, BSV_STRUCTURE
 from ..models import FicheDetection
 
 
 def test_can_notify_ac(live_server, page: Page, fiche_detection: FicheDetection, mailoutbox):
     fiche_detection.visibilite = Visibilite.LOCAL
     fiche_detection.save()
-    Contact.objects.create(structure=Structure.objects.create(niveau2="MUS"), email="foo@bar.com")
-    Contact.objects.create(structure=Structure.objects.create(niveau2="SAS/SDSPV/BSV"), email="foo@bar.com")
+    Contact.objects.create(structure=Structure.objects.create(niveau2=MUS_STRUCTURE), email="foo@bar.com")
+    Contact.objects.create(structure=Structure.objects.create(niveau2=BSV_STRUCTURE), email="foo@bar.com")
     page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
 
     page.get_by_role("button", name="Actions").click()
@@ -66,3 +67,20 @@ def test_cant_notify_ac_if_draft_with_request(mocked_authentification_user, clie
     assert len(messages) == 1
     assert messages[0].level_tag == "error"
     assert str(messages[0]) == "Action impossible car la fiche est en brouillon"
+
+
+def test_if_email_notification_fails_does_not_create_message_or_update_status(
+    live_server, page: Page, fiche_detection: FicheDetection, mailoutbox
+):
+    Contact.objects.create(structure=Structure.objects.create(niveau2=MUS_STRUCTURE))
+    Contact.objects.create(structure=Structure.objects.create(niveau2=BSV_STRUCTURE), email="foo@bar.com")
+
+    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
+    page.get_by_role("button", name="Actions").click()
+    page.get_by_role("button", name="Déclarer à l'AC").click()
+
+    assert len(mailoutbox) == 0
+    expect(page.get_by_text("Une erreur s'est produite lors de la notification")).to_be_visible()
+    assert not fiche_detection.messages.filter(message_type=Message.NOTIFICATION_AC).exists()
+    fiche_detection.refresh_from_db()
+    assert fiche_detection.is_ac_notified is False


### PR DESCRIPTION
Le problème initial est que `notify_message(message)` dans la méthode `notify_ac()` raise une exception de type `ValidationError - 'recipients:  is not a valid email address'` si le mail du contact MUS et/ou BSV est vide.
Donc, la sauvegarde du booléen `is_ac_notified` via `self.save()` n'est jamais effectuée.
De plus, un objet de type `Message` est créé en base alors qu'il y a eu un problème lors de l'envoi.

Pour garantir une cohérence en base des différents objets impliqués : 
- gérer `notify_message(message)` dans un try et sauvegarder le message uniquement si pas d'erreur dans l'envoi de la notif
- ajout d'une transaction atomique pour la sauvegarde de la fiche et du message