### PR TITLE
Retirer la notion de rattachement

### DIFF
--- a/sv/forms.py
+++ b/sv/forms.py
@@ -1,18 +1,15 @@
 import datetime
 
-from django.conf import settings
-
-from core.forms import DSFRForm, VisibiliteUpdateBaseForm
-
 from django import forms
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.forms import BaseInlineFormSet
 from django.forms.models import inlineformset_factory
 from django.utils.timezone import now
-from django.core.exceptions import ValidationError
 from django.utils.translation import ngettext
-from django.forms import BaseInlineFormSet
-from django.db.models import TextChoices
 
 from core.fields import DSFRRadioButton
+from core.forms import DSFRForm, VisibiliteUpdateBaseForm
 from sv.form_mixins import WithDataRequiredConversionMixin
 from sv.models import (
     FicheZoneDelimitee,
@@ -32,20 +29,6 @@ class EvenementVisibiliteUpdateForm(VisibiliteUpdateBaseForm, forms.ModelForm):
     class Meta:
         model = Evenement
         fields = ["visibilite"]
-
-
-class RattachementChoices(TextChoices):
-    HORS_ZONE_INFESTEE = "hors_zone_infestee", "Hors zone infestée"
-    ZONE_INFESTEE = "zone_infestee", "Zone infestée"
-
-
-class RattachementDetectionForm(DSFRForm, forms.Form):
-    rattachement = forms.ChoiceField(
-        choices=RattachementChoices.choices,
-        widget=DSFRRadioButton,
-        label="Où souhaitez-vous rattacher la détection ?",
-        initial=RattachementChoices.HORS_ZONE_INFESTEE,
-    )
 
 
 class LieuForm(DSFRForm, WithDataRequiredConversionMixin, forms.ModelForm):


### PR DESCRIPTION
Retire complétement la notion de choix de rattachement qui n'est plus utilisé depuis le commit précédent sur l'introduction de l'événement. Corrige les tests et retire complétement un test qui n'a plus de sens (ce comportement est déjà testé par
test_fiche_detection_are_filtered_by_evenement_of_fiche_detection)