### PR TITLE
Empêcher de créer plusieurs fois une zone

### DIFF
--- a/sv/static/sv/evenement_details.css
+++ b/sv/static/sv/evenement_details.css
@@ -9,6 +9,7 @@ main{
 .evenement-top-row--actions {
     display: flex;
     justify-content: space-between;
+    max-height: 2.5rem;
 }
 
 .no-tab-look .fr-tabs__panel{
@@ -32,4 +33,20 @@ main{
 .fr-btn--delete:hover{
     color: white;
     background-color: var(--text-default-error) !important;
+}
+.zone-button {
+    background-image: none;
+}
+.zone-button .fr-btn {
+    height: 100%;
+}
+.evenement-top-row--actions .fr-translate__btn::before {
+    -webkit-mask-image: url(../../../static/icons/system/add-line.svg);
+    mask-image: url(../../../static/icons/system/add-line.svg);
+}
+.evenement-top-row--actions .fr-translate__btn{
+    height: 100%;
+}
+.evenement-top-row--actions .fr-nav__item{
+    height: 100%;
 }

--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -39,7 +39,13 @@
 
                 <div class="evenement-top-row--actions">
                     <a href="{% url 'fiche-detection-creation' %}?evenement={{ evenement.pk }}" class="fr-btn fr-btn--secondary fr-mr-2w">Ajouter une détection</a>
-                    <a href="{% url 'fiche-zone-delimitee-creation' %}?evenement={{ evenement.pk }}" class="fr-btn fr-btn--secondary fr-mr-2w">Ajouter une zone</a>
+
+                    {% if evenement.fiche_zone_delimitee %}
+                        <button class="fr-btn fr-btn--secondary fr-mr-2w" disabled>Ajouter une zone</button>
+                    {% else %}
+                        <a href="{% url 'fiche-zone-delimitee-creation' %}?evenement={{ evenement.pk }}" class="zone-button"><button class="fr-btn fr-btn--secondary fr-mr-2w">Ajouter une zone</button></a>
+                    {% endif %}
+
                     {% include "sv/_evenement_action_navigation.html" %}
                     {% include "sv/_cloturer_modal.html" %}
                 </div>

--- a/sv/tests/test_evenement_details.py
+++ b/sv/tests/test_evenement_details.py
@@ -1,0 +1,10 @@
+from playwright.sync_api import expect, Page
+
+from sv.factories import EvenementFactory, FicheZoneFactory
+
+
+def test_cant_add_zone_if_alreay_one(live_server, page: Page):
+    fiche_zone = FicheZoneFactory()
+    evenement = EvenementFactory(fiche_zone_delimitee=fiche_zone)
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    expect(page.get_by_text("Ajouter une zone", exact=True)).to_be_disabled()


### PR DESCRIPTION
Au sein d'un même événémenent, désactiver le bouton de création de Zone si une zone existe déjà. La vérification est déjà faite côté back et amenait de toute façon sur une page d'erreur.