### PR TITLE
Masque le bloc de suivi si la fiche zone délimitée est en visibilité brouillon

### DIFF
--- a/sv/templates/sv/fichezonedelimitee_detail.html
+++ b/sv/templates/sv/fichezonedelimitee_detail.html
@@ -164,6 +164,8 @@
         </div>
 
         {% include "sv/_list_free_links.html" with classes="fr-mt-8v" %}
-        {% include "core/_fiche_bloc_commun.html" %}
+        {% if not fiche.is_draft %}
+            {% include "core/_fiche_bloc_commun.html" %}
+        {% endif %}
     </div>
 {% endblock %}

--- a/sv/tests/test_fichedetection_detail.py
+++ b/sv/tests/test_fichedetection_detail.py
@@ -1,7 +1,4 @@
 from django.urls import reverse
-
-import pytest
-
 from core.models import Visibilite
 from sv.models import Lieu, Prelevement, FicheZoneDelimitee, ZoneInfestee, FicheDetection
 from model_bakery import baker
@@ -191,34 +188,3 @@ def test_fiche_detection_brouillon_cannot_add_zone(live_server, page, mocked_aut
     # simule le fait d'effectuer la requete GET directement pour ajouter une zone
     page.goto(f"{live_server.url}{reverse('rattachement-fiche-zone-delimitee', args=[fiche_detection.id])}")
     expect(page.get_by_text("Action impossible car la fiche est en brouillon")).to_be_visible()
-
-
-def test_fiche_detection_brouillon_does_not_have_bloc_suivi_display(live_server, page, mocked_authentification_user):
-    fiche_detection = baker.make(
-        FicheDetection, visibilite=Visibilite.BROUILLON, createur=mocked_authentification_user.agent.structure
-    )
-    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
-    expect(page.get_by_label("Fil de suivi")).not_to_be_visible()
-    expect(page.get_by_label("Contacts")).not_to_be_visible()
-    expect(page.get_by_label("Documents")).not_to_be_visible()
-
-
-@pytest.mark.parametrize(
-    "visibilite",
-    [
-        Visibilite.LOCAL,
-        Visibilite.NATIONAL,
-    ],
-)
-def test_fiche_detection_local_or_national_have_bloc_suivi_display(
-    live_server, page, visibilite: Visibilite, mocked_authentification_user
-):
-    fiche_detection = baker.make(
-        FicheDetection, visibilite=visibilite, createur=mocked_authentification_user.agent.structure
-    )
-    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
-    expect(page.get_by_label("Fil de suivi")).to_be_visible()
-    expect(page.get_by_label("Contacts")).to_have_count(1)
-    expect(page.get_by_label("Contacts")).to_be_hidden()
-    expect(page.get_by_label("Documents")).to_have_count(1)
-    expect(page.get_by_label("Documents")).to_be_hidden()

--- a/sv/tests/test_fiches_bloc_suivi.py
+++ b/sv/tests/test_fiches_bloc_suivi.py
@@ -1,0 +1,46 @@
+import pytest
+from model_bakery import baker
+from playwright.sync_api import expect
+
+from core.models import Visibilite
+from sv.models import FicheDetection, FicheZoneDelimitee
+
+
+@pytest.mark.parametrize(
+    "model_class",
+    [
+        FicheDetection,
+        FicheZoneDelimitee,
+    ],
+)
+def test_fiche_brouillon_does_not_have_bloc_suivi_display(live_server, page, mocked_authentification_user, model_class):
+    fiche_detection = baker.make(
+        model_class, visibilite=Visibilite.BROUILLON, createur=mocked_authentification_user.agent.structure
+    )
+    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
+    expect(page.get_by_label("Fil de suivi")).not_to_be_visible()
+    expect(page.get_by_label("Contacts")).not_to_be_visible()
+    expect(page.get_by_label("Documents")).not_to_be_visible()
+
+
+@pytest.mark.parametrize(
+    "model_class,visibilite",
+    [
+        (FicheDetection, Visibilite.LOCAL),
+        (FicheDetection, Visibilite.NATIONAL),
+        (FicheZoneDelimitee, Visibilite.LOCAL),
+        (FicheZoneDelimitee, Visibilite.NATIONAL),
+    ],
+)
+def test_fiche_local_or_national_have_bloc_suivi_display(
+    live_server, page, model_class, visibilite: Visibilite, mocked_authentification_user
+):
+    fiche_detection = baker.make(
+        model_class, visibilite=visibilite, createur=mocked_authentification_user.agent.structure
+    )
+    page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
+    expect(page.get_by_label("Fil de suivi")).to_be_visible()
+    expect(page.get_by_label("Contacts")).to_have_count(1)
+    expect(page.get_by_label("Contacts")).to_be_hidden()
+    expect(page.get_by_label("Documents")).to_have_count(1)
+    expect(page.get_by_label("Documents")).to_be_hidden()


### PR DESCRIPTION
Cette PR permet de masquer le bloc de suivi si la fiche zone délimitée est en visibilité brouillon.
## Côté front
- modification du template detail de la fiche zone pour masquer le bloc de suivi.
- ajout des tests pour fiche zone et regroupés dans`sv/tests/test_fiches_bloc_suivi.py` (uniquement ceux concernant les tests de présence du bloc de suivi dans l'UI).
## Côté back
dans la PR #479 :
- toutes les protections des routes ont déjà été effectuées dans `core/views.py`, y compris pour la fiche zone délimitée.
- les tests permettant de s'assurer de la protection des routes pour la fiche zone délimitée ont été faits via la fixture `fiche_variable`.
