### PR TITLE
Corrige interface bloc prélèvement quand pas de lieux

### DIFF
--- a/sv/static/sv/fichedetection_lieux_form.js
+++ b/sv/static/sv/fichedetection_lieux_form.js
@@ -38,7 +38,6 @@ function displayLieuxCards() {
     lieuListElement.innerHTML = ""
     if (document.lieuxCards.length === 0) {
         lieuListElement.innerHTML = "Aucun lieu."
-        return
     }
 
     document.lieuxCards.forEach(card =>{

--- a/sv/tests/test_fichedetection_form.py
+++ b/sv/tests/test_fichedetection_form.py
@@ -598,3 +598,17 @@ def test_cant_see_fiches_brouillon_in_liens_libres_in_add_form(page, mocked_auth
 def test_numero_rapport_inspection_format(page):
     inputs_rapport_inspection = page.locator("input[name^='prelevements-'][name$='-numero_rapport_inspection']").all()
     assert all(input.get_attribute("pattern") == "^\\d{2}-\\d{6}$" for input in inputs_rapport_inspection)
+
+
+def test_info_message_in_prelevement_bloc_should_be_visible_without_locations(
+    page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+):
+    expect(page.locator("#no-lieux-text")).to_be_visible()
+
+    form_elements.add_lieu_btn.click()
+    lieu_form_elements.nom_input.fill("un lieu")
+    lieu_form_elements.save_btn.click()
+    page.get_by_role("button", name="Supprimer le lieu").click()
+    page.get_by_role("dialog", name="Supprimer").get_by_role("button", name="Supprimer").click()
+
+    expect(page.locator("#no-lieux-text")).to_be_visible()


### PR DESCRIPTION
## Problème
Sur le formulaire de la fiche détection, si je créé un lieu et que je le supprime, le message d'information `"pour ajouter un prélèvement vous devez..."` ne s'affiche plus.

## Correction
Suppression du `return` lorsqu'il y a pas de lieu car l'appel `showOrHidePrelevementUI()` n'était pas exécuté.