### PR TITLE
Uniformiser et expliciter les valeurs vides des selects

### DIFF
--- a/seves/context_processors.py
+++ b/seves/context_processors.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+def select_empty_choice(request):
+    return {"select_empty_choice": settings.SELECT_EMPTY_CHOICE}

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -84,6 +84,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "seves.context_processors.select_empty_choice",
             ],
         },
     },
@@ -224,3 +225,5 @@ if env("EMAIL_HOST", default=None):
 
 
 ROOT_URL = env("ROOT_URL", default=None)
+
+SELECT_EMPTY_CHOICE = "Choisir dans la liste"

--- a/sv/templates/sv/_fichedetection_form__lieux_form.html
+++ b/sv/templates/sv/_fichedetection_form__lieux_form.html
@@ -31,7 +31,7 @@
                             <p>
                                 <label class="fr-label" for="site-inspection">Site d'inspection</label>
                                 <select x-model="lieuForm.siteInspectionId" class="fr-select" data-testid="lieu-form-type-etablissement" id="site-inspection">
-                                    <option value="">----</option>
+                                    <option value="">{{ select_empty_choice }}</option>
                                     {% for site_inspection in sites_inspections %}
                                         <option value="{{ site_inspection.id }}">{{ site_inspection.nom }}</option>
                                     {% endfor %}
@@ -96,7 +96,7 @@
                                 <p>
                                     <label class="fr-label" for="position-etablissement">Position</label>
                                     <select x-model="lieuForm.positionEtablissementId" class="fr-select" data-testid="lieu-form-position-etablissement" id="position-etablissement">
-                                        <option value="">----</option>
+                                        <option value="">{{ select_empty_choice }}</option>
                                         {% for position_etablissement in positions_chaine_distribution %}
                                             <option value="{{ position_etablissement.id }}">{{ position_etablissement.libelle }}</option>
                                         {% endfor %}

--- a/sv/templates/sv/_fichedetection_form__prelevements_form.html
+++ b/sv/templates/sv/_fichedetection_form__prelevements_form.html
@@ -22,7 +22,7 @@
                             <div id="structure" class="fr-select-group prelevement-form--fieldset">
                                 <label class="fr-label">Structure</label>
                                 <select x-model="formPrelevement.structurePreleveurId" class="fr-select" required data-testid="prelevement-form-structure">
-                                    <option value="">----</option>
+                                    <option value="">{{ select_empty_choice }}</option>
                                     {% for structure in structures_preleveurs %}
                                         <option value="{{ structure.id }}">{{ structure.nom }}</option>
                                     {% endfor %}
@@ -39,7 +39,7 @@
                             <p id="matrice-prelevee" class="prelevement-form--fieldset">
                                 <label class="fr-label">Matrice prélevée</label>
                                 <select x-model="formPrelevement.matricePreleveeId" class="fr-select" data-testid="prelevement-form-matrice-prelevee">
-                                    <option value="">----</option>
+                                    <option value="">{{ select_empty_choice }}</option>
                                     {% for matrice in matrices_prelevees %}
                                         <option value="{{ matrice.id }}">{{ matrice.libelle }}</option>
                                     {% endfor %}
@@ -90,7 +90,7 @@
                                 <p id="laboratoire-agree" class="prelevement-form--fieldset">
                                     <label class="fr-label">Laboratoire agréé</label>
                                     <select x-model="formPrelevement.laboratoireAgreeId" class="fr-select" data-testid="prelevement-form-laboratoire-agree">
-                                        <option value="">----</option>
+                                        <option value="">{{ select_empty_choice }}</option>
                                         {% for laboratoire_agree in laboratoires_agrees %}
                                             <option value="{{ laboratoire_agree.id }}">{{ laboratoire_agree.nom }}</option>
                                         {% endfor %}
@@ -99,7 +99,7 @@
                                 <p id="laboratoire-confirmation" class="prelevement-form--fieldset">
                                     <label class="fr-label">Laboratoire de confirmation</label>
                                     <select x-model="formPrelevement.laboratoireConfirmationOfficielleId" class="fr-select" data-testid="prelevement-form-laboratoire-confirmation">
-                                        <option value="">----</option>
+                                        <option value="">{{ select_empty_choice }}</option>
                                         {% for laboratoire_confirmation_officielle in laboratoires_confirmation_officielle %}
                                             <option value="{{ laboratoire_confirmation_officielle.id }}">{{ laboratoire_confirmation_officielle.nom }}</option>
                                         {% endfor %}

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -86,7 +86,7 @@
                         <div id="statut-evenement">
                             <label class="fr-label" for="statut-evenement-input">Statut évènement</label>
                             <select x-model="ficheDetection.statutEvenementId" id="statut-evenement-input" class="fr-select">
