### PR TITLE
Dans la liste des fiches (détection et zone), affiche non attribué si pas de numéro de fiche

### DIFF
--- a/sv/display.py
+++ b/sv/display.py
@@ -19,7 +19,7 @@ class DisplayedFiche:
     def from_fiche_zone(cls, fiche: FicheZoneDelimitee):
         return cls(
             type="Zone",
-            numero=str(fiche.numero),
+            numero=str(fiche.numero) if fiche.numero else "non attribué",
             organisme_nuisible=fiche.organisme_nuisible,
             is_ac_notified=False,
             date_creation=fiche.date_creation.strftime("%d/%m/%Y"),
@@ -34,7 +34,7 @@ class DisplayedFiche:
     def from_fiche_detection(cls, fiche: FicheDetection):
         return cls(
             type="Détection",
-            numero=str(fiche.numero),
+            numero=str(fiche.numero) if fiche.numero else "non attribué",
             organisme_nuisible=fiche.organisme_nuisible,
             is_ac_notified=fiche.is_ac_notified,
             date_creation=fiche.date_creation.strftime("%d/%m/%Y"),

--- a/sv/tests/test_fiches_search.py
+++ b/sv/tests/test_fiches_search.py
@@ -115,7 +115,12 @@ def test_search_with_region(live_server, page: Page, mocked_authentification_use
     Effectuer une recherche en sélectionnant uniquement une région.
     Vérifier que tous les résultats retournés sont bien associés à cette région."""
     region1, region2 = baker.make(Region, _quantity=2)
-    fiche1 = baker.make(FicheDetection, etat=baker.make(Etat), createur=mocked_authentification_user.agent.structure)
+    fiche1 = baker.make(
+        FicheDetection,
+        etat=baker.make(Etat),
+        createur=mocked_authentification_user.agent.structure,
+        visibilite=Visibilite.LOCAL,
+    )
     baker.make(
         Lieu,
         departement=baker.make(Departement, region=region1),


### PR DESCRIPTION
Cette PR permet d'afficher `non attribué` si pas de numéro de fiche dans la liste des fiches.

Liée à https://github.com/betagouv/seves/issues/408