### PR TITLE
Réinitialiser l'organisme nuisible au clic sur effacer

### DIFF
--- a/sv/static/sv/fiche_list.js
+++ b/sv/static/sv/fiche_list.js
@@ -1,4 +1,11 @@
 document.addEventListener('DOMContentLoaded', function() {
+    const choices = new Choices(document.getElementById('id_organisme_nuisible'), {
+        classNames: {
+            containerInner: 'fr-select',
+        },
+        itemSelectText: ''
+    });
+
     document.getElementById('search-form').addEventListener('reset', function (e) {
         e.preventDefault();
         this.elements['numero'].value = '';
@@ -7,12 +14,8 @@ document.addEventListener('DOMContentLoaded', function() {
         this.elements['start_date'].value = '';
         this.elements['end_date'].value = '';
         this.elements['etat'].value = '';
+        choices.setChoiceByValue('');
     });
 
-    const choices = new Choices(document.getElementById('id_organisme_nuisible'), {
-        classNames: {
-            containerInner: 'fr-select',
-        },
-        itemSelectText: ''
-    });
+
 });

--- a/sv/tests/test_fiches_search.py
+++ b/sv/tests/test_fiches_search.py
@@ -50,7 +50,7 @@ def test_search_form_have_all_fields(live_server, page: Page) -> None:
 
 
 @pytest.mark.django_db
-def test_clear_button_clears_form(live_server, page: Page, choice_js_fill) -> None:
+def test_reset_button_clears_form(live_server, page: Page, choice_js_fill) -> None:
     """Test que le bouton Effacer efface les champs du formulaire de recherche."""
     baker.make(Region, _quantity=5)
     baker.make(OrganismeNuisible, _quantity=5)
@@ -72,6 +72,21 @@ def test_clear_button_clears_form(live_server, page: Page, choice_js_fill) -> No
     expect(page.get_by_label("Période du")).to_be_empty()
     expect(page.get_by_label("Au")).to_be_empty()
     expect(page.get_by_label("État")).to_contain_text(settings.SELECT_EMPTY_CHOICE)
+
+
+@pytest.mark.django_db
+def test_reset_button_clears_form_when_filters_in_url(live_server, page: Page, choice_js_fill) -> None:
+    """Test que le bouton Effacer efface les champs du formulaire de recherche."""
+    baker.make(Region, _quantity=2)
+    baker.make(OrganismeNuisible, _quantity=2)
+    baker.make(Etat, _quantity=2)
+    on = OrganismeNuisible.objects.first()
+
+    page.goto(f"{live_server.url}{get_fiche_detection_search_form_url()}?organisme_nuisible={on.pk}")
+    expect(page.get_by_label("Organisme")).to_contain_text(on.libelle_court)
+    page.get_by_role("button", name="Effacer").click()
+
+    expect(page.get_by_label("Organisme")).to_contain_text(settings.SELECT_EMPTY_CHOICE)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Quand une recherche est faite avec un organisme nuisible, s'assrurer que le bouton effacer efface bien le champ organismie nuisible.