### PR TITLE
Ajout du bouton publier sur la page de détail d'une fiche détection.

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -320,10 +320,16 @@ class VisibiliteUpdateBaseForm(DSFRForm):
 
     def __init__(self, *args, **kwargs):
         obj = kwargs.pop("obj", None)
+        action = kwargs.pop("action", None)
         super().__init__(*args, **kwargs)
         fiche_detection = obj or self.instance
 
         local = (Visibilite.LOCAL, Visibilite.LOCAL.capitalize())
         national = (Visibilite.NATIONAL, Visibilite.NATIONAL.capitalize())
-        self.fields["visibilite"].choices = [local] if fiche_detection.is_draft else [local, national]
-        self.fields["visibilite"].initial = fiche_detection.visibilite
+        if action == "publier":
+            self.fields["visibilite"].choices = [local]
+            self.fields["visibilite"].initial = Visibilite.LOCAL
+            self.fields["visibilite"].widget = forms.HiddenInput()
+        else:
+            self.fields["visibilite"].choices = [local] if fiche_detection.is_draft else [local, national]
+            self.fields["visibilite"].initial = fiche_detection.visibilite

--- a/sv/templates/sv/fichedetection_detail.html
+++ b/sv/templates/sv/fichedetection_detail.html
@@ -48,6 +48,15 @@
                 <button class="fr-btn fr-btn--secondary fr-mr-2w">
                     <a href="{% url 'fiche-detection-modification' fichedetection.pk %}"><span class="fr-icon-edit-fill">Modifier</span></a>
                 </button>
+                {% if fichedetection.is_draft %}
+                    <div>
+                        <form method="post" action="{{ fichedetection.get_visibilite_update_url }}">
+                            {% csrf_token %}
+                            {{ publier_form.as_dsfr_div }}
+                            <button type="submit" name="action" value="publier" class="fr-btn fr-btn--secondary fr-mr-2w">Publier</button>
+                        </form>
+                    </div>
+                {% endif %}
                 {% include "sv/_detection_action_navigation.html" %}
                 {% include "sv/_delete_fiche_modal.html" %}
                 {% include "sv/_cloturer_modal.html" with fiche=fichedetection %}

--- a/sv/tests/test_fichedetection_performances.py
+++ b/sv/tests/test_fichedetection_performances.py
@@ -4,7 +4,7 @@ from model_bakery import baker
 from core.models import Message, Document, Structure, Contact
 from sv.models import FicheDetection, Lieu, Prelevement
 
-BASE_NUM_QUERIES = 13  # Please note a first call is made without assertion to warm up any possible cache
+BASE_NUM_QUERIES = 14  # Please note a first call is made without assertion to warm up any possible cache
 
 
 @pytest.mark.django_db

