### PR TITLE
Suppression des doublons dans les résultats de filtrage par région des fiches détection

### DIFF
--- a/sv/filters.py
+++ b/sv/filters.py
@@ -21,7 +21,7 @@ class FicheFilter(django_filters.FilterSet):
         initial="Détection",
     )
     lieux__departement__region = django_filters.ModelChoiceFilter(
-        label="Région", queryset=Region.objects.all(), empty_label=settings.SELECT_EMPTY_CHOICE
+        label="Région", queryset=Region.objects.all(), empty_label=settings.SELECT_EMPTY_CHOICE, method="filter_region"
     )
     organisme_nuisible = django_filters.ModelChoiceFilter(
         label="Organisme", queryset=OrganismeNuisible.objects.all(), empty_label=settings.SELECT_EMPTY_CHOICE
@@ -71,3 +71,6 @@ class FicheFilter(django_filters.FilterSet):
             return queryset
         annee, numero = map(int, value.split("."))
         return queryset.filter(numero__annee=annee, numero__numero=numero)
+
+    def filter_region(self, queryset, name, value):
+        return queryset.filter(lieux__departement__region=value).distinct()


### PR DESCRIPTION
Cette PR corrige le bug suivant : 

> Si dans une fiche detection, j'ai 2 lieux situés dans la même region, quand j'effectue un filtre sur cette région, la fiche détection apparait deux fois dans les résultats.

Ticket Notion : https://www.notion.so/incubateur-masa/Suppression-des-doublons-dans-les-r-sultats-de-filtrage-par-r-gion-des-fiches-d-tection-153de24614be8043ad0dd10991737371?pvs=4