### PR TITLE
Rediriger vers la bonne page après la connection

### DIFF
--- a/core/templates/core/login.html
+++ b/core/templates/core/login.html
@@ -44,8 +44,7 @@
                 <main>
                     <div>
                         <h1 class="fr-h1">Connexion</h1>
-
-                        <a href="{% url 'oidc_authentication_init' %}" class="fr-btn">Me connecter via le portail EAP</a>
+                        <a href="{% url 'oidc_authentication_init' %}{% if request.GET.next %}?next={{ request.GET.next|urlencode }}{% endif %}" class="fr-btn">Me connecter via le portail EAP</a>
                     </div>
                 </main>
 

--- a/seves/middlewares.py
+++ b/seves/middlewares.py
@@ -1,5 +1,4 @@
-from django.http import HttpResponseRedirect
-from django.conf import settings
+from django.contrib.auth.views import redirect_to_login
 from django.urls import resolve
 
 
@@ -19,9 +18,7 @@ class LoginRequiredMiddleware:
         if match and match.url_name in self.authorized_routes:
             return self.get_response(request)
 
-        if not request.user:
-            return HttpResponseRedirect(settings.LOGIN_URL)
-        if not request.user.is_authenticated:
-            return HttpResponseRedirect(settings.LOGIN_URL)
+        if not request.user or not request.user.is_authenticated:
+            return redirect_to_login(request.get_full_path())
 
         return self.get_response(request)


### PR DESCRIPTION
En cas de demande de connection suite à la consultation d'une URL précise (une fiche par exemple), redirigier automatiquement le navigateur sur la page de la requête initiale.

- Simplification du middleware pour utiliser une vue déjà présente dans Django et qui gère le paramètre next
- Ajout du paramètre dans le template
- Fonctionne sans autre paramètrage car Django OIDC respecte le champ next pour la redirection (https://mozilla-django-oidc.readthedocs.io/en/stable/settings.html#OIDC_REDIRECT_FIELD_NAME)