### PR TITLE
Empêcher d'écrire aux utilisateurs inactifs

### DIFF
--- a/core/managers.py
+++ b/core/managers.py
@@ -41,6 +41,15 @@ class ContactQueryset(QuerySet):
     def structures_only(self):
         return self.exclude(structure__isnull=True)
 
+    def with_active_agent(self):
+        return self.filter(agent__user__is_active=True)
+
+    def exclude_empty_emails(self):
+        return self.exclude(email="")
+
+    def can_be_emailed(self):
+        return self.exclude_empty_emails().with_active_agent() | self.exclude_empty_emails().structures_only()
+
     def services_deconcentres_first(self):
         return self.annotate(
             services_deconcentres_first=Case(
@@ -83,3 +92,8 @@ class LienLibreQueryset(QuerySet):
             object_id_1=object_2.id,
         ).first()
         return link
+
+
+class StructureQueryset(QuerySet):
+    def has_at_least_one_active_contact(self):
+        return self.filter(agent__user__is_active=True).distinct()

--- a/core/models.py
+++ b/core/models.py
@@ -7,7 +7,7 @@ from django.db.models import Q, CheckConstraint
 from django.utils.translation import gettext_lazy as _
 
 from django.contrib.auth import get_user_model
-from .managers import DocumentQueryset, ContactQueryset, LienLibreQueryset
+from .managers import DocumentQueryset, ContactQueryset, LienLibreQueryset, StructureQueryset
 from django.apps import apps
 from core.constants import AC_STRUCTURE, MUS_STRUCTURE, BSV_STRUCTURE
 from .storage import get_timestamped_filename
@@ -50,6 +50,8 @@ class Structure(models.Model):
     niveau1 = models.CharField(max_length=255)
     niveau2 = models.CharField(max_length=255, blank=True)
     libelle = models.CharField(max_length=255, blank=True)
+
+    objects = StructureQueryset.as_manager()
 
     def __str__(self):
         return self.libelle

--- a/core/tests/test_managers.py
+++ b/core/tests/test_managers.py
@@ -1,8 +1,12 @@
-from core.models import Document, Structure, Agent
+from django.contrib.auth import get_user_model
+
+from core.models import Document, Structure, Agent, Contact
 import pytest
 from datetime import datetime
 from model_bakery import baker
 from django.utils import timezone
+
+User = get_user_model()
 
 
 @pytest.mark.django_db
@@ -40,3 +44,22 @@ def test_document_ordered():
     )
 
     assert list(Document.objects.order_list()) == [doc_4, doc_3, doc_2, doc_1]
+
+
+@pytest.mark.django_db
+def test_can_be_emailed():
+    Contact.objects.all().delete()
+    structure = baker.make(Structure, libelle="Struct")
+    contact_for_structure = baker.make(Contact, structure=structure, agent=None, email="foo@bar.com")
+
+    inactive_user = baker.make(User)
+    inactive_agent = baker.make(Agent, user=inactive_user)
+    _contact_for_inactive_agent = baker.make(Contact, structure=None, agent=inactive_agent)
+
+    active_user = baker.make(User)
+    active_user.is_active = True
+    active_user.save()
+    active_agent = baker.make(Agent, user=active_user)
+    contact_for_active_agent = baker.make(Contact, structure=None, agent=active_agent)
+
+    assert list(Contact.objects.can_be_emailed()) == [contact_for_structure, contact_for_active_agent]

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -471,6 +471,7 @@ def test_fiche_detection_with_free_link_cant_see_draft(
     form_elements: FicheDetectionFormDomElements,
     mocked_authentification_user,
     fiche_zone_bakery,
+    choice_js_cant_pick,
 ):
     fiche_zone = fiche_zone_bakery()
     fiche_zone.visibilite = Visibilite.BROUILLON
@@ -479,7 +480,4 @@ def test_fiche_detection_with_free_link_cant_see_draft(
 
     page.goto(f"{live_server.url}{reverse('fiche-detection-creation')}")
     fiche_input = "Fiche zone délimitée : " + str(fiche_zone.numero)
-    page.query_selector("#liens-libre .choices").click()
-    page.wait_for_selector("input:focus", state="visible", timeout=2_000)
-    page.locator("*:focus").fill(str(fiche_zone.numero))
-    expect(page.get_by_role("option", name=fiche_input, exact=True)).not_to_be_visible()
+    choice_js_cant_pick(page, "#liens-libre .choices", str(fiche_zone.numero), fiche_input)


### PR DESCRIPTION
On peut écrire uniquement a:
- un contact dont l'utilisateur qui est actif et qui a un email
- une structure qui a un mail

Cela s'applique dans l'interface de rédaction des messages (fil de suivi) ou dans l'interface d'ajout de structures ou de contacts.

Fixes #438 