### PR TITLE
Ajout bouton publier et retrait modale visibilité sur page consultation fiche zone délimitée brouillon

### DIFF
--- a/sv/templates/sv/_zone_action_navigation.html
+++ b/sv/templates/sv/_zone_action_navigation.html
@@ -4,7 +4,7 @@
                 aria-expanded="false" title="Sélectionner une action">Actions</button>
         <div class="fr-collapse fr-translate__menu fr-menu" id="action-1">
             <ul class="fr-menu__list">
-                {% if can_update_visibilite %}
+                {% if visibilite_form %}
                     <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-edit-visibilite"><span class="fr-icon-eye-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Modifier la visibilité</a></li>
                 {% endif %}
                 {% if user.agent.structure.is_ac and not fiche.etat.is_cloture %}

--- a/sv/templates/sv/fichezonedelimitee_detail.html
+++ b/sv/templates/sv/fichezonedelimitee_detail.html
@@ -22,8 +22,17 @@
                 <button class="fr-btn fr-btn--secondary fr-mr-2w">
                     <a href="{{ fiche.get_update_url }}"><span class="fr-icon-edit-fill">Modifier</span></a>
                 </button>
+                {% if publish_form %}
+                    <div>
+                        <form method="post" action="{{ fiche.get_visibilite_update_url }}">
+                            {% csrf_token %}
+                            {{ publish_form }}
+                            <button type="submit" name="action" value="publier" class="fr-btn fr-btn--secondary fr-mr-2w">Publier</button>
+                        </form>
+                    </div>
+                {% endif %}
                 {% include "sv/_zone_action_navigation.html" %}
-                {% if can_update_visibilite %}
+                {% if visibilite_form %}
                     {% include "sv/_update_visibilite_modal.html" %}
                 {% endif %}
                 {% include "sv/_cloturer_modal.html" %}

--- a/sv/tests/test_fichezonedelimite_visibilite_update.py
+++ b/sv/tests/test_fichezonedelimite_visibilite_update.py
@@ -6,19 +6,18 @@ from core.constants import BSV_STRUCTURE, MUS_STRUCTURE, AC_STRUCTURE
 from sv.models import FicheZoneDelimitee, OrganismeNuisible, StatutReglementaire
 
 
-def _update_visibilite_fiche(fiche, visibilite_libelle):
-    fiche.visibilite = visibilite_libelle
-    fiche.save()
-
-
 @pytest.mark.django_db
 def test_cannot_update_fiche_zone_delimitee_visibilite_by_other_structures(
     live_server, page: Page, fiche_zone, mocked_authentification_user
 ):
     """Test que les agents n'appartenant pas à la structure créatrice d'une fiche ne peuvent pas modifier la visibilité de cette fiche
     lorsqu'elle est en visibilité national."""
-    _update_visibilite_fiche(fiche_zone, Visibilite.NATIONAL)
+    mocked_authentification_user.agent.structure = baker.make(Structure)
+    mocked_authentification_user.agent.save()
+    fiche_zone.visibilite = Visibilite.NATIONAL
+    fiche_zone.save()
     page.goto(f"{live_server.url}{fiche_zone.get_absolute_url()}")
+    page.get_by_role("button", name="Actions").click()
     expect(page.get_by_text("Modifier la visibilité")).not_to_be_visible()
 
 
@@ -35,11 +34,7 @@ def test_agent_in_structure_createur_can_update_fiche_zone_delimitee_visibilite_
         statut_reglementaire=baker.make(StatutReglementaire),
     )
     page.goto(f"{live_server.url}{fiche_zone.get_absolute_url()}")
-    page.get_by_role("button", name="Actions").click()
-    expect(page.get_by_role("link", name="Modifier la visibilité")).to_be_visible()
-    page.get_by_role("link", name="Modifier la visibilité").click()
-    page.get_by_text("Local").click()
-    page.get_by_role("button", name="Valider").click()
+    page.get_by_role("button", name="Publier").click()
     expect(
         page.get_by_role("heading", name="La visibilité de la fiche zone délimitée a bien été modifiée")
     ).to_be_visible()