--- a/sv/tests/test_fichedetection_visibilite_access.py
+++ b/sv/tests/test_fichedetection_visibilite_access.py
@@ -1,0 +1,100 @@
+import pytest
+from model_bakery import baker
+from playwright.sync_api import Page, expect
+from django.urls import reverse
+
+from sv.models import FicheDetection
+from core.models import Structure, Visibilite
+from core.constants import BSV_STRUCTURE, MUS_STRUCTURE, AC_STRUCTURE
+
+"""
+Les tests vérifient :
+- l'accès à une fiche de détection en fonction de sa visibilité et de l'agent connecté
+- l'accès à la liste de fiches détection en fonction de la visibilité des fiches et de l'agent connecté
+"""
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("visibilite_libelle", [Visibilite.BROUILLON, Visibilite.LOCAL, Visibilite.NATIONAL])
+def test_agent_in_structure_createur_can_view_fiche_detection(
+    live_server, page: Page, mocked_authentification_user, visibilite_libelle: str
+):
+    """Test qu'un agent appartennant à la structure créatrice d'une fiche de détection peut voir la fiche quelque soit sa visibilité"""
+    fiche_detection = baker.make(
+        FicheDetection, visibilite=visibilite_libelle, createur=mocked_authentification_user.agent.structure
+    )
+    response = page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
+    assert response.status == 200
+    page.goto(f"{live_server.url}{reverse('fiche-liste')}")
+    expect(page.get_by_role("link", name=str(fiche_detection.createur))).to_be_visible()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("visibilite_libelle", [Visibilite.BROUILLON, Visibilite.LOCAL])
+def test_agent_not_in_structure_createur_cannot_view_fiche_detection_brouillon_or_local(
+    live_server, page: Page, mocked_authentification_user, visibilite_libelle: str
+):
+    """Test qu'un agent n'appartenant pas à la structure créatrice d'une fiche détection ne peut pas voir la fiche
+    si elle est en visibilité brouillon ou local"""
+    fiche_detection = baker.make(FicheDetection, visibilite=visibilite_libelle)
+    mocked_authentification_user.agent.structure = baker.make(Structure)
+    mocked_authentification_user.agent.save()
+    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
+    expect(page.get_by_text("403 Forbidden")).to_be_visible()
+    page.goto(f"{live_server.url}{reverse('fiche-liste')}")
+    expect(page.get_by_role("link", name=str(fiche_detection.numero))).not_to_be_visible()
+
+
+@pytest.mark.django_db
+def test_agent_not_in_structure_createur_can_view_fiche_detection_nationale(
+    live_server, page: Page, fiche_detection: FicheDetection, mocked_authentification_user
+):
+    """Test qu'un agent n'appartenant pas à la structure créatrice d'une fiche détection peut voir la fiche
+    si elle est en visibilité national"""
+    fiche_detection.visibilite = Visibilite.NATIONAL
+    fiche_detection.save()
+    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
+    expect(page.get_by_role("heading", name=f"Fiche détection n° {str(fiche_detection.numero)}")).to_be_visible()
+    page.goto(f"{live_server.url}{reverse('fiche-liste')}")
+    expect(page.get_by_role("link", name=str(fiche_detection.numero))).to_be_visible()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("structure_ac", [MUS_STRUCTURE, BSV_STRUCTURE])
+def test_agent_ac_cannot_view_fiche_detection_brouillon(
+    live_server, page: Page, mocked_authentification_user, structure_ac: str
+):
+    """Test qu'un agent appartenant à l'AC ne peut pas voir une fiche détection en visibilité brouillon"""
+    fiche_detection = baker.make(FicheDetection, visibilite=Visibilite.BROUILLON)
+    mocked_authentification_user.agent.structure, _ = Structure.objects.get_or_create(
+        niveau1=AC_STRUCTURE, niveau2=structure_ac
+    )
+    mocked_authentification_user.agent.save()
+    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
+    expect(page.get_by_text("403 Forbidden")).to_be_visible()
+    page.goto(f"{live_server.url}{reverse('fiche-liste')}")
+    expect(page.get_by_role("link", name=str(fiche_detection.numero))).not_to_be_visible()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("visibilite_libelle", [Visibilite.LOCAL, Visibilite.NATIONAL])
+@pytest.mark.parametrize("structure_ac", [MUS_STRUCTURE, BSV_STRUCTURE])
+def test_agent_ac_can_view_fiche_detection(
+    live_server,
+    page: Page,
+    fiche_detection: FicheDetection,
+    mocked_authentification_user,
+    visibilite_libelle: str,
+    structure_ac: str,
+):
+    """Test qu'un agent appartenant à l'AC peut voir une fiche détection en visibilité local ou national"""
+    fiche_detection.visibilite = visibilite_libelle
+    fiche_detection.save()
+    mocked_authentification_user.agent.structure, _ = Structure.objects.get_or_create(
+        niveau1=AC_STRUCTURE, niveau2=structure_ac
+    )
+    mocked_authentification_user.agent.save()
+    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
+    expect(page.get_by_role("heading", name=f"Fiche détection n° {str(fiche_detection.numero)}")).to_be_visible()
+    page.goto(f"{live_server.url}{reverse('fiche-liste')}")
+    expect(page.get_by_role("link", name=str(fiche_detection.numero))).to_be_visible()


### PR DESCRIPTION
Cette PR ajoute un bouton `Publier` sur la page de détail d'une fiche détection permettant de passer la visibilité de la fiche de `brouillon` à `local`.

J'ai modifié le form `VisibiliteUpdateBaseForm` pour prendre en compte le fait que la visibilité peut aussi être modifié via le bouton Publier.
Cela à pour conséquence l'augmentation du nombre de requête (+1) car un autre form est injecté dans le context (`publier_form`).
À noter que le changement de visibilité pour une fiche brouillon via la modale va disparaitre dans PR #483.
Donc à terme (dans la PR #483), il n'y aura qu'un form d'injecté dans le context pour le changement de visibilité (`publier_form`) :  https://github.com/betagouv/seves/blob/c80d5307e42ff2bbc0e1f44caa93b1edfd328b1c/sv/views.py#L138-L141

J'ai ajouté un mixin `CanUpdateVisibiliteRequiredMixin` pour vérifier que l'utilisateur connecté a le droit de modifier la visibilité de la fiche.
Cela ajoute un contrôle côté serveur en plus du masquage de l'action côté front déjà effectué.
J'en ai profité pour séparer les tests de la visibilité pour la fiche détection en deux fichiers (comme c'est fait pour les tests de visibilité de la fiche zone delimitée) : 
- `test_fichedetection_visibilite_access` pour le contrôle d'accès et 
- `test_fichedetection_visibilite_update` pour la mise à jour

Pour la fiche zone délimitée, j'ajouterai cette vérification (`CanUpdateVisibiliteRequiredMixin`) dans la view `FicheZoneDelimiteeVisibiliteUpdateView` dans une autre PR.

Liée à https://github.com/betagouv/seves/issues/408