### PR TITLE
Corrige le titre de la page du formulaire de modification d'une fiche détection

### DIFF
--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -28,8 +28,7 @@
                         {% if is_creation %}
                             Création d'une fiche détection
                         {% else %}
-                            Modification de la fiche détection {% if form.instance.numero %}n°{{ form.instance.numero }}{% endif %}
-                            Modification de la fiche détection n°{{ fichedetection.numero }}
+                            Modification de la fiche détection {% if form.instance.numero %}n° {{ form.instance.numero }}{% endif %}
                         {% endif %}
                     </h1>
                     {% if not is_creation %}

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -53,9 +53,8 @@ def create_fixtures_if_needed(db):
 
 
 def test_page_title(live_server, page: Page, form_elements: FicheDetectionFormDomElements):
-    """Test que le titre de la page est bien "Modification de la fiche détection n°2024.1"""
     page.goto(f"{live_server.url}{reverse('fiche-detection-creation')}")
-    expect(form_elements.title).to_contain_text("Création d'une fiche détection")
+    expect(page.get_by_role("heading", name="Création d'une fiche détection", exact=True)).to_be_visible()
 
 
 def test_new_fiche_detection_form_content(live_server, page: Page, form_elements: FicheDetectionFormDomElements):

--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -27,6 +27,7 @@ from ..models import (
 
 from sv.constants import REGIONS, DEPARTEMENTS, STRUCTURE_EXPLOITANT
 from .test_utils import FicheDetectionFormDomElements, LieuFormDomElements, PrelevementFormDomElements
+from sv.factories import FicheDetectionFactory
 
 
 @pytest.fixture(autouse=True)
@@ -65,12 +66,18 @@ def fiche_detection_with_one_lieu_and_one_prelevement(fiche_detection_with_one_l
     return fiche_detection_with_one_lieu
 
 
-def test_page_title(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, fiche_detection: FicheDetection
-):
-    """Test que le titre de la page est bien "Modification de la fiche détection n°2024.1"""
-    page.goto(f"{live_server.url}{fiche_detection.get_update_url()}")
-    expect(form_elements.title).to_contain_text(f"Modification de la fiche détection n°{fiche_detection.numero}")
+def test_page_title(live_server, page: Page):
+    fiche = FicheDetectionFactory()
+    page.goto(f"{live_server.url}{fiche.get_update_url()}")
+    expect(
+        page.get_by_role("heading", name=f"Modification de la fiche détection n° {fiche.numero}", exact=True)
+    ).to_be_visible()
+
+
+def test_page_title_for_fiche_brouillon(live_server, page):
+    fiche = FicheDetectionFactory(visibilite=Visibilite.BROUILLON)
+    page.goto(f"{live_server.url}{fiche.get_update_url()}")
+    expect(page.get_by_role("heading", name="Modification de la fiche détection", exact=True)).to_be_visible()
 
 
 def test_fiche_detection_update_page_content(


### PR DESCRIPTION
Cette PR supprime le doublon "Modification de la fiche..." dans le formulaire de modification d'une fiche détection.

- supprime le doublon "Modification de la fiche..." dans le template
- utilisation de `get_by_role` pour tester les titres pour vérifier l'exactitude du texte (via paramètre `exact=True`)
- ajoute un test pour le titre de la page du formulaire de modification pour une fiche détection brouillon

Ticket Notion : https://www.notion.so/incubateur-masa/Ticket-de-recette-158de24614be80d488c2d9b9f2228cd7?pvs=4