### PR TITLE
Liens libres : empêche l'ajout de fiche brouillon

### DIFF
--- a/sv/forms.py
+++ b/sv/forms.py
@@ -93,10 +93,20 @@ class FicheZoneDelimiteeForm(DSFRForm, forms.ModelForm):
         if self.instance.pk:
             self.fields.pop("visibilite")
 
-        qs_detection = FicheDetection.objects.all().order_by_numero_fiche().get_fiches_user_can_view(self.user)
-        qs_detection = qs_detection.select_related("numero")
-        qs_zone = FicheZoneDelimitee.objects.all().order_by_numero_fiche().get_fiches_user_can_view(self.user)
-        qs_zone = qs_zone.select_related("numero")
+        qs_detection = (
+            FicheDetection.objects.all()
+            .order_by_numero_fiche()
+            .get_fiches_user_can_view(self.user)
+            .select_related("numero")
+            .exclude_brouillon()
+        )
+        qs_zone = (
+            FicheZoneDelimitee.objects.all()
+            .order_by_numero_fiche()
+            .get_fiches_user_can_view(self.user)
+            .select_related("numero")
+            .exclude_brouillon()
+        )
         if self.instance:
             qs_zone = qs_zone.exclude(id=self.instance.id)
         self.fields["free_link"] = MultiModelChoiceField(

--- a/sv/managers.py
+++ b/sv/managers.py
@@ -39,6 +39,9 @@ class BaseVisibilityQuerySet(models.QuerySet):
             )
         )
 
+    def exclude_brouillon(self):
+        return self.exclude(visibilite=Visibilite.BROUILLON)
+
 
 class FicheDetectionQuerySet(BaseVisibilityQuerySet):
     def get_contacts_structures_not_in_fin_suivi(self, fiche_detection):
@@ -82,9 +85,6 @@ class FicheDetectionQuerySet(BaseVisibilityQuerySet):
 
     def with_fiche_zone_delimitee_numero(self):
         return self.select_related("hors_zone_infestee__numero", "zone_infestee__fiche_zone_delimitee__numero")
-
-    def exclude_brouillon(self):
-        return self.exclude(visibilite=Visibilite.BROUILLON)
 
 
 class FicheZoneManager(models.Manager):

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -448,6 +448,8 @@ def test_fiche_detection_with_free_link(
     choice_js_fill,
 ):
     fiche_zone = fiche_zone_bakery()
+    fiche_zone.visibilite = Visibilite.LOCAL
+    fiche_zone.save()
     page.goto(f"{live_server.url}{reverse('fiche-detection-creation')}")
     fiche_input = "Fiche zone délimitée : " + str(fiche_zone.numero)
     choice_js_fill(page, "#liens-libre .choices", str(fiche_zone.numero), fiche_input)

--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -1116,3 +1116,23 @@ def test_can_publish_fiche_detection_in_visibilite_brouillon_from_update_form(
 
     fiche_detection.refresh_from_db()
     assert fiche_detection.visibilite == Visibilite.LOCAL
+
+
+@pytest.mark.django_db
+def test_cant_see_fiches_brouillon_in_liens_libres_in_update_form(
+    live_server,
+    page,
+    form_elements: FicheDetectionFormDomElements,
+    mocked_authentification_user,
+    fiche_detection,
+    fiche_zone,
+):
+    FicheDetection.objects.create(
+        visibilite=Visibilite.BROUILLON, createur=mocked_authentification_user.agent.structure
+    )
+    fiche_zone.visibilite = Visibilite.BROUILLON
+    fiche_zone.save()
+    page.goto(f"{live_server.url}{get_fiche_detection_update_form_url(fiche_detection)}")
+    select_options = page.locator("#liens-libre .choices__list--dropdown .choices__item")
+    expect(select_options).to_have_count(1)
+    expect(select_options).to_have_text("Aucune fiche à sélectionner")

--- a/sv/tests/test_fichezonedelimitee_create.py
+++ b/sv/tests/test_fichezonedelimitee_create.py
@@ -419,3 +419,17 @@ def test_free_links_are_ordered_in_form(
     expect(page.locator("#liens-libre .choices .choices__item--selectable:nth-of-type(2)")).to_contain_text(
         "Fiche Détection : 2024.1"
     )
+
+
+@pytest.mark.django_db
+def test_cant_see_fiches_brouillon_in_liens_libres(
+    live_server, page: Page, choice_js_fill, fiche_detection: FicheDetection, fiche_zone
+):
+    FicheDetection.objects.create(visibilite=Visibilite.BROUILLON, createur=fiche_detection.createur)
+    fiche_zone.visibilite = Visibilite.BROUILLON
+    fiche_zone.save()
+    form_page = FicheZoneDelimiteeFormPage(page, choice_js_fill)
+    form_page.goto_create_form_page(live_server, fiche_detection.pk, RattachementChoices.HORS_ZONE_INFESTEE)
+    select_options = page.locator("#liens-libre .choices__list--dropdown .choices__item")
+    expect(select_options).to_have_count(1)
+    expect(select_options).to_have_text(f"Fiche Détection : {str(fiche_detection.numero)}")


### PR DESCRIPTION
Cette PR permet de ne pas pouvoir ajouter des fiches brouillon dans les liens libres

- ajout du filtre pour le formulaire de création et de modification pour les fiches détection et fiches zones délimitées
- ajout des tests pour vérifier que le champ Liens libres ne contient pas de fiche brouillon