### PR TITLE
Modification affichage Commune sur vue synthèse et liste fiches détection

### DIFF
--- a/sv/display.py
+++ b/sv/display.py
@@ -70,7 +70,7 @@ class DisplayedFiche:
             createur=str(fiche.createur),
             etat=fiche.etat,
             visibilite=str(fiche.visibilite),
-            communes_list=fiche.lieux_list,
+            communes_list=fiche.lieux_list_with_commune,
             get_absolute_url=fiche.get_absolute_url(),
             link=DisplayedLink.from_fiche_detection(fiche),
         )

--- a/sv/managers.py
+++ b/sv/managers.py
@@ -50,10 +50,12 @@ class FicheDetectionQuerySet(BaseVisibilityQuerySet):
         contacts_not_in_fin_suivi = contacts_structure_fiche.exclude(id__in=fin_suivi_contacts_ids)
         return contacts_not_in_fin_suivi
 
-    def with_list_of_lieux(self):
+    def with_list_of_lieux_with_commune(self):
         from sv.models import Lieu
 
-        lieux_prefetch = Prefetch("lieux", queryset=Lieu.objects.order_by("id"), to_attr="lieux_list")
+        lieux_prefetch = Prefetch(
+            "lieux", queryset=Lieu.objects.exclude(commune="").order_by("id"), to_attr="lieux_list_with_commune"
+        )
         return self.prefetch_related(lieux_prefetch)
 
     def with_first_region_name(self):

--- a/sv/templates/sv/_fichedetection_synthese.html
+++ b/sv/templates/sv/_fichedetection_synthese.html
@@ -18,19 +18,20 @@
         <div class="fr-col-3">
             <div class="fr-grid-row">
                 <div class="fr-col-5 fiche-synthese__label fr-pb-1w">Commune</div>
-                <div class="fr-col-7">
-                    {% with lieux|length as lieux_count %}
-                        {% if lieux_count == 0 %}
-                            nc.
-                        {% else %}
-                            {{ lieux.0.commune|default:"nc." }} <span aria-describedby="tooltip-2989">+{{ lieux_count|add:"-1" }}</span>
-                            <span class="fr-tooltip fr-placement" id="tooltip-2989" role="tooltip" aria-hidden="true">
-                                {% for lieu in lieux|slice:"1:" %}
-                                    {{ lieu.commune|default:"nc." }}{% if not forloop.last %}, {% endif %}
+                <div id="synthese-communes-list" class="fr-col-7">
+                    {% if not lieux_with_commune %}
+                        nc.
+                    {% else %}
+                        {{ lieux_with_commune.0.commune }}
+                        {% if lieux_with_commune|length > 1 %}
+                            <span aria-describedby="tooltip-additional-communes">+{{ lieux_with_commune|length|add:"-1" }}</span>
+                            <span class="fr-tooltip fr-placement" id="tooltip-additional-communes" role="tooltip" aria-hidden="true">
+                                {% for lieu in lieux_with_commune|slice:"1:" %}
+                                    {{ lieu.commune }}{% if not forloop.last %}, {% endif %}
                                 {% endfor %}
                             </span>
                         {% endif %}
-                    {% endwith %}
+                    {% endif %}
                 </div>
             </div>
 

--- a/sv/templates/sv/fichedetection_detail.html
+++ b/sv/templates/sv/fichedetection_detail.html
@@ -144,7 +144,7 @@
                                         </div>
                                     </div>
                                     <p class="fr-card__desc">
-                                        Commune : {{ lieu_initial.commune|default:"" }} <br/>
+                                        Commune : {{ lieu_initial.commune|default:"nc." }} <br/>
                                         {% if lieu_initial.departement %}
                                             Département : {{ lieu_initial.departement.nom }} ({{ lieu_initial.departement.numero }})
                                         {% endif %}

