### PR TITLE
Modification du champ Activité établissement dans le formulaire Lieu d'une fiche détection

### DIFF
--- a/sv/forms.py
+++ b/sv/forms.py
@@ -81,6 +81,15 @@ class LieuForm(DSFRForm, WithDataRequiredConversionMixin, forms.ModelForm):
             }
         ),
     )
+    activite_etablissement = forms.CharField(
+        required=False,
+        label="Description de l’activité",
+        widget=forms.Textarea(
+            attrs={
+                "rows": 2,
+            }
+        ),
+    )
 
     class Meta:
         model = Lieu

--- a/sv/static/sv/fichedetection_form.css
+++ b/sv/static/sv/fichedetection_form.css
@@ -154,7 +154,7 @@ main {
 [id^=lieu-form] p label, [id^=lieu-form] .commune label {
     flex: 0.75;
 }
-[id^=lieu-form] p input, #lieu-form .commune .choices{
+[id^=lieu-form] p input, [id^=lieu-form] p textarea, #lieu-form .commune .choices{
     flex: 1.25;
     margin-top: .5rem;
 }


### PR DESCRIPTION
Dans le formulaire d'ajout/modification d'un lieu d'une fiche détection, pour le champ `activite_etablissement` : 
- ajout d'une textarea pour augmenter le nombre de ligne
- modification du label

Ticket Notion : https://www.notion.so/incubateur-masa/Case-activit-s-d-un-tablissement-revoir-150de24614be80b4ada2f23e95284b3a?pvs=4