### PR TITLE
Afficher que boutons enregistrer brouillon et publier sur formulaire de modification fiche détection

### DIFF
--- a/sv/static/sv/fichedetection_form.js
+++ b/sv/static/sv/fichedetection_form.js
@@ -90,7 +90,6 @@ document.addEventListener('alpine:init', () => {
 
 		// Données du formulaire de la fiche détection (champs fiche détection et listes des lieux et prélèvements)
         ficheDetection: {
-            numero: '',
             statutEvenementId: '',
             numeroRasff: '',
             numeroEurophyt: '',
@@ -192,7 +191,6 @@ document.addEventListener('alpine:init', () => {
             });
 
             this.ficheDetection = {
-                numero: this.getValueById('numeroFiche'),
                 numeroEurophyt: this.getValueById('numeroEurophyt'),
                 numeroRasff: this.getValueById('numeroRasff'),
                 statutEvenementId: this.getValueById('statut-evenement-id'),
@@ -319,11 +317,6 @@ document.addEventListener('alpine:init', () => {
         getValueById(id) {
             const element = document.getElementById(id);
             return element ? element.value : null;
-        },
-
-        getNumeroIfExist() {
-            const numero = document.getElementById('fiche-detection-numero');
-            return numero ? numero.textContent : '';
         },
 
 		/**

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -20,7 +20,6 @@
 
 {% block content %}
     <main x-data="app">
-        <input type="hidden" id="numeroFiche" value="{{ form.instance.numero }}">
         <input type="hidden" id="numeroEurophyt" value="{{ form.instance.numero_europhyt }}">
         <input type="hidden" id="numeroRasff" value="{{ form.instance.numero_rasff }}">
         <input type="hidden" id="statut-evenement-id" value="{{ form.instance.statut_evenement_id|default:'' }}">
@@ -48,7 +47,7 @@
                         {% if is_creation %}
                             Création d'une fiche détection
                         {% else %}
-                            Modification de la fiche détection n°<span x-text="ficheDetection.numero" x-model="ficheDetection.numero"></span>
+                            Modification de la fiche détection {% if form.instance.numero %}n°{{ form.instance.numero }}{% endif %}
                         {% endif %}
                     </h1>
                     {% if not is_creation %}

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -58,7 +58,7 @@
                 </div>
 
                 <p>
-                    {% if is_creation %}
+                    {% if form.instance.is_draft %}
                         <input type="submit" name="action" value="Enregistrer le brouillon" data-action="brouillon" class="fr-btn fr-btn--secondary fr-mr-2w">
                         <input type="submit" name="action" value="Publier" data-action="publier" class="fr-btn">
                     {% else %}

--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -1097,3 +1097,22 @@ def test_fiche_can_add_and_delete_free_links(
 
     assert lien_libre.related_object_1 == fiche_detection
     assert lien_libre.related_object_2 == other_fiche_2
+
+
+def test_can_publish_fiche_detection_in_visibilite_brouillon_from_update_form(
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    mocked_authentification_user,
+):
+    fiche_detection = FicheDetection.objects.create(
+        visibilite=Visibilite.BROUILLON,
+        etat=Etat.objects.get(id=Etat.get_etat_initial()),
+        createur=mocked_authentification_user.agent.structure,
+    )
+    page.goto(f"{live_server.url}{get_fiche_detection_update_form_url(fiche_detection)}")
+    form_elements.publish_btn.click()
+    page.wait_for_timeout(600)
+
+    fiche_detection.refresh_from_db()
+    assert fiche_detection.visibilite == Visibilite.LOCAL

--- a/sv/views.py
+++ b/sv/views.py
@@ -508,6 +508,8 @@ class FicheDetectionUpdateView(FicheDetectionContextMixin, UpdateView):
         if self.request.user.agent.structure.is_ac:
             fiche_detection.numero_europhyt = data.get("numeroEurophyt")
             fiche_detection.numero_rasff = data.get("numeroRasff")
+        if data.get("action") == "publier":
+            fiche_detection.visibilite = Visibilite.LOCAL
 
         try:
             fiche_detection.full_clean()


### PR DESCRIPTION
Cette PR permet d'afficher le boutons `enregistrer brouillon` et `publier` sur le formulaire de modification d'une fiche détection si la fiche est en visibilité `brouillon`.
cf. commit ee523ccbfb8d070f9133b2f2187ed8aca3db69a5

J'ai aussi supprimé l'affichage du numéro de fiche sur le formulaire de modification d'une fiche détection en visibilité brouillon car actuellement None est affiché (car pas de numéro de fiche en brouillon). 
cf. commit 2b6b7e229b38cc44973a9bc9cb084480ba4b0149

Liée à https://github.com/betagouv/seves/issues/408