### PR TITLE
Normaliser l'affichage des contacts

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -220,7 +220,7 @@ class MessageForm(DSFRForm, WithNextUrlMixin, WithContentTypeMixin, forms.ModelF
             )
 
         self.initial["sender"] = sender.agent.contact_set.get()
-        self.initial["displayed_sender"] = sender.agent.name_with_structure
+        self.initial["displayed_sender"] = sender.agent.contact_set.get().display_with_agent_unit
 
         if message_type == Message.FIN_SUIVI:
             self.initial["title"] = "Fin de suivi"

--- a/core/models.py
+++ b/core/models.py
@@ -40,10 +40,6 @@ class Agent(models.Model):
     def is_in_structure(self, structure):
         return self.structure == structure
 
-    @property
-    def name_with_structure(self):
-        return f"{self.structure} [{self.nom} {self.prenom}]"
-
 
 class Structure(models.Model):
     class Meta:

--- a/core/templates/core/message_detail.html
+++ b/core/templates/core/message_detail.html
@@ -12,7 +12,7 @@
                 <div class="fr-container--fluid">
                     <div class="fr-grid-row">
                         <div class="fr-col-9">
-                            <p><span class="fr-text--bold">De : </span>{{ message.sender.agent.name_with_structure }}</p>
+                            <p><span class="fr-text--bold">De : </span>{{ message.sender.display_with_agent_unit }}</p>
                             {% if message.recipients.all|length %}
                                 <p><span class="fr-text--bold">A : </span>
                                     {% for recipient in message.recipients.all %}

--- a/sv/tests/test_fiches_message.py
+++ b/sv/tests/test_fiches_message.py
@@ -276,3 +276,18 @@ def test_can_click_on_shortcut_when_fiche_has_structure(live_server, page: Page,
 
     fiche.refresh_from_db()
     assert fiche.messages.get().recipients.get() == contact
+
+
+def test_formatting_contacts_messages_details_page(live_server, page: Page, fiche_variable):
+    fiche = fiche_variable()
+    structure = Structure.objects.create(niveau1="MUS", niveau2="MUS", libelle="MUS")
+    sender = Contact.objects.create(agent=baker.make(Agent, nom="Reinhardt", prenom="Django", structure=structure))
+    fiche.contacts.add(sender)
+    contact = Contact.objects.create(agent=baker.make(Agent, nom="Reinhardt", prenom="Jean", structure=structure))
+    fiche.contacts.add(contact)
+    message = Message.objects.create(content_object=fiche, sender=sender, title="Minor", content="Swing")
+    message.recipients.set([contact])
+
+    page.goto(f"{live_server.url}{message.get_absolute_url()}")
+    expect(page.get_by_text("De : Reinhardt Django (MUS)", exact=True)).to_be_visible()
+    expect(page.get_by_text("A : Reinhardt Jean (MUS)", exact=True)).to_be_visible()


### PR DESCRIPTION
Ce commit s'assure que tous les affichages de contacts respectent la même règle d'affichage.

- Normalisation des méthodes utilisées
- Ajout d'un test

Fixes #436 