### PR TITLE
Masque le bloc de suivi si la fiche détection est en visibilité brouillon

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -129,7 +129,7 @@ class AllowACNotificationMixin(models.Model):
 
 
 class WithMessageUrlsMixin:
-    def _add_message_url(self, message_type):
+    def get_add_message_url(self, message_type):
         content_type = ContentType.objects.get_for_model(self)
         return reverse(
             "message-add", kwargs={"message_type": message_type, "obj_type_pk": content_type.pk, "obj_pk": self.pk}
@@ -137,27 +137,27 @@ class WithMessageUrlsMixin:
 
     @property
     def add_message_url(self):
-        return self._add_message_url(Message.MESSAGE)
+        return self.get_add_message_url(Message.MESSAGE)
 
     @property
     def add_note_url(self):
-        return self._add_message_url(Message.NOTE)
+        return self.get_add_message_url(Message.NOTE)
 
     @property
     def add_point_de_suivi_url(self):
-        return self._add_message_url(Message.POINT_DE_SITUATION)
+        return self.get_add_message_url(Message.POINT_DE_SITUATION)
 
     @property
     def add_demande_intervention_url(self):
-        return self._add_message_url(Message.DEMANDE_INTERVENTION)
+        return self.get_add_message_url(Message.DEMANDE_INTERVENTION)
 
     @property
     def add_compte_rendu_url(self):
-        return self._add_message_url(Message.COMPTE_RENDU)
+        return self.get_add_message_url(Message.COMPTE_RENDU)
 
     @property
     def add_fin_suivi_url(self):
-        return self._add_message_url(Message.FIN_SUIVI)
+        return self.get_add_message_url(Message.FIN_SUIVI)
 
 
 class AllowVisibiliteMixin(models.Model):
@@ -236,11 +236,11 @@ class PreventActionIfVisibiliteBrouillonMixin:
     Mixin pour empêcher des actions sur des objets ayant la visibilité 'brouillon'.
     """
 
-    def get_object(self):
-        raise NotImplementedError("Vous devez implémenter la méthode `get_object` pour ce mixin.")
+    def get_fiche_object(self):
+        raise NotImplementedError("Vous devez implémenter la méthode `get_fiche_object` pour ce mixin.")
 
     def dispatch(self, request, *args, **kwargs):
-        obj = self.get_object()
+        obj = self.get_fiche_object()
         if obj.visibilite == Visibilite.BROUILLON:
             messages.error(request, "Action impossible car la fiche est en brouillon")
             return safe_redirect(request.POST.get("next") or obj.get_absolute_url() or "/")

--- a/sv/templates/sv/fichedetection_detail.html
+++ b/sv/templates/sv/fichedetection_detail.html
@@ -229,8 +229,9 @@
         </div>
         {% include "sv/_fichedetection_synthese.html" %}
 
-
-        {% include "core/_fiche_bloc_commun.html" with fiche=fichedetection %}
+        {% if not fichedetection.is_draft %}
+            {% include "core/_fiche_bloc_commun.html" with fiche=fichedetection %}
+        {% endif %}
     </main>
 
 {% endblock %}

--- a/sv/tests/test_fichedetection_detail.py
+++ b/sv/tests/test_fichedetection_detail.py
@@ -1,5 +1,7 @@
 from django.urls import reverse
 
+import pytest
+
 from core.models import Visibilite
 from sv.models import Lieu, Prelevement, FicheZoneDelimitee, ZoneInfestee, FicheDetection
 from model_bakery import baker
@@ -205,3 +207,34 @@ def test_fiche_detection_brouillon_cannot_add_zone(live_server, page, mocked_aut
     # simule le fait d'effectuer la requete GET directement pour ajouter une zone
     page.goto(f"{live_server.url}{reverse('rattachement-fiche-zone-delimitee', args=[fiche_detection.id])}")
     expect(page.get_by_text("Action impossible car la fiche est en brouillon")).to_be_visible()
+
+
+def test_fiche_detection_brouillon_does_not_have_bloc_suivi_display(live_server, page, mocked_authentification_user):
+    fiche_detection = baker.make(
+        FicheDetection, visibilite=Visibilite.BROUILLON, createur=mocked_authentification_user.agent.structure
+    )
+    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
+    expect(page.get_by_label("Fil de suivi")).not_to_be_visible()
+    expect(page.get_by_label("Contacts")).not_to_be_visible()
+    expect(page.get_by_label("Documents")).not_to_be_visible()
+
+
+@pytest.mark.parametrize(
+    "visibilite",
+    [
+        Visibilite.LOCAL,
+        Visibilite.NATIONAL,
+    ],
+)
+def test_fiche_detection_local_or_national_have_bloc_suivi_display(
+    live_server, page, visibilite: Visibilite, mocked_authentification_user
+):
+    fiche_detection = baker.make(
+        FicheDetection, visibilite=visibilite, createur=mocked_authentification_user.agent.structure
+    )
+    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
+    expect(page.get_by_label("Fil de suivi")).to_be_visible()
+    expect(page.get_by_label("Contacts")).to_have_count(1)
+    expect(page.get_by_label("Contacts")).to_be_hidden()
+    expect(page.get_by_label("Documents")).to_have_count(1)
+    expect(page.get_by_label("Documents")).to_be_hidden()

--- a/sv/tests/test_fichedetection_performances.py
+++ b/sv/tests/test_fichedetection_performances.py
@@ -2,100 +2,92 @@ import pytest
 from model_bakery import baker
 
 from core.models import Message, Document, Structure, Contact
-from sv.models import FicheDetection, Lieu, Prelevement
+from sv.models import Lieu, Prelevement
 
 BASE_NUM_QUERIES = 14  # Please note a first call is made without assertion to warm up any possible cache
 
 
 @pytest.mark.django_db
-def test_empty_fiche_detection_performances(client, django_assert_num_queries, mocked_authentification_user):
-    fiche = baker.make(FicheDetection, createur=mocked_authentification_user.agent.structure)
-    client.get(fiche.get_absolute_url())
+def test_empty_fiche_detection_performances(client, django_assert_num_queries, fiche_detection):
+    client.get(fiche_detection.get_absolute_url())
 
     with django_assert_num_queries(BASE_NUM_QUERIES):
-        client.get(fiche.get_absolute_url())
+        client.get(fiche_detection.get_absolute_url())
 
 
 @pytest.mark.django_db
 def test_fiche_detection_performances_with_messages_from_same_user(
-    client, django_assert_num_queries, mocked_authentification_user
+    client, django_assert_num_queries, mocked_authentification_user, fiche_detection
 ):
-    fiche = baker.make(FicheDetection, createur=mocked_authentification_user.agent.structure)
-    client.get(fiche.get_absolute_url())
+    client.get(fiche_detection.get_absolute_url())
 
-    baker.make(Message, content_object=fiche, sender=mocked_authentification_user.agent.contact_set.get())
+    baker.make(Message, content_object=fiche_detection, sender=mocked_authentification_user.agent.contact_set.get())
     with django_assert_num_queries(BASE_NUM_QUERIES + 6):
-        client.get(fiche.get_absolute_url())
+        client.get(fiche_detection.get_absolute_url())
 
     baker.make(
         Message,
-        content_object=fiche,
+        content_object=fiche_detection,
         sender=mocked_authentification_user.agent.contact_set.get(),
         _quantity=3,
     )
 
     with django_assert_num_queries(BASE_NUM_QUERIES + 6):
-        response = client.get(fiche.get_absolute_url())
+        response = client.get(fiche_detection.get_absolute_url())
 
     assert len(response.context["message_list"]) == 4
 
 
 @pytest.mark.django_db
-def test_fiche_detection_performances_with_lieux(client, django_assert_num_queries, mocked_authentification_user):
-    fiche = baker.make(FicheDetection, createur=mocked_authentification_user.agent.structure)
-    client.get(fiche.get_absolute_url())
+def test_fiche_detection_performances_with_lieux(client, django_assert_num_queries, fiche_detection):
+    client.get(fiche_detection.get_absolute_url())
 
     with django_assert_num_queries(BASE_NUM_QUERIES):
-        client.get(fiche.get_absolute_url())
+        client.get(fiche_detection.get_absolute_url())
 
-    baker.make(Lieu, fiche_detection=fiche, _quantity=3, _fill_optional=True)
+    baker.make(Lieu, fiche_detection=fiche_detection, _quantity=3, _fill_optional=True)
     with django_assert_num_queries(BASE_NUM_QUERIES):
-        client.get(fiche.get_absolute_url())
+        client.get(fiche_detection.get_absolute_url())
 
 
 @pytest.mark.django_db
-def test_fiche_detection_performances_with_document(client, django_assert_num_queries, mocked_authentification_user):
-    fiche = baker.make(FicheDetection, createur=mocked_authentification_user.agent.structure)
-    client.get(fiche.get_absolute_url())
+def test_fiche_detection_performances_with_document(client, django_assert_num_queries, fiche_detection):
+    client.get(fiche_detection.get_absolute_url())
 
     with django_assert_num_queries(BASE_NUM_QUERIES):
-        client.get(fiche.get_absolute_url())
+        client.get(fiche_detection.get_absolute_url())
 
-    baker.make(Document, content_object=fiche, _quantity=3, _create_files=True)
+    baker.make(Document, content_object=fiche_detection, _quantity=3, _create_files=True)
     with django_assert_num_queries(BASE_NUM_QUERIES + 1):
-        client.get(fiche.get_absolute_url())
+        client.get(fiche_detection.get_absolute_url())
 
 
 @pytest.mark.django_db
-def test_fiche_detection_performances_with_prelevement(client, django_assert_num_queries, mocked_authentification_user):
-    fiche = baker.make(FicheDetection, createur=mocked_authentification_user.agent.structure)
-    client.get(fiche.get_absolute_url())
+def test_fiche_detection_performances_with_prelevement(client, django_assert_num_queries, fiche_detection):
+    client.get(fiche_detection.get_absolute_url())
 
     with django_assert_num_queries(BASE_NUM_QUERIES):
-        client.get(fiche.get_absolute_url())
+        client.get(fiche_detection.get_absolute_url())
 
     for _ in range(0, 3):
-        lieu = baker.make(Lieu, fiche_detection=fiche)
+        lieu = baker.make(Lieu, fiche_detection=fiche_detection)
         baker.make(Prelevement, lieu=lieu, _fill_optional=True)
 
     with django_assert_num_queries(BASE_NUM_QUERIES):
-        client.get(fiche.get_absolute_url())
+        client.get(fiche_detection.get_absolute_url())
 
 
 @pytest.mark.django_db
-def test_fiche_detection_performances_when_adding_structure(
-    client, django_assert_num_queries, mocked_authentification_user
-):
-    fiche = baker.make(FicheDetection, createur=mocked_authentification_user.agent.structure)
-    client.get(fiche.get_absolute_url())
+def test_fiche_detection_performances_when_adding_structure(client, django_assert_num_queries, fiche_detection):
+    client.get(fiche_detection.get_absolute_url())
 
     with django_assert_num_queries(BASE_NUM_QUERIES):
-        client.get(fiche.get_absolute_url())
+        client.get(fiche_detection.get_absolute_url())
 
     for _ in range(0, 10):
         structure = baker.make(Structure)
         contact = baker.make(Contact, structure=structure, agent=None)
-        fiche.contacts.add(contact)
+        fiche_detection.contacts.add(contact)
 
     with django_assert_num_queries(BASE_NUM_QUERIES + 1):
-        client.get(fiche.get_absolute_url())
+        client.get(fiche_detection.get_absolute_url())

--- a/sv/tests/test_fiches_contact_add.py
+++ b/sv/tests/test_fiches_contact_add.py
@@ -1,9 +1,12 @@
 import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.utils.http import urlencode
 from playwright.sync_api import expect
 from model_bakery import baker
 from django.urls import reverse
 
-from core.models import Contact, Structure, Agent
+from core.models import Contact, Structure, Agent, Visibilite
+from sv.models import FicheDetection
 
 
 @pytest.fixture
@@ -48,6 +51,18 @@ def test_add_contact_form(live_server, page, fiche_variable, mocked_authentifica
     expect(page.get_by_role("button", name="Rechercher")).to_be_visible()
 
 
+def test_cant_access_add_contact_form_if_fiche_brouillon(live_server, page, fiche_variable):
+    fiche = fiche_variable()
+    fiche.visibilite = Visibilite.BROUILLON
+    fiche.numero = None
+    fiche.save()
+    content_type = ContentType.objects.get_for_model(fiche)
+    page.goto(
+        f"{live_server.url}/{reverse('contact-add-form')}?fiche_id={fiche.id}&content_type_id={content_type.id}&next={fiche.get_absolute_url()}"
+    )
+    expect(page.get_by_text("Action impossible car la fiche est en brouillon")).to_be_visible()
+
+
 def test_add_contact_form_back_to_fiche(live_server, page, fiche_variable):
     """Test le lien de retour vers la fiche"""
     fiche = fiche_variable()
@@ -60,25 +75,29 @@ def test_add_contact_form_back_to_fiche(live_server, page, fiche_variable):
 
 
 @pytest.mark.django_db
-def test_structure_list(client):
+def test_structure_list(live_server, page):
     """Test que la liste des structures soit bien dans le contexte du formulaire d'ajout de contact"""
     Contact.objects.all().delete()
     Agent.objects.all().delete()
     Structure.objects.all().delete()
-    for _ in range(0, 3):
-        structure = baker.make(Structure)
+    for i in range(0, 3):
+        structure = baker.make(Structure, libelle=f"Structure {i+1}")
         agent = baker.make(Agent, structure=structure)
         user = agent.user
         user.is_active = True
         user.save()
         baker.make(Contact, email="foo@example.com", agent=agent)
+    assert Structure.objects.count() == 3
 
-    url = reverse("contact-add-form")
-    response = client.get(url)
-    form = response.context["form"]
-    form_structures = form.fields["structure"].queryset
-    assert form_structures.count() == 3
-    assert all(structure in form_structures for structure in Structure.objects.all())
+    fiche = FicheDetection.objects.create(visibilite=Visibilite.LOCAL, createur=Structure.objects.first())
+    url = f"{reverse('contact-add-form')}?{urlencode({'fiche_id': fiche.pk, 'content_type_id': ContentType.objects.get_for_model(fiche).id, 'next': fiche.get_absolute_url()})}"
+    page.goto(f"{live_server.url}{url}")
+
+    page.query_selector(".choices").click()
+    page.wait_for_selector("input:focus", state="visible", timeout=2_000)
+    page.locator("*:focus").fill("Structure")
+    for i in range(0, 3):
+        expect(page.get_by_role("option", name=f"Structure {i+1}", exact=True)).to_be_visible()
 
 
 def test_add_contact_form_select_structure(live_server, page, fiche_variable, contacts, choice_js_fill):
@@ -95,6 +114,30 @@ def test_add_contact_form_select_structure(live_server, page, fiche_variable, co
     expect(page.get_by_text(f"{contact1.agent.nom}")).to_contain_text(f"{contact1.agent.nom} {contact1.agent.prenom}")
     expect(page.get_by_text(f"{contact2.agent.nom}")).to_be_visible()
     expect(page.get_by_text(f"{contact2.agent.nom}")).to_contain_text(f"{contact2.agent.nom} {contact2.agent.prenom}")
+
+
+def test_cant_add_contact_form_select_structure_if_fiche_brouillon(client, fiche_variable):
+    """Test que si une fiche est en visibilité brouillon, on ne peut pas afficher des contacts dans le formulaire de sélection suite à la selection d'une structure"""
+    fiche = fiche_variable()
+    fiche.visibilite = Visibilite.BROUILLON
+    fiche.numero = None
+    fiche.save()
+
+    response = client.post(
+        reverse("contact-add-form"),
+        data={
+            "fiche_id": fiche.id,
+            "structure": fiche.createur,
+            "next": fiche.get_absolute_url(),
+            "content_type_id": ContentType.objects.get_for_model(fiche).id,
+        },
+        follow=True,
+    )
+
+    messages = list(response.context["messages"])
+    assert len(messages) == 1
+    assert messages[0].level_tag == "error"
+    assert str(messages[0]) == "Action impossible car la fiche est en brouillon"
 
 
 def test_add_contact_to_a_fiche(live_server, page, fiche_variable, contacts, choice_js_fill):
@@ -190,3 +233,51 @@ def test_add_contact_form_back_to_fiche_after_error_message(live_server, page, f
     page.get_by_role("link", name="Retour à la fiche").click()
 
     expect(page).to_have_url(f"{live_server.url}{fiche.get_absolute_url()}")
+
+
+def test_cant_add_contact_if_fiche_brouillon(client, fiche_variable, contact):
+    fiche = fiche_variable()
+    fiche.visibilite = Visibilite.BROUILLON
+    fiche.numero = None
+    fiche.save()
+
+    response = client.post(
+        reverse("contact-add-form-select-agents"),
+        data={
+            "structure": contact.agent.structure.id,
+            "contacts": [contact.id],
+            "content_type_id": ContentType.objects.get_for_model(fiche).id,
+            "fiche_id": fiche.id,
+            "next": fiche.get_absolute_url(),
+        },
+        follow=True,
+    )
+
+    messages = list(response.context["messages"])
+    assert len(messages) == 1
+    assert messages[0].level_tag == "error"
+    assert str(messages[0]) == "Action impossible car la fiche est en brouillon"
+
+
+def test_cant_delete_contact_if_fiche_brouillon(client, fiche_variable, contact):
+    fiche = fiche_variable()
+    fiche.visibilite = Visibilite.BROUILLON
+    fiche.numero = None
+    fiche.save()
+    fiche.contacts.set([contact])
+
+    response = client.post(
+        reverse("contact-delete"),
+        data={
+            "content_type_pk": ContentType.objects.get_for_model(fiche).id,
+            "fiche_pk": fiche.id,
+            "pk": contact.id,
+            "next": fiche.get_absolute_url(),
+        },
+        follow=True,
+    )
+
+    messages = list(response.context["messages"])
+    assert len(messages) == 1
+    assert messages[0].level_tag == "error"
+    assert str(messages[0]) == "Action impossible car la fiche est en brouillon"

--- a/sv/views.py
+++ b/sv/views.py
@@ -733,7 +733,7 @@ class FicheZoneDelimiteeVisibiliteUpdateView(SuccessMessageMixin, UpdateView):
 class RattachementDetectionView(PreventActionIfVisibiliteBrouillonMixin, FormView):
     form_class = RattachementDetectionForm
 
-    def get_object(self):
+    def get_fiche_object(self):
         self.fiche_detection = FicheDetection.objects.get(pk=self.kwargs.get("pk"))
         return self.fiche_detection
 


### PR DESCRIPTION
Cette PR permet de masquer le bloc de suivi si la fiche détection est en visibilité brouillon.
Liée à https://github.com/betagouv/seves/issues/408

## Côté front
- modification du template detail de la fiche détection pour masquer le bloc de suivi et les modales utilisées dans celui-ci.
- ajout de tests bloc de suivi masqué si brouillon et affiché si local ou national

## Côté serveur
- Application du mixin `PreventActionIfVisibiliteBrouillonMixin` dans les vues du bloc de suivi
- ajout de tests pour vérifier que les requêtes HTTP sur les différentes routes du bloc de suivi soient refusées si la fiche est en brouillon

## Modification du mixin `PreventActionIfVisibiliteBrouillonMixin`
Renommage de la méthode `get_object` en `get_fiche_object` dans `PreventActionIfVisibiliteBrouillonMixin`.

Le renommage était nécessaire car avec `get_object`, il y avait un conflit avec la méthode du même nom dans DetailView. 
Quand une vue héritait à la fois de DetailView et du mixin :
- DetailView utilisait la méthode `get_object` du mixin qui retournait la fiche au lieu du message
- Cela causait une redirection non désirée vers l'URL de la fiche

Le renommage en `get_fiche_object` permet de séparer :
- la récupération de la fiche pour vérifier sa visibilité (mixin)
- la récupération de l'objet à afficher (DetailView)

## Autres:
- modification du nom et de l'accessibilité de la méthode `_add_message_url` dans le mixin `WithMessageUrlsMixin` car besoin dans les tests `sv/tests/test_fiches_message.py`
- modification de `sv/tests/test_fichedetection_performances.py` pour que les test s'effectuent sur une fiche détection en visibilité `local` car `BASE_NUM_QUERIES` prend en compte l'affichage du bloc de suivi (14 requêtes contre 10 sans).
- modification du test `test_structure_list` pour que la vérification se fasse directement dans le formulaire HTML et non dans le contexte du formulaire.
