### PR TITLE
Fiche zone délimitée: empêche l'ajout d'une fiche détection brouillon en zone infestée ou hors zone infestée

### DIFF
--- a/sv/forms.py
+++ b/sv/forms.py
@@ -112,6 +112,7 @@ class FicheZoneDelimiteeForm(DSFRForm, forms.ModelForm):
             .get_all_not_in_fiche_zone_delimitee(
                 organisme_nuisible_libelle, self.instance if self.instance.pk else None
             )
+            .exclude_brouillon()
             .order_by_numero_fiche()
         )
 
@@ -224,6 +225,7 @@ class ZoneInfesteeForm(DSFRForm, forms.ModelForm):
         self.fields["detections"].queryset = (
             FicheDetection.objects.all()
             .get_all_not_in_fiche_zone_delimitee(organisme_nuisible_libelle, fiche_zone_delimitee)
+            .exclude_brouillon()
             .order_by_numero_fiche()
         )
 

--- a/sv/managers.py
+++ b/sv/managers.py
@@ -83,6 +83,9 @@ class FicheDetectionQuerySet(BaseVisibilityQuerySet):
     def with_fiche_zone_delimitee_numero(self):
         return self.select_related("hors_zone_infestee__numero", "zone_infestee__fiche_zone_delimitee__numero")
 
+    def exclude_brouillon(self):
+        return self.exclude(visibilite=Visibilite.BROUILLON)
+
 
 class FicheZoneManager(models.Manager):
     def get_queryset(self):

--- a/sv/tests/test_fichezonedelimitee_update.py
+++ b/sv/tests/test_fichezonedelimitee_update.py
@@ -81,6 +81,7 @@ def test_update_zone_infestee(live_server, page: Page, fiche_zone_bakery, choice
         FicheDetection,
         organisme_nuisible=fiche_zone_delimitee.organisme_nuisible,
         statut_reglementaire=fiche_zone_delimitee.statut_reglementaire,
+        visibilite=Visibilite.LOCAL,
     )
     form_page = FicheZoneDelimiteeFormPage(page, choice_js_fill)
     page.goto(f"{live_server.url}{fiche_zone_delimitee.get_update_url()}")
@@ -105,6 +106,7 @@ def test_add_zone_infestee(live_server, page: Page, fiche_zone_bakery, choice_js
         FicheDetection,
         organisme_nuisible=fiche_zone_delimitee.organisme_nuisible,
         statut_reglementaire=fiche_zone_delimitee.statut_reglementaire,
+        visibilite=Visibilite.LOCAL,
     )
     form_page = FicheZoneDelimiteeFormPage(page, choice_js_fill)
     page.goto(f"{live_server.url}{fiche_zone_delimitee.get_update_url()}")


### PR DESCRIPTION
Cette PR empêche l'ajout d'une fiche détection brouillon en zone infestée ou hors zone infestée dans le formulaire de création et modification d'une fiche zone délimitée.
- ajout d'une méthode dans le manager permettant d'exclure les fiches détection ayant la visibilité brouillon
- modification du queryset pour le champ détections dans hors zone infestée et zone infestée
- ajout de tests pour zone infestée et hors zone infestée
- modification de la visibilité à local dans certains tests car ne passés plus