### PR TITLE
Corrige l'affichage du nom de l'établissement

### DIFF
--- a/sv/templates/sv/fichedetection_detail_lieu.html
+++ b/sv/templates/sv/fichedetection_detail_lieu.html
@@ -78,7 +78,7 @@
                             <div class="fr-grid-row fr-mb-2w">
                                 <div class="fr-col-offset-2"></div>
                                 <div class="fr-col-4 detail-lieu__label--nom-etablissement">Nom</div>
-                                <div class="fr-col-6" data-testid="lieu-{{lieu_index}}-nom-etablissement">{{lieu.nom_etablisement|default:"nc."}}</div>
+                                <div class="fr-col-6" data-testid="lieu-{{lieu_index}}-nom-etablissement">{{lieu.nom_etablissement|default:"nc."}}</div>
                             </div>
                             <div class="fr-grid-row fr-mb-2w">
                                 <div class="fr-col-offset-2"></div>

--- a/sv/tests/test_fichedetection_detail.py
+++ b/sv/tests/test_fichedetection_detail.py
@@ -5,7 +5,7 @@ from playwright.sync_api import expect
 
 def test_lieu_details(live_server, page, fiche_detection):
     "Test que les détails d'un lieu s'affichent correctement dans la modale"
-    lieu = baker.make(Lieu, fiche_detection=fiche_detection, _fill_optional=True)
+    lieu = baker.make(Lieu, fiche_detection=fiche_detection, _fill_optional=True, is_etablissement=True)
     page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
     page.get_by_role("button", name=f"Consulter le détail du lieu {lieu.nom}").click()
     expect(page.get_by_role("heading", name=lieu.nom)).to_be_visible()
@@ -29,6 +29,19 @@ def test_lieu_details(live_server, page, fiche_detection):
     )
     expect(page.get_by_test_id("lieu-1-wgs84-latitude")).to_contain_text(str(lieu.wgs84_latitude).replace(".", ","))
     expect(page.get_by_test_id("lieu-1-wgs84-longitude")).to_contain_text(str(lieu.wgs84_longitude).replace(".", ","))
+    expect(page.get_by_text("Il s'agit d'un établissement", exact=True)).to_be_visible()
+    expect(page.get_by_test_id("lieu-1-nom-etablissement")).to_contain_text(lieu.nom_etablissement)
+    expect(page.get_by_test_id("lieu-1-activite-etablissement")).to_contain_text(lieu.activite_etablissement)
+    expect(page.get_by_test_id("lieu-1-pays-etablissement")).to_contain_text(lieu.pays_etablissement)
+    expect(page.get_by_test_id("lieu-1-raison-sociale-etablissement")).to_contain_text(
+        lieu.raison_sociale_etablissement
+    )
+    expect(page.get_by_test_id("lieu-1-adresse-etablissement")).to_contain_text(lieu.adresse_etablissement)
+    expect(page.get_by_test_id("lieu-1-siret-etablissement")).to_contain_text(lieu.siret_etablissement)
+    expect(page.get_by_test_id("lieu-1-code-inpp-etablissement")).to_contain_text(lieu.code_inpp_etablissement)
+    expect(page.get_by_test_id("lieu-1-position-etablissement")).to_contain_text(
+        lieu.position_chaine_distribution_etablissement.libelle
+    )
 
 
 def test_lieu_details_second_lieu(live_server, page, fiche_detection):


### PR DESCRIPTION
Quand un lieu est un établissement le nom de l'établissement n'était jamais affiché dans la modale de visualisation du lieu sur la page détails de la fiche détection.
Ajout de test pour vérifier la modale dans le cas le plus complet.

Fixes #420 