### PR TITLE
Empêcher de rechercher par région sur la liste de zone

### DIFF
--- a/sv/static/sv/fiche_list.js
+++ b/sv/static/sv/fiche_list.js
@@ -23,5 +23,8 @@ document.addEventListener('DOMContentLoaded', function() {
         document.getElementById('id_lieux__departement__region').disabled = true
         document.getElementById('id_lieux__departement__region').selectedIndex = 0
     })
-
+    if (new URLSearchParams(window.location.search).get('type_fiche') === "zone"){
+        document.getElementById('id_lieux__departement__region').disabled = true
+        document.getElementById('id_lieux__departement__region').selectedIndex = 0
+    }
 });

--- a/sv/tests/test_fiches_search.py
+++ b/sv/tests/test_fiches_search.py
@@ -350,3 +350,8 @@ def test_cant_search_region_for_zone(live_server, page: Page):
     page.wait_for_url(f"**{reverse('fiche-liste')}**")
     response = page.goto(page.url)
     assert response.status == 200
+
+
+def test_cant_search_region_for_zone_on_page_load(live_server, page: Page):
+    page.goto(f"{live_server.url}{get_fiche_detection_search_form_url()}?type_fiche=zone")
+    expect(page.locator("#id_lieux__departement__region")).to_be_disabled()


### PR DESCRIPTION
Au chargement de la page désactiver le filtre des régions si jamais l'utilisateur est sur une liste de fiche zone.