### PR TITLE
fix(sentry): adjust tracesSampleRate

### DIFF
--- a/seves/settings.py
+++ b/seves/settings.py
@@ -159,7 +159,7 @@ if SENTRY_DSN:
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         integrations=[DjangoIntegration()],
-        traces_sample_rate=1.0,
+        traces_sample_rate=0.1,
     )
 
 


### PR DESCRIPTION
SEVES is sending +800k/events/day on the shared sentry instance. the production value should be around 0.1 or lower

https://docs.sentry.io/platforms/javascript/tracing/#configure