### PR TITLE
Correction affichage visibilité sur le formulaire de modification de la fiche zone délimitée

### DIFF
--- a/sv/models.py
+++ b/sv/models.py
@@ -515,6 +515,9 @@ class FicheDetection(
     def get_absolute_url(self):
         return reverse("fiche-detection-vue-detaillee", kwargs={"pk": self.pk})
 
+    def get_update_url(self):
+        return reverse("fiche-detection-modification", kwargs={"pk": self.pk})
+
     def get_visibilite_update_url(self):
         return reverse("fiche-detection-visibilite-update", kwargs={"pk": self.pk})
 

--- a/sv/templates/sv/fichezonedelimitee_form.html
+++ b/sv/templates/sv/fichezonedelimitee_form.html
@@ -23,7 +23,7 @@
                         Création d'une fiche zone délimitée
                     {% endif %}
                 </h1>
-                <p class="fr-badge fr-badge--no-icon fr-mb-4w">brouillon</p>
+                <p class="fr-badge fr-badge--no-icon fr-mb-4w">{{ fiche.visibilite }}</p>
             </div>
             <div class="fr-col fichezone_form__save-btn">
                 {% if fiche.id %}


### PR DESCRIPTION
Cette PR corrige le fait que la visibilité sur le formulaire de modification de la fiche zone délimitée était toujours affichée `brouillon`.
J'ai aussi ajouté `get_update_url` et refactoré les tests en conséquence.
Issue Notion : https://www.notion.so/incubateur-masa/Visibilit-de-la-fiche-zone-toujours-brouillon-d-affich-e-154de24614be8030acebd4b6e9b459c9?pvs=4