### PR TITLE
Fiabiliser les tests sur la liste de fiches

### DIFF
--- a/sv/tests/test_fiches_search.py
+++ b/sv/tests/test_fiches_search.py
@@ -357,7 +357,7 @@ def test_search_fiche_zone(live_server, page: Page, fiche_detection_bakery, fich
 
 
 def test_link_fiche_detection(live_server, page, fiche_detection_bakery, fiche_zone_bakery):
-    fiche_detection_bakery()
+    fiche = fiche_detection_bakery()
     page.goto(f"{live_server.url}{get_fiche_detection_search_form_url()}")
 
     cell_selector = ".fiches__list-row:nth-child(1) td:nth-child(9)"
@@ -368,7 +368,6 @@ def test_link_fiche_detection(live_server, page, fiche_detection_bakery, fiche_z
     numero.annee = 2024
     numero.numero = 1
     numero.save()
-    fiche = fiche_detection_bakery()
     fiche.hors_zone_infestee = fiche_zone
     fiche.save()
     page.goto(f"{live_server.url}{get_fiche_detection_search_form_url()}")


### PR DESCRIPTION
On réutilise la même fiche pour ne pas avoir a gérer le cas où le nouveau numéro est plus grand ou plus petit que l'ancien (ce qui change l'ordre dans le tableau et donc le sélecteur a utiliser).