### PR TITLE
Ajout max length sur l'input du champ Description de l’activité (Lieu) + compteur de caractères

### DIFF
--- a/sv/forms.py
+++ b/sv/forms.py
@@ -65,6 +65,8 @@ class LieuForm(DSFRForm, WithDataRequiredConversionMixin, forms.ModelForm):
         widget=forms.Textarea(
             attrs={
                 "rows": 2,
+                "maxlength": 100,
+                "title": "Ce champ est limité à 100 caractères.",
             }
         ),
     )

--- a/sv/static/sv/fichedetection_form.css
+++ b/sv/static/sv/fichedetection_form.css
@@ -161,6 +161,10 @@ main {
 [id^=lieu-form] p select {
     flex: 1.15;
 }
+[id^=lieu-form] .character-counter {
+    text-align: right;
+}
+
 .lieu-initial,
 .prelevement {
     background-color: #E3E3FD;

--- a/sv/static/sv/fichedetection_lieux_form.js
+++ b/sv/static/sv/fichedetection_lieux_form.js
@@ -155,6 +155,20 @@ function getNextAvailableModal() {
     }
 }
 
+function setupCharacterCounter(element) {
+    const input = element.querySelector(`[id^="id_lieux-"][id$="-activite_etablissement"]`);
+    let counterDiv = element.querySelector('.character-counter');
+    const maxLength = input.getAttribute('maxlength');
+
+    counterDiv.textContent = `${maxLength - input.value.length} caractères restants`;
+
+    input.addEventListener('input', function(e) {
+        const remaining = maxLength - e.target.value.length;
+        counterDiv.textContent = `${remaining} caractères restants`;
+    });
+}
+
+
 (function() {
     document.querySelector("#add-lieu-bouton").addEventListener("click", showLieuModal)
     document.querySelectorAll(".lieu-save-btn").forEach(button => button.addEventListener("click", saveLieu))
@@ -166,11 +180,11 @@ function getNextAvailableModal() {
     document.querySelectorAll("[id^=modal-add-lieu-] .lieu-cancel-btn").forEach(element => element.addEventListener("click", closeDSFRModal))
 
     document.querySelectorAll("[id^=modal-add-lieu-]").forEach(element =>{
+        setupCharacterCounter(element);
         const data = buildLieuCardFromModal(element)
         if (!!data.nom){
             document.lieuxCards.push(data)
         }
     })
     displayLieuxCards()
-
 })();

--- a/sv/templates/sv/_fichedetection_form__lieux_modal.html
+++ b/sv/templates/sv/_fichedetection_form__lieux_modal.html
@@ -48,8 +48,9 @@
                                 <p>
                                     {{ form.nom_etablissement.label_tag }}{{ form.nom_etablissement }}
                                 </p>
-                                <p>
+                                <p class="fr-mb-0">
                                     {{ form.activite_etablissement.label_tag }}{{ form.activite_etablissement }}
+                                    <div class="fr-hint-text character-counter"></div>
                                 </p>
                                 <p>
                                     {{ form.pays_etablissement.label_tag }}{{ form.pays_etablissement }}

--- a/sv/templates/sv/fichedetection_detail_lieu.html
+++ b/sv/templates/sv/fichedetection_detail_lieu.html
@@ -68,7 +68,7 @@
                             </div>
                             <div class="fr-grid-row fr-mb-2w">
                                 <div class="fr-col-offset-2"></div>
-                                <div class="fr-col-4 detail-lieu__label--activite-etablissement">Activité</div>
+                                <div class="fr-col-4 detail-lieu__label--activite-etablissement">Description de l’activité</div>
                                 <div class="fr-col-6" data-testid="lieu-{{lieu_index}}-activite-etablissement">{{lieu.activite_etablissement|default:"nc."}}</div>
                             </div>
                             <div class="fr-grid-row fr-mb-2w">

--- a/sv/tests/test_fichedetection_form.py
+++ b/sv/tests/test_fichedetection_form.py
@@ -152,6 +152,33 @@ def test_coordonnees_gps_are_numeric_in_add_lieu_form(
     expect(lieu_form_elements.coord_gps_wgs84_longitude_input).to_have_attribute("type", "number")
 
 
+def test_description_activite_have_max_length(
+    page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+):
+    form_elements.add_lieu_btn.click()
+    lieu_form_elements.is_etablissement_checkbox.click(force=True)
+    expect(lieu_form_elements.activite_etablissement_input).to_have_attribute("maxlength", "100")
+    lieu_form_elements.activite_etablissement_input.fill("a" * 101)
+    expect(lieu_form_elements.activite_etablissement_input).to_have_value("a" * 100)
+
+
+def test_description_activite_counter_behavior(
+    page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
+):
+    form_elements.add_lieu_btn.click()
+    lieu_form_elements.is_etablissement_checkbox.click(force=True)
+    counter = page.locator(".character-counter").first
+
+    expect(counter).to_be_visible()
+    expect(counter).to_have_text("100 caractères restants")
+
+    lieu_form_elements.activite_etablissement_input.fill("a" * 50)
+    expect(counter).to_have_text("50 caractères restants")
+
+    lieu_form_elements.activite_etablissement_input.fill("a" * 101)
+    expect(counter).to_have_text("0 caractères restants")
+
+
 def test_add_lieu_to_list(
     live_server, page: Page, form_elements: FicheDetectionFormDomElements, lieu_form_elements: LieuFormDomElements
 ):


### PR DESCRIPTION
Dans le formulaire d'un lieu dans une fiche détection ajout : 
-  d'une restriction sur la taille max du descripteur "Description de l’activité" côté front (ajout de maxlength dans l'input)
- d'un compteur de caractères visuel permettant à l'utilisateur de suivre en temps réel le nombre de caractères restants lors de la saisie.

![image](https://github.com/user-attachments/assets/4336e08f-2f10-4212-abd4-ce0b3c8c8845)