@@ -51,14 +46,14 @@ def test_agent_in_structure_createur_can_update_fiche_zone_delimitee_visibilite_
 @pytest.mark.django_db
 @pytest.mark.parametrize("visibilite_libelle", [Visibilite.LOCAL, Visibilite.NATIONAL])
 def test_agent_in_structure_createur_cannot_update_fiche_zone_delimitee_visibilite(
-    live_server, page: Page, fiche_zone, mocked_authentification_user, visibilite_libelle: str
+    live_server, page: Page, fiche_zone, visibilite_libelle: str
 ):
     """Test qu'un agent appartenant à la structure créatrice d'une fiche
     ne peut pas modifier la visibilité de cette fiche si elle est en visibilité local ou national"""
-    _update_visibilite_fiche(fiche_zone, visibilite_libelle)
-    fiche_zone.createur = mocked_authentification_user.agent.structure
+    fiche_zone.visibilite = visibilite_libelle
     fiche_zone.save()
     page.goto(f"{live_server.url}{fiche_zone.get_absolute_url()}")
+    page.get_by_role("button", name="Actions").click()
     expect(page.get_by_text("Modifier la visibilité")).not_to_be_visible()
 
 
@@ -87,14 +82,15 @@ def test_agent_ac_can_update_fiche_zone_delimitee_visibilite_local_to_national(
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("structure_ac", [MUS_STRUCTURE, BSV_STRUCTURE])
+@pytest.mark.parametrize("ac_structure_niveau2", [MUS_STRUCTURE, BSV_STRUCTURE])
 def test_agent_ac_can_update_fiche_zone_delimitee_visibilite_national_to_local(
-    live_server, page: Page, fiche_zone, mocked_authentification_user, structure_ac: str
+    live_server, page: Page, fiche_zone, mocked_authentification_user, ac_structure_niveau2: str
 ):
     """Test qu'un agent appartenant à l'AC peut modifier la visibilité d'une fiche de national à local"""
-    _update_visibilite_fiche(fiche_zone, Visibilite.NATIONAL)
+    fiche_zone.visibilite = Visibilite.NATIONAL
+    fiche_zone.save()
     mocked_authentification_user.agent.structure, _ = Structure.objects.get_or_create(
-        niveau1=AC_STRUCTURE, niveau2=structure_ac
+        niveau1=AC_STRUCTURE, niveau2=ac_structure_niveau2
     )
     mocked_authentification_user.agent.save()
     page.goto(f"{live_server.url}{fiche_zone.get_absolute_url()}")
@@ -109,3 +105,17 @@ def test_agent_ac_can_update_fiche_zone_delimitee_visibilite_national_to_local(
     expect(page.get_by_text(Visibilite.LOCAL, exact=True)).to_be_visible()
     fiche_zone.refresh_from_db()
     assert fiche_zone.visibilite == Visibilite.LOCAL
+
+
+def test_fiche_zone_delimitee_brouillon_cannot_change_visibility_through_actions_btn(
+    live_server, page, mocked_authentification_user
+):
+    fiche_zone = FicheZoneDelimitee.objects.create(
+        visibilite=Visibilite.BROUILLON,
+        createur=mocked_authentification_user.agent.structure,
+        organisme_nuisible=baker.make(OrganismeNuisible),
+        statut_reglementaire=baker.make(StatutReglementaire),
+    )
+    page.goto(f"{live_server.url}{fiche_zone.get_absolute_url()}")
+    page.get_by_role("button", name="Actions").click()
+    expect(page.get_by_role("link", name="Modifier la visibilité")).not_to_be_visible()

--- a/sv/tests/test_fichezonedelimitee_detail_performances.py
+++ b/sv/tests/test_fichezonedelimitee_detail_performances.py
@@ -1,7 +1,7 @@
 from model_bakery import baker
 from sv.models import FicheDetection, ZoneInfestee
 
-BASE_NUM_QUERIES = 14
+BASE_NUM_QUERIES = 13
 
 
 def test_empty_fiche_zone_delimitee_performances(


### PR DESCRIPTION
Sur la page de consultation d'une fiche zone délimitée en visibilité brouillon :
- ajout du bouton publier, permettant de passer la visibilité à 'local'
- suppression de l'accès au formulaire de modification de la visibilité (modale) via le menu +Actions

J'ai aussi : 
- modifier les tests `test_cannot_update_fiche_zone_delimitee_visibilite_by_other_structures ` et `test_agent_in_structure_createur_cannot_update_fiche_zone_delimitee_visibilite ` car faux positif.
- supprimé la méthode `get_form_kwargs` dans `FicheDetectionVisibiliteUpdateView ` car pas utile.