### PR TITLE
Corriger le lien d'annulation sur le form de zone

### DIFF
--- a/sv/templates/sv/fichezonedelimitee_form.html
+++ b/sv/templates/sv/fichezonedelimitee_form.html
@@ -27,7 +27,7 @@
             </div>
             <div class="fr-col fichezone_form__save-btn">
                 <input type="hidden" name="evenement" value="{{ request.GET.evenement }}">
-                <a href="{{ fiche.get_absolute_url }}" class="fr-link fr-mr-3w">Annuler</a>
+                <a href="{% url 'evenement-details' request.GET.evenement %}" class="fr-link fr-mr-3w">Annuler</a>
                 <input type="submit" form="fiche-zone-delimitee-form" value="Enregistrer les modifications" class="fr-btn" >
             </div>
         </div>

--- a/sv/tests/test_fichezonedelimitee_create.py
+++ b/sv/tests/test_fichezonedelimitee_create.py
@@ -12,6 +12,16 @@ from sv.tests.test_utils import FicheZoneDelimiteeFormPage
 
 
 @pytest.mark.django_db
+def test_can_go_back_to_event_from_fiche_zone_form(live_server, page: Page, choice_js_fill):
+    evenement = EvenementFactory()
+    form_page = FicheZoneDelimiteeFormPage(page, choice_js_fill)
+    form_page.goto_create_form_page(live_server, evenement)
+    form_page.page.get_by_role("link", name="Annuler").click()
+
+    assert form_page.page.url == f"{live_server.url}{evenement.get_absolute_url()}"
+
+
+@pytest.mark.django_db
 def test_fiche_detection_are_filtered_by_evenement_of_fiche_detection(client):
     """Test que les fiches détection proposées dans la page de création de la fiche zone délimitée viennent du même événement"""
     fiche = FicheDetectionFactory()


### PR DESCRIPTION
Corrige le lien d'annnulation sur la page de création de fiche zone delimitée. Ajout d'un test.