### PR TITLE
Restriction des actions lors de la consultation d'une fiche détection brouillon

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -223,3 +223,20 @@ class CanUpdateVisibiliteRequiredMixin:
             messages.error(request, "Vous n'avez pas les droits pour modifier la visibilité de cette fiche.")
             return safe_redirect(self.object.get_absolute_url())
         return super().dispatch(request, *args, **kwargs)
+
+
+class PreventActionIfVisibiliteBrouillonMixin:
+    """
+    Mixin pour empêcher des actions sur des objets ayant la visibilité 'brouillon'.
+    """
+
+    def get_object(self):
+        raise NotImplementedError("Vous devez implémenter la méthode `get_object` pour ce mixin.")
+
+    def dispatch(self, request, *args, **kwargs):
+        obj = self.get_object()
+        if obj.visibilite == Visibilite.BROUILLON:
+            messages.error(request, "Action impossible car la fiche est en brouillon")
+            return safe_redirect(request.POST.get("next") or obj.get_absolute_url() or "/")
+
+        return super().dispatch(request, *args, **kwargs)

--- a/sv/templates/sv/_detection_action_navigation.html
+++ b/sv/templates/sv/_detection_action_navigation.html
@@ -4,30 +4,32 @@
                 aria-expanded="false" title="Sélectionner une action">Actions</button>
         <div class="fr-collapse fr-translate__menu fr-menu" id="action-1">
             <ul class="fr-menu__list">
-                <li>
-                    {% if fichedetection.can_notifiy %}
-                        <form action="{% url 'notify-ac' %}" method="post">
-                            <button class="fr-translate__language fr-nav__link" href="#" type="submit"><span class="fr-icon-notification-3-fill fr-mr-2v fr-icon--sm" aria-hidden="true">
-                                {% csrf_token %}
-                                <input type="hidden" value="{{ fichedetection.get_absolute_url }}" name="next">
-                                <input type="hidden" value="{{ content_type.id }}" name="content_type_id">
-                                <input type="hidden" value="{{ fichedetection.pk }}" name="content_id">
-                            </span>Déclarer à l'AC</button>
-                        </form>
-                    {% else %}
-                        <button class="fr-translate__language fr-nav__link" href="#" type="submit" disabled><span class="fr-icon-notification-3-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Déclarer à l'AC</button>
+                {% if not fichedetection.is_draft %}
+                    <li>
+                        {% if fichedetection.can_notifiy %}
+                            <form action="{% url 'notify-ac' %}" method="post">
+                                <button class="fr-translate__language fr-nav__link" href="#" type="submit"><span class="fr-icon-notification-3-fill fr-mr-2v fr-icon--sm" aria-hidden="true">
+                                    {% csrf_token %}
+                                    <input type="hidden" value="{{ fichedetection.get_absolute_url }}" name="next">
+                                    <input type="hidden" value="{{ content_type.id }}" name="content_type_id">
+                                    <input type="hidden" value="{{ fichedetection.pk }}" name="content_id">
+                                </span>Déclarer à l'AC</button>
+                            </form>
+                        {% else %}
+                            <button class="fr-translate__language fr-nav__link" href="#" type="submit" disabled><span class="fr-icon-notification-3-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Déclarer à l'AC</button>
+                        {% endif %}
+                    </li>
+                    <li>
+                        <button class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-create-fiche-zone-delimitee" {% if fichedetection.is_linked_to_fiche_zone_delimitee %}disabled{% endif %}>
+                            <span class="fr-icon-git-pull-request-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Ajouter une zone
+                        </button>
+                    </li>
+                    {% if user.agent.structure.is_ac and not fichedetection.etat.is_cloture %}
+                        <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-cloturer-fiche"><span class="fr-icon-close-circle-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Clôturer la fiche</a></li>
                     {% endif %}
-                </li>
-                <li>
-                    <button class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-create-fiche-zone-delimitee" {% if fichedetection.is_linked_to_fiche_zone_delimitee %}disabled{% endif %}>
-                        <span class="fr-icon-git-pull-request-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Ajouter une zone
-                    </button>
-                </li>
-                {% if user.agent.structure.is_ac and not fichedetection.etat.is_cloture %}
-                    <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-cloturer-fiche"><span class="fr-icon-close-circle-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Clôturer la fiche</a></li>
-                {% endif %}
-                {% if can_update_visibilite %}
-                    <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-edit-visibilite"><span class="fr-icon-eye-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Modifier la visibilité</a></li>
+                    {% if can_update_visibilite %}
+                        <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-edit-visibilite"><span class="fr-icon-eye-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Modifier la visibilité</a></li>
+                    {% endif %}
                 {% endif %}
                 <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-delete"><span class="fr-icon-close-circle-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Supprimer la fiche</a></li>
             </ul>

--- a/sv/templates/sv/fichedetection_detail.html
+++ b/sv/templates/sv/fichedetection_detail.html
@@ -58,13 +58,16 @@
                     </div>
                 {% endif %}
                 {% include "sv/_detection_action_navigation.html" %}
