### PR TITLE
Affiche fin de suivi pour les contacts (agents) d’une structure en fin de suivi

### DIFF
--- a/core/templates/core/_carte_resume_contact.html
+++ b/core/templates/core/_carte_resume_contact.html
@@ -3,13 +3,16 @@
         <div class="fr-card__content fr-pb-0-5v">
             {% if contact.agent %}
                 <p class="fr-h6 fr-mb-1w">{{ contact.agent }}</p>
+                {% if is_in_fin_suivi %}
+                    <p class="fr-mt-0-5w fr-badge fr-badge--new fr-badge--no-icon">Fin de suivi</p>
+                {% endif %}
                 <p class="fr-mb-1w">{{ contact.agent.fonction_hierarchique }}</p>
                 <p class="fr-tag">{{contact.agent.structure}}</p>
                 <p class="fr-mt-2w fr-mb-1w"><a href="mailto:{{ contact.email }}" class="fr-link">{{ contact.email }}</a></p>
                 <p class="fr-mt-1w fr-mb-0-5v">{{ contact.agent.telephone }}</p>
             {% elif contact.structure %}
                 <p class="fr-h6 fr-mb-1w">{{ contact.structure.libelle }}</p>
-                {% if contact in contacts_fin_suivi %}
+                {% if is_in_fin_suivi %}
                     <p class="fr-mt-0-5w fr-badge fr-badge--new fr-badge--no-icon">Fin de suivi</p>
                 {% endif %}
                 <p class="fr-mt-3w fr-mb-0-5v"><a href="mailto:{{ contact.email }}" class="fr-link">{{ contact.email }}</a></p>

--- a/core/templates/core/_contacts.html
+++ b/core/templates/core/_contacts.html
@@ -9,13 +9,13 @@
 <div class="fr-container--fluid">
     <div class="fr-grid-row fr-grid-row--gutters">
         {% for contact in contacts_agents %}
-            <div class="fr-col-3 fr-col-xl-3">
-                {% include "core/_carte_resume_contact.html" %}
+            <div class="fr-col-3 fr-col-xl-3" data-testid="contacts-agents">
+                {% include "core/_carte_resume_contact.html" with contact=contact.contact is_in_fin_suivi=contact.is_in_fin_suivi %}
             </div>
         {% endfor %}
         {% for contact in contacts_structures %}
-            <div class="fr-col-3 fr-col-xl-3">
-                {% include "core/_carte_resume_contact.html" %}
+            <div class="fr-col-3 fr-col-xl-3" data-testid="contacts-structures">
+                {% include "core/_carte_resume_contact.html" with contact=contact.contact is_in_fin_suivi=contact.is_in_fin_suivi %}
             </div>
         {% endfor %}
     </div>

--- a/sv/tests/test_evenement_contacts_list.py
+++ b/sv/tests/test_evenement_contacts_list.py
@@ -42,3 +42,24 @@ def test_contacts_structures_order_in_list(
 
     expect(page.locator(".fr-card__content").first).to_contain_text(contact2.structure.libelle)
     expect(page.locator(".fr-card__content").last).to_contain_text(contact1.structure.libelle)
+
+
+def test_when_structure_is_in_fin_suivi_all_agents_should_be_in_fin_suivi(
+    live_server, page, mocked_authentification_user
+):
+    evenement = EvenementFactory()
+    contact_structure = Contact.objects.get(email="structure_test@test.fr")
+    contact_agent_1 = Contact.objects.get(email="text@example.com")
+    contact_agent_2 = Contact.objects.create(agent=baker.make(Agent, structure=contact_structure.structure))
+    evenement.contacts.set([contact_agent_1, contact_agent_2, contact_structure])
+
+    page.goto(f"{live_server.url}/{evenement.get_absolute_url()}")
+    page.get_by_test_id("element-actions").click()
+    page.get_by_role("link", name="Signaler la fin de suivi").click()
+    page.get_by_label("Message").fill("aaa")
+    page.get_by_test_id("fildesuivi-add-submit").click()
+    page.get_by_test_id("contacts").click()
+
+    contacts_agents = page.get_by_test_id("contacts-agents")
+    for contact in contacts_agents.all():
+        expect(contact).to_contain_text("Fin de suivi")

--- a/sv/tests/test_evenement_etats.py
+++ b/sv/tests/test_evenement_etats.py
@@ -52,7 +52,7 @@ def test_element_suivi_fin_suivi_creates_etat_fin_suivi(live_server, page: Page,
     page.get_by_label("Message").fill("test")
     page.get_by_test_id("fildesuivi-add-submit").click()
     page.get_by_test_id("contacts").click()
-    expect(page.get_by_label("Contacts").get_by_text("Fin de suivi")).to_be_visible()
+    expect(page.get_by_test_id("contacts-structures").get_by_text("Fin de suivi")).to_be_visible()
 
 
 def test_element_suivi_fin_suivi_already_exists(live_server, page: Page, mocked_authentification_user):


### PR DESCRIPTION
Cette PR permet d'afficher le badge "fin de suivi" pour les contacts de type agent dont la structure est en fin de suivi

Optimisation :
- Récupération des ids de structures en fin de suivi
- Pour is_in_fin_suivi : comparaison par ids au lieu d'objets pour de meilleures performances
- Cache de l'objet principal dans le mixin pour éviter les appels multiples à get_object()