### PR TITLE
Empêcher de supprimer une fiche sans droit de lecture

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, PermissionDenied
 from django.db import models, transaction
 from django.urls import reverse
 
@@ -82,7 +82,12 @@ class WithFreeLinksListInContextMixin:
 class AllowsSoftDeleteMixin(models.Model):
     is_deleted = models.BooleanField(default=False)
 
-    def soft_delete(self):
+    def can_user_delete(self, user):
+        raise NotImplementedError
+
+    def soft_delete(self, user):
+        if not self.can_user_delete(user):
+            raise PermissionDenied
         self.is_deleted = True
         self.save()
 

--- a/core/views.py
+++ b/core/views.py
@@ -23,7 +23,7 @@ from .notifications import notify_message
 from .models import Document, Message, Contact, FinSuiviContact
 
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError, PermissionDenied
 
 from .redirect import safe_redirect
 
@@ -384,10 +384,12 @@ class SoftDeleteView(View):
         obj = content_type.objects.get(pk=content_id)
 
         try:
-            obj.soft_delete()
+            obj.soft_delete(request.user)
             messages.success(request, "Objet supprimé avec succès")
         except AttributeError:
             messages.error(request, "Ce type d'objet ne peut pas être supprimé")
+        except PermissionDenied:
+            messages.error(request, "Vous n'avez pas les droits pour supprimer cet objet")
 
         return safe_redirect(request.POST.get("next"))
 

--- a/sv/models.py
+++ b/sv/models.py
@@ -561,6 +561,9 @@ class FicheDetection(
     def get_visibilite_update_url(self):
         return reverse("fiche-detection-visibilite-update", kwargs={"pk": self.pk})
 
+    def can_user_delete(self, user):
+        return self.can_user_access(user)
+
     def __str__(self):
         return str(self.numero)
 

--- a/sv/tests/test_fichedetection_soft_delete.py
+++ b/sv/tests/test_fichedetection_soft_delete.py
@@ -1,7 +1,11 @@
 import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
 
 from playwright.sync_api import expect
 
+from core.models import Structure
+from sv.factories import FicheDetectionFactory
 from sv.models import FicheDetection
 
 
@@ -17,3 +21,21 @@ def test_can_delete_fiche_detection(live_server, page, fiche_detection):
 
     assert FicheDetection.objects.count() == 0
     expect(page.get_by_role("link", name=str(fiche_detection.numero))).not_to_be_visible()
+
+
+@pytest.mark.django_db
+def test_cant_forge_deletion_of_fiche_we_cant_see(client, mocked_authentification_user):
+    fiche_detection = FicheDetectionFactory(createur=Structure.objects.create(libelle="A new structure"))
+    response = client.get(fiche_detection.get_absolute_url())
+
+    assert response.status_code == 403
+
+    payload = {
+        "content_type_id": ContentType.objects.get_for_model(fiche_detection).id,
+        "content_id": fiche_detection.pk,
+    }
+    response = client.post(reverse("soft-delete"), data=payload)
+
+    assert response.status_code == 302
+    fiche_detection.refresh_from_db()
+    assert fiche_detection.is_deleted is False


### PR DESCRIPTION
Ce commit empêche un(e) utilisateur(trice) de supprimer une fiche / un objet si cela n'est pas explicitement autorisé au niveau de l'objet. Cela empêche en particulier de supprimer une fiche détection auquelle l'utilisateur n'aurait pas accès en créant la bonne requête HTTP de toute pièce.