-                {% include "sv/_delete_fiche_modal.html" %}
-                {% include "sv/_cloturer_modal.html" with fiche=fichedetection %}
-                {% if can_update_visibilite %}
-                    {% include "sv/_update_visibilite_modal.html" with fiche=fichedetection %}
+                {% if not fichedetection.is_draft %}
+                    {% include "sv/_delete_fiche_modal.html" %}
+                    {% include "sv/_cloturer_modal.html" with fiche=fichedetection %}
+                    {% if can_update_visibilite %}
+                        {% include "sv/_update_visibilite_modal.html" with fiche=fichedetection %}
+                    {% endif %}
+                    {% include "sv/_create_fichezonedelimitee_modal.html" %}
                 {% endif %}
-                {% include "sv/_create_fichezonedelimitee_modal.html" %}
             </div>
+
         </div>
 
         <div class="fiche-detail">

--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -1018,10 +1018,7 @@ def test_fiche_detection_numero_fiche_is_not_null_when_visibilite_change_from_br
     )
 
     page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
-    page.get_by_role("button", name="Actions").click()
-    page.get_by_role("link", name="Modifier la visibilité").click()
-    page.get_by_text("Local").click()
-    page.get_by_role("button", name="Valider").click()
+    page.get_by_role("button", name="Publier").click()
     page.wait_for_timeout(600)
     fiche_detection.refresh_from_db()
 

--- a/sv/tests/test_fichedetection_visibilite_update.py
+++ b/sv/tests/test_fichedetection_visibilite_update.py
@@ -54,11 +54,7 @@ def test_agent_in_structure_createur_can_update_fiche_detection_visibilite_broui
         FicheDetection, visibilite=Visibilite.BROUILLON, createur=mocked_authentification_user.agent.structure
     )
     page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
-    page.get_by_role("button", name="Actions").click()
-    expect(page.get_by_role("link", name="Modifier la visibilité")).to_be_visible()
-    page.get_by_role("link", name="Modifier la visibilité").click()
-    page.get_by_text("Local").click()
-    page.get_by_role("button", name="Valider").click()
+    page.get_by_role("button", name="Publier").click()
     expect(page.get_by_role("heading", name="La visibilité de la fiche détection a bien été modifiée")).to_be_visible()
     expect(page.get_by_text(Visibilite.LOCAL)).to_be_visible()
     fiche_detection.refresh_from_db()
@@ -138,3 +134,14 @@ def test_publier_fiche_detection_from_btn(live_server, page: Page, mocked_authen
     expect(page.get_by_text(Visibilite.LOCAL)).to_be_visible()
     fiche_detection.refresh_from_db()
     assert fiche_detection.visibilite == Visibilite.LOCAL
+
+
+def test_fiche_detection_brouillon_cannot_change_visibility_through_actions_btn(
+    live_server, page, mocked_authentification_user, client
+):
+    fiche_detection = FicheDetection.objects.create(
+        visibilite=Visibilite.BROUILLON, createur=mocked_authentification_user.agent.structure
+    )
+
+    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
+    expect(page.get_by_role("button", name="Modifier la visibilité")).not_to_be_visible()

--- a/sv/views.py
+++ b/sv/views.py
@@ -29,6 +29,7 @@ from core.mixins import (
     WithContactListInContextMixin,
     WithFreeLinksListInContextMixin,
     CanUpdateVisibiliteRequiredMixin,
+    PreventActionIfVisibiliteBrouillonMixin,
 )
 from core.redirect import safe_redirect
 from sv.forms import (
@@ -729,14 +730,17 @@ class FicheZoneDelimiteeVisibiliteUpdateView(SuccessMessageMixin, UpdateView):
         return super().form_invalid(form)
 
 
-class RattachementDetectionView(FormView):
+class RattachementDetectionView(PreventActionIfVisibiliteBrouillonMixin, FormView):
     form_class = RattachementDetectionForm
 
+    def get_object(self):
+        self.fiche_detection = FicheDetection.objects.get(pk=self.kwargs.get("pk"))
+        return self.fiche_detection
+
     def form_valid(self, form):
-        fiche_detection_id = self.kwargs.get("pk")
         rattachement = form.cleaned_data["rattachement"]
         return safe_redirect(
-            f"{reverse('fiche-zone-delimitee-creation')}?fiche_detection_id={fiche_detection_id}&rattachement={rattachement}"
+            f"{reverse('fiche-zone-delimitee-creation')}?fiche_detection_id={self.fiche_detection.id}&rattachement={rattachement}"
         )
 
 


### PR DESCRIPTION
Cette PR permet de restreindre le nombre d'actions possibles lors de la consultation d'une fiche détection en brouillon.
Aussi, elle supprime l'accès à la modal de changement de visibilité.

## Restriction Actions
Lors de la consultation d'une fiche détection en brouillon, la seule action accessible est supprimer. 
La restriction effectuée côté frond, dans le template `sv/templates/sv/_detection_action_navigation.html`.
Pour le contrôle côté serveur, j'ai ajouté le mixin `PreventActionIfVisibiliteBrouillonMixin `.
Il a été appliqué aux view correspondantes aux actions : déclarer à l'AC et ajouter une zone.

## Changement de visibillité
L'accès à la modale étant supprimé, l'ajout d'un bouton publier a été fait dans la PR #481.