### PR TITLE
Suppression du champ lambert93 dans le formulaire

### DIFF
--- a/sv/static/sv/fichedetection_form.js
+++ b/sv/static/sv/fichedetection_form.js
@@ -107,9 +107,9 @@ document.addEventListener('alpine:init', () => {
         },
 
         lieux: [
-			//{ id: '0c5bed5c-9f3f-4e0d-83b8-e52e89b9eb09', nomLieu: 'Lieu 1', adresseLieuDit: 'Adresse 1', commune: 'Commune 1', codeINSEE: '12345', departementId: '1', coordGPSLambert93Latitude: '6000000', coordGPSLambert93Longitude: '200000', coordGPSWGS84Latitude: '0', coordGPSWGS84Longitude: '0' },
-			//{ id: 'e16e5305-76c0-4758-a0c7-e6674cff5086', nomLieu: 'Lieu 2', adresseLieuDit: 'Adresse 2', commune: 'Commune 2', codeINSEE: '54321', departementId: '2', coordGPSLambert93Latitude: '6000000', coordGPSLambert93Longitude: '200000', coordGPSWGS84Latitude: '0', coordGPSWGS84Longitude: '0' },
-			//{ id: 'b5492275-a960-477a-aeca-af50932ca21e', nomLieu: 'Lieu 3', adresseLieuDit: 'Adresse 3', commune: 'Commune 3', codeINSEE: '54321', departementId: '3', coordGPSLambert93Latitude: '6000000', coordGPSLambert93Longitude: '200000', coordGPSWGS84Latitude: '0', coordGPSWGS84Longitude: '0' },
+			//{ id: '0c5bed5c-9f3f-4e0d-83b8-e52e89b9eb09', nomLieu: 'Lieu 1', adresseLieuDit: 'Adresse 1', commune: 'Commune 1', codeINSEE: '12345', departementId: '1', coordGPSWGS84Latitude: '0', coordGPSWGS84Longitude: '0' },
+			//{ id: 'e16e5305-76c0-4758-a0c7-e6674cff5086', nomLieu: 'Lieu 2', adresseLieuDit: 'Adresse 2', commune: 'Commune 2', codeINSEE: '54321', departementId: '2', coordGPSWGS84Latitude: '0', coordGPSWGS84Longitude: '0' },
+			//{ id: 'b5492275-a960-477a-aeca-af50932ca21e', nomLieu: 'Lieu 3', adresseLieuDit: 'Adresse 3', commune: 'Commune 3', codeINSEE: '54321', departementId: '3', coordGPSWGS84Latitude: '0', coordGPSWGS84Longitude: '0' },
         ],
 
         prelevements: [
@@ -133,8 +133,6 @@ document.addEventListener('alpine:init', () => {
             codeINSEE: '',
             departementNom: '',
             region: '',
-            coordGPSLambert93Latitude: '',
-            coordGPSLambert93Longitude: '',
             coordGPSWGS84Latitude: '',
             coordGPSWGS84Longitude: '',
             isEtablissement: false,
@@ -373,8 +371,6 @@ document.addEventListener('alpine:init', () => {
                 codeINSEE: '',
                 departementNom: '',
                 region: '',
-                coordGPSLambert93Latitude: '',
-                coordGPSLambert93Longitude: '',
                 coordGPSWGS84Latitude: '',
                 coordGPSWGS84Longitude: '',
                 isEtablissement: false,

--- a/sv/templates/sv/_fichedetection_form__lieux_form.html
+++ b/sv/templates/sv/_fichedetection_form__lieux_form.html
@@ -37,12 +37,6 @@
                                     {% endfor %}
                                 </select>
                             </p>
-
-                            <p>
-                                <label class="fr-label" for="coordonnees-gps-lambert-93-latitude">Coordonnées GPS (Lambert 93)</label>
-                                <input x-model="lieuForm.coordGPSLambert93Latitude" style="flex: 0.55; margin-right: 0.5rem;" type="number" step="1" min="6000000" max="7200000" id="coordonnees-gps-lambert-93-latitude" class="fr-input" placeholder="Latitude">
-                                <input x-model="lieuForm.coordGPSLambert93Longitude" style="flex: 0.55; margin-top: .5rem;" type="number" step="1" min="200000" max="1200000" id="coordonnees-gps-lambert-93-longitude" class="fr-input" placeholder="Longitude">
-                            </p>
                             <p>
                                 <label class="fr-label" for="coordonnees-gps-wgs84-latitude">Coordonnées GPS (WGS84)</label>
                                 <input x-model="lieuForm.coordGPSWGS84Latitude" style="flex: 0.55; margin-right: 0.5rem;" type="number" step="0.000001" min="-90" max="90" id="coordonnees-gps-wgs84-latitude" class="fr-input" placeholder="Latitude">

--- a/sv/tests/test_fichedetection_form.py
+++ b/sv/tests/test_fichedetection_form.py
@@ -54,10 +54,6 @@ def _add_new_lieu(
     page.wait_for_timeout(100)
     choice_js_fill(page, ".fr-modal__content .choices__list--single", "Lille", "Lille (59)")
 
-    lieu_form_elements.coord_gps_lamber93_latitude_input.click()
-    lieu_form_elements.coord_gps_lamber93_latitude_input.fill(str(6_000_000 + extra_int))
-    lieu_form_elements.coord_gps_lamber93_longitude_input.click()
-    lieu_form_elements.coord_gps_lamber93_longitude_input.fill(str(200_000 + extra_int))
     lieu_form_elements.coord_gps_wgs84_latitude_input.click()
     lieu_form_elements.coord_gps_wgs84_latitude_input.fill(str(1 + extra_int))
     lieu_form_elements.coord_gps_wgs84_longitude_input.click()
@@ -70,8 +66,6 @@ def _check_add_lieu_form_fields_are_empty(page: Page, lieu_form_elements: LieuFo
     expect(lieu_form_elements.nom_input).to_be_empty()
     expect(lieu_form_elements.adresse_input).to_be_empty()
     expect(lieu_form_elements.commune_input).to_be_empty()
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_input).to_be_empty()
-    expect(lieu_form_elements.coord_gps_lamber93_longitude_input).to_be_empty()
     expect(lieu_form_elements.coord_gps_wgs84_latitude_input).to_be_empty()
     expect(lieu_form_elements.coord_gps_wgs84_longitude_input).to_be_empty()
 
@@ -137,13 +131,6 @@ def test_add_lieu_form_have_all_fields(
     expect(lieu_form_elements.commune_label).to_have_text("Commune")
     expect(lieu_form_elements.commune_input).to_be_empty()
 
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_label).to_be_visible()
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_label).to_have_text("Coordonnées GPS (Lambert 93)")
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_input).to_be_empty()
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_input).to_have_attribute("placeholder", "Latitude")
-    expect(lieu_form_elements.coord_gps_lamber93_longitude_input).to_be_empty()
-    expect(lieu_form_elements.coord_gps_lamber93_longitude_input).to_have_attribute("placeholder", "Longitude")
-
     expect(lieu_form_elements.coord_gps_wgs84_latitude_label).to_be_visible()
     expect(lieu_form_elements.coord_gps_wgs84_latitude_label).to_have_text("Coordonnées GPS (WGS84)")
     expect(lieu_form_elements.coord_gps_wgs84_latitude_input).to_be_empty()
@@ -169,30 +156,10 @@ def test_nom_lieu_is_required_in_add_lieu_form(
 def test_coordonnees_gps_are_numeric_in_add_lieu_form(
     live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
 ):
-    """Test que les champs de coordonnées GPS (Lambert 93 et WGS84) sont des champs numériques"""
+    """Test que les champs de coordonnées GPS (WGS84) sont des champs numériques"""
     form_elements.add_lieu_btn.click()
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_input).to_have_attribute("type", "number")
-    expect(lieu_form_elements.coord_gps_lamber93_longitude_input).to_have_attribute("type", "number")
     expect(lieu_form_elements.coord_gps_wgs84_latitude_input).to_have_attribute("type", "number")
     expect(lieu_form_elements.coord_gps_wgs84_longitude_input).to_have_attribute("type", "number")
-
-
-def test_latitude_min_max_value_of_lambert93_format_in_add_lieu_form(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
-):
-    """Test que la valeur minimal de la latitude du format lambert 93 est de 6000000 et la valeur max est de 7200000"""
-    form_elements.add_lieu_btn.click()
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_input).to_have_attribute("min", "6000000")
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_input).to_have_attribute("max", "7200000")
-
-
-def test_longitude_min_max_value_of_lambert93_format_in_add_lieu_form(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
-):
-    """Test que la valeur minimal de la longitude du format lambert 93 est de 200000 et la valeur max est de 1200000"""
-    form_elements.add_lieu_btn.click()
-    expect(lieu_form_elements.coord_gps_lamber93_longitude_input).to_have_attribute("min", "200000")
-    expect(lieu_form_elements.coord_gps_lamber93_longitude_input).to_have_attribute("max", "1200000")
 
 
 def test_add_lieu_to_list(
@@ -244,8 +211,6 @@ def test_lieu_is_added_to_alpinejs_data(
     assert lieux[0]["commune"] == "Lille"
     assert lieux[0]["codeINSEE"] == "59350"
     assert lieux[0]["departementNom"] == "Nord"
-    assert lieux[0]["coordGPSLambert93Latitude"] == "6000000"
-    assert lieux[0]["coordGPSLambert93Longitude"] == "200000"
     assert lieux[0]["coordGPSWGS84Latitude"] == "1"
     assert lieux[0]["coordGPSWGS84Longitude"] == "2"
 
@@ -293,8 +258,6 @@ def test_two_lieux_are_added_to_alpinejs_data(
     assert lieux[0]["commune"] == "Lille"
     assert lieux[0]["codeINSEE"] == "59350"
     assert lieux[0]["departementNom"] == "Nord"
-    assert lieux[0]["coordGPSLambert93Latitude"] == "6000000"
-    assert lieux[0]["coordGPSLambert93Longitude"] == "200000"
     assert lieux[0]["coordGPSWGS84Latitude"] == "1"
     assert lieux[0]["coordGPSWGS84Longitude"] == "2"
     assert lieux[1]["nomLieu"] == "nom lieu 2"
@@ -302,8 +265,6 @@ def test_two_lieux_are_added_to_alpinejs_data(
     assert lieux[1]["commune"] == "Lille"
     assert lieux[1]["codeINSEE"] == "59350"
     assert lieux[1]["departementNom"] == "Nord"
-    assert lieux[1]["coordGPSLambert93Latitude"] == "6000000"
-    assert lieux[1]["coordGPSLambert93Longitude"] == "200000"
     assert lieux[1]["coordGPSWGS84Latitude"] == "1"
     assert lieux[1]["coordGPSWGS84Longitude"] == "2"
 
@@ -362,8 +323,6 @@ def test_edit_lieu_form_with_only_nom_lieu(
     expect(lieu_form_elements.commune_input).to_be_empty()
     expect(lieu_form_elements.code_insee_hidden_input).to_be_empty()
     expect(lieu_form_elements.departement_hidden_input).to_be_empty()
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_input).to_be_empty()
-    expect(lieu_form_elements.coord_gps_lamber93_longitude_input).to_be_empty()
     expect(lieu_form_elements.coord_gps_wgs84_latitude_input).to_be_empty()
     expect(lieu_form_elements.coord_gps_wgs84_longitude_input).to_be_empty()
 
@@ -401,13 +360,6 @@ def test_edit_lieu_form_have_all_fields(
     expect(page.get_by_text("LilleRemove item")).to_be_visible()
     expect(lieu_form_elements.departement_hidden_input).to_have_value("Nord")
 
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_label).to_be_visible()
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_label).to_have_text("Coordonnées GPS (Lambert 93)")
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_input).to_be_visible()
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_input).to_have_value("6000000")
-    expect(lieu_form_elements.coord_gps_lamber93_longitude_input).to_be_visible()
-    expect(lieu_form_elements.coord_gps_lamber93_longitude_input).to_have_value("200000")
-
     expect(lieu_form_elements.coord_gps_wgs84_latitude_label).to_be_visible()
     expect(lieu_form_elements.coord_gps_wgs84_latitude_label).to_have_text("Coordonnées GPS (WGS84)")
     expect(lieu_form_elements.coord_gps_wgs84_latitude_input).to_be_visible()
@@ -436,8 +388,6 @@ def test_edit_lieu_form_have_all_fields_with_multiple_lieux(
     expect(lieu_form_elements.commune_hidden_input).to_have_value("Lille")
     expect(lieu_form_elements.code_insee_hidden_input).to_have_value("59350")
     expect(lieu_form_elements.departement_hidden_input).to_have_value("Nord")
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_input).to_have_value("6000000")
-    expect(lieu_form_elements.coord_gps_lamber93_longitude_input).to_have_value("200000")
     expect(lieu_form_elements.coord_gps_wgs84_latitude_input).to_have_value("1")
     expect(lieu_form_elements.coord_gps_wgs84_longitude_input).to_have_value("2")
     page.get_by_role("button", name="Fermer").click()
@@ -449,8 +399,6 @@ def test_edit_lieu_form_have_all_fields_with_multiple_lieux(
     expect(lieu_form_elements.commune_hidden_input).to_have_value("Lille")
     expect(lieu_form_elements.code_insee_hidden_input).to_have_value("59350")
     expect(lieu_form_elements.departement_hidden_input).to_have_value("Nord")
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_input).to_have_value("6000002")
-    expect(lieu_form_elements.coord_gps_lamber93_longitude_input).to_have_value("200002")
     expect(lieu_form_elements.coord_gps_wgs84_latitude_input).to_have_value("3")
     expect(lieu_form_elements.coord_gps_wgs84_longitude_input).to_have_value("4")
     page.get_by_role("button", name="Fermer").click()
@@ -473,8 +421,6 @@ def test_edit_lieu_is_updated_in_alpinejs_data(
     lieu_form_elements.nom_input.fill("nom lieu modifié")
     lieu_form_elements.adresse_input.fill("une adresse modifiée")
     choice_js_fill(page, ".fr-modal__content .choices__list--single", "Paris", "Paris (75)")
-    lieu_form_elements.coord_gps_lamber93_latitude_input.fill("6000001")
-    lieu_form_elements.coord_gps_lamber93_longitude_input.fill("200001")
     lieu_form_elements.coord_gps_wgs84_latitude_input.fill("11")
     lieu_form_elements.coord_gps_wgs84_longitude_input.fill("21")
     page.get_by_role("button", name="Enregistrer les modifications").click()
@@ -487,8 +433,6 @@ def test_edit_lieu_is_updated_in_alpinejs_data(
     assert lieux[0]["commune"] == "Paris"
     assert lieux[0]["codeINSEE"] == "75056"
     assert lieux[0]["departementNom"] == "Paris"
-    assert lieux[0]["coordGPSLambert93Latitude"] == "6000001"
-    assert lieux[0]["coordGPSLambert93Longitude"] == "200001"
     assert lieux[0]["coordGPSWGS84Latitude"] == "11"
     assert lieux[0]["coordGPSWGS84Longitude"] == "21"
 
@@ -509,8 +453,6 @@ def test_add_lieu_form_is_empty_after_edit(
     lieu_form_elements.nom_input.fill("nom lieu modifié")
     lieu_form_elements.adresse_input.fill("une adresse modifiée")
     choice_js_fill(page, ".fr-modal__content .choices__list--single", "Paris", "Paris (75)")
-    lieu_form_elements.coord_gps_lamber93_latitude_input.fill("6000001")
-    lieu_form_elements.coord_gps_lamber93_longitude_input.fill("200001")
     lieu_form_elements.coord_gps_wgs84_latitude_input.fill("11")
     lieu_form_elements.coord_gps_wgs84_longitude_input.fill("21")
     page.get_by_role("button", name="Enregistrer les modifications").click()
@@ -522,8 +464,6 @@ def test_add_lieu_form_is_empty_after_edit(
     expect(lieu_form_elements.commune_input).to_be_empty()
     expect(lieu_form_elements.code_insee_hidden_input).to_be_empty()
     expect(lieu_form_elements.departement_hidden_input).to_be_empty()
-    expect(lieu_form_elements.coord_gps_lamber93_latitude_input).to_be_empty()
-    expect(lieu_form_elements.coord_gps_lamber93_longitude_input).to_be_empty()
     expect(lieu_form_elements.coord_gps_wgs84_latitude_input).to_be_empty()
     expect(lieu_form_elements.coord_gps_wgs84_longitude_input).to_be_empty()
 

--- a/sv/tests/test_utils.py
+++ b/sv/tests/test_utils.py
@@ -250,18 +250,6 @@ class LieuFormDomElements:
         return self.page.locator("#departement")
 
     @property
-    def coord_gps_lamber93_latitude_label(self) -> Locator:
-        return self.page.get_by_text("Coordonnées GPS (Lambert 93)")
-
-    @property
-    def coord_gps_lamber93_latitude_input(self) -> Locator:
-        return self.page.get_by_label("Coordonnées GPS (Lambert 93)")
-
-    @property
-    def coord_gps_lamber93_longitude_input(self) -> Locator:
-        return self.page.locator("#coordonnees-gps-lambert-93-longitude")
-
-    @property
     def coord_gps_wgs84_latitude_label(self) -> Locator:
         return self.page.get_by_text("Coordonnées GPS (WGS84)")
 


### PR DESCRIPTION
Cette PR supprime le champ lambert93 dans le formulaire d'ajout/modification d'un Lieu (cf. fiche détection).
Oubli de la PR #503 