### PR TITLE
Empêcher les soumissions multiples du formulaire de la fiche détection

### DIFF
--- a/sv/static/sv/fichedetection_form.js
+++ b/sv/static/sv/fichedetection_form.js
@@ -571,6 +571,10 @@ document.addEventListener('alpine:init', () => {
             const boutonClique = event.submitter;
             const action = boutonClique.dataset.action;
 
+            document.querySelectorAll('input[name="action"]').forEach(button => {
+                button.disabled = true;
+            });
+
             let formData = new FormData();
             const organismeNuisibleId = this.ficheDetection.organismeNuisibleId.value ? this.ficheDetection.organismeNuisibleId.value : this.ficheDetection.organismeNuisibleId
             formData.append('statutEvenementId', this.ficheDetection.statutEvenementId);

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -514,3 +514,19 @@ def test_free_links_are_ordered_in_fiche_detection_form(
     expect(page.locator("#liens-libre .choices .choices__item--selectable:nth-of-type(2)")).to_contain_text(
         "Fiche zone délimitée : 2024.1"
     )
+
+
+@pytest.mark.django_db
+def test_one_fiche_detection_is_created_when_double_click_on_save_btn(live_server, page: Page):
+    page.goto(f"{live_server.url}{reverse('fiche-detection-creation')}")
+    page.get_by_role("button", name="Enregistrer").dblclick()
+    page.wait_for_timeout(600)
+    assert FicheDetection.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_one_fiche_detection_is_created_when_double_click_on_publish_btn(live_server, page: Page):
+    page.goto(f"{live_server.url}{reverse('fiche-detection-creation')}")
+    page.get_by_role("button", name="Publier").dblclick()
+    page.wait_for_timeout(600)
+    assert FicheDetection.objects.count() == 1


### PR DESCRIPTION
Cette PR empêche les soumissions multiples du formulaire de la fiche détection.

Lors de clics rapides ou répétés sur le bouton "Enregistre le brouillon" ou "Publier", plusieurs requêtes sont envoyées au serveur avant que la première ne soit terminée. Cela se produit parce que chaque clic déclenche une nouvelle exécution de la fonction JavaScript permettant de sauvegarder la fiche détection en base, sans mécanisme natif pour limiter ces appels simultanés.

Pour résoudre ce problème, les boutons "Enregistre le brouillon" et "Publier" sont désactivés après le premier clic. Cela garantit qu'une seule requête est envoyée par soumission, tout en réactivant le bouton en cas de validation échouée ou d'erreur de requête.