--- a/sv/tests/test_fichedetection_list.py
+++ b/sv/tests/test_fichedetection_list.py
@@ -1,0 +1,38 @@
+from django.urls import reverse
+from playwright.sync_api import Page, expect
+
+from sv.factories import FicheDetectionFactory, LieuFactory
+
+
+def test_commune_column_with_multiple_communes(live_server, page: Page):
+    fiche = FicheDetectionFactory()
+    LieuFactory(fiche_detection=fiche, commune="Paris")
+    LieuFactory(fiche_detection=fiche, commune="Lyon")
+    LieuFactory(fiche_detection=fiche, commune="Marseille")
+
+    page.goto(f"{live_server}{reverse('fiche-liste')}")
+    expect(page.get_by_role("link", name="Paris, Lyon, Marseille")).to_be_visible()
+
+
+def test_commune_column_with_some_empty_communes(live_server, page: Page):
+    fiche = FicheDetectionFactory()
+    LieuFactory(fiche_detection=fiche, commune="Paris")
+    LieuFactory(fiche_detection=fiche, commune="Lyon")
+    LieuFactory(fiche_detection=fiche, commune="")
+
+    page.goto(f"{live_server}{reverse('fiche-liste')}")
+    expect(page.get_by_role("link", name="Paris, Lyon")).to_be_visible()
+
+
+def test_commune_column_with_empty_commune(live_server, page: Page):
+    fiche = FicheDetectionFactory()
+    LieuFactory(fiche_detection=fiche, commune="")
+
+    page.goto(f"{live_server}{reverse('fiche-liste')}")
+    expect(page.get_by_role("link", name="nc.")).to_be_visible()
+
+
+def test_commune_column_without_lieu(live_server, page: Page):
+    FicheDetectionFactory()
+    page.goto(f"{live_server}{reverse('fiche-liste')}")
+    expect(page.get_by_role("link", name="nc.")).to_be_visible()

--- a/sv/tests/test_fichedetection_performances.py
+++ b/sv/tests/test_fichedetection_performances.py
@@ -4,7 +4,7 @@ from model_bakery import baker
 from core.models import Message, Document, Structure, Contact
 from sv.models import Lieu, Prelevement
 
-BASE_NUM_QUERIES = 14  # Please note a first call is made without assertion to warm up any possible cache
+BASE_NUM_QUERIES = 15  # Please note a first call is made without assertion to warm up any possible cache
 
 
 @pytest.mark.django_db

--- a/sv/views.py
+++ b/sv/views.py
@@ -72,7 +72,7 @@ class FicheListView(ListView):
             queryset = queryset.optimized_for_list().order_by_numero_fiche().with_nb_fiches_detection()
         else:
             queryset = FicheDetection.objects.all().get_fiches_user_can_view(self.request.user)
-            queryset = queryset.with_list_of_lieux().with_first_region_name()
+            queryset = queryset.with_list_of_lieux_with_commune().with_first_region_name()
             queryset = queryset.optimized_for_list().order_by_numero_fiche()
         self.filter = FicheFilter(self.request.GET, queryset=queryset)
         return self.filter.qs
@@ -110,6 +110,9 @@ class FicheDetectionDetailView(
             Lieu.objects.filter(fiche_detection=self.get_object())
             .order_by("id")
             .select_related("departement__region", "site_inspection")
+        )
+        context["lieux_with_commune"] = (
+            Lieu.objects.filter(fiche_detection=self.get_object()).exclude(commune="").order_by("id")
         )
         prelevement = Prelevement.objects.filter(lieu__fiche_detection=self.get_object())
         context["prelevements"] = prelevement.select_related(


### PR DESCRIPTION
- ajout d'une liste des lieux sans commune renseignée dans le context du détail de la fiche détection (cf. `FicheDetectionDetailView`)
- dans la vue liste des fiches détection, suppression des lieux qui n'ont pas de commune renseignée dans la requête
- ajout de nc. sur la carte d'un lieu si pas de commune renseignée

Ticket Notion : https://www.notion.so/incubateur-masa/Enlever-le-commune-0-en-vue-synth-se-150de24614be8013be43c9e88dd75a7c?pvs=4