-                                <option value="">----</option>
+                                <option value="">{{ select_empty_choice }}</option>
                                 {% for statut_evenement in statuts_evenement %}
                                     <option value="{{ statut_evenement.id }}">{{ statut_evenement.libelle }}</option>
                                 {% endfor %}
@@ -108,7 +108,7 @@
                     <p id="organisme-nuisible">
                         <label class="fr-label" for="organisme-nuisible-input">Organisme nuisible</label>
                         <select x-model="ficheDetection.organismeNuisibleId" id="organisme-nuisible-input">
-                            <option value="">----</option>
+                            <option value="">{{ select_empty_choice }}</option>
                             {% for organisme_nuisible in organismes_nuisibles %}
                                 <option value="{{ organisme_nuisible.id }}">{{ organisme_nuisible.libelle_court }}</option>
                             {% endfor %}
@@ -117,7 +117,7 @@
                     <p id="statut-reglementaire">
                         <label class="fr-label" for="statut-reglementaire-input">Statut règlementaire</label>
                         <select x-model="ficheDetection.statutReglementaireId" id="statut-reglementaire-input" class="fr-select">
-                            <option value="">----</option>
+                            <option value="">{{ select_empty_choice }}</option>
                             {% for statut_reglementaire in statuts_reglementaires %}
                                 <option value="{{ statut_reglementaire.id }}">{{ statut_reglementaire.libelle }}</option>
                             {% endfor %}
@@ -126,7 +126,7 @@
                     <p id="contexte">
                         <label class="fr-label" for="contexte-input">Contexte</label>
                         <select x-model="ficheDetection.contexteId" id="contexte-input" class="fr-select">
-                            <option value="">----</option>
+                            <option value="">{{ select_empty_choice }}</option>
                             {% for contexte in contextes %}
                                 <option value="{{ contexte.id }}">{{ contexte.nom }}</option>
                             {% endfor %}
@@ -201,7 +201,7 @@
                     <div>
                         <label class="fr-label" for="free-links">Lien vers une fiche</label>
                         <select id="free-links" multiple="">
-                            <option value="">----</option>
+                            <option value="">{{ select_empty_choice }}</option>
                             {% for object_type_id, label, queryset in possible_links %}
                                 {% for object in queryset %}
                                     <option value="{{ object_type_id }}-{{ object.id }}">{{ label }} : {{ object }}</option>

--- a/sv/tests/conftest.py
+++ b/sv/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 
@@ -31,7 +32,7 @@ def check_select_options(page, label, expected_options):
     options = page.locator(f"label:has-text('{label}') ~ select option").element_handles()
     option_texts = [option.inner_text() for option in options]
     assert (
-        option_texts == ["----"] + expected_options
+        option_texts == [settings.SELECT_EMPTY_CHOICE] + expected_options
     ), f"Les options pour {label} ne correspondent pas aux options attendues"
 
 

--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -1,4 +1,5 @@
 import pytest
+from django.conf import settings
 from model_bakery import baker
 from playwright.sync_api import Page, expect
 from django.urls import reverse
@@ -128,13 +129,13 @@ def test_fiche_detection_update_page_content_with_no_data(
 
     page.goto(f"{live_server.url}{get_fiche_detection_update_form_url(fiche_detection)}")
 
-    expect(form_elements.statut_evenement_input).to_contain_text("----")
+    expect(form_elements.statut_evenement_input).to_contain_text(settings.SELECT_EMPTY_CHOICE)
     expect(form_elements.statut_evenement_input).to_have_value("")
-    expect(form_elements.organisme_nuisible_input).to_contain_text("----")
+    expect(form_elements.organisme_nuisible_input).to_contain_text(settings.SELECT_EMPTY_CHOICE)
     expect(form_elements.organisme_nuisible_input).to_have_value("")
-    expect(form_elements.statut_reglementaire_input).to_contain_text("----")
+    expect(form_elements.statut_reglementaire_input).to_contain_text(settings.SELECT_EMPTY_CHOICE)
     expect(form_elements.statut_reglementaire_input).to_have_value("")
-    expect(form_elements.contexte_input).to_contain_text("----")
+    expect(form_elements.contexte_input).to_contain_text(settings.SELECT_EMPTY_CHOICE)
     expect(form_elements.contexte_input).to_have_value("")
     expect(form_elements.date_1er_signalement_input).to_have_value("")
     expect(form_elements.commentaire_input).to_have_value("")


### PR DESCRIPTION
iAjout d'un context processor et d'un setting Django pour s'assurer que toutes les listes déroulantes (select) ont la même valeur vide de proposée à l'utilisateur.

Fixes #456 