### PR TITLE
Améliore l'affichage des cartes documents

### DIFF
--- a/core/templates/core/_carte_resume_document.html
+++ b/core/templates/core/_carte_resume_document.html
@@ -20,7 +20,7 @@
         </div>
         {% if not document.is_deleted %}
             <div class="fr-card__footer">
-                <ul class="fr-btns-group fr-btns-group--inline-reverse fr-btns-group--inline-lg">
+                <ul class="fr-btns-group fr-btns-group--inline-reverse fr-btns-group--inline">
                     <li>
                         <a href="#" class="fr-icon-edit-line fr-btn fr-btn--tertiary" data-fr-opened="false" aria-controls="fr-modal-edit-{{ document.pk }}"></a>
                     </li>

--- a/core/templates/core/_documents.html
+++ b/core/templates/core/_documents.html
@@ -22,7 +22,7 @@
     {% if document_filter.qs %}
         <div class="fr-grid-row fr-grid-row--gutters">
             {% for document in document_filter.qs %}
-                <div class="fr-col-3 fr-col-xl-2">
+                <div class="fr-col-12 fr-col-sm-6 fr-col-md-4 fr-col-lg-3">
                     {% include "core/_carte_resume_document.html" %}
                 </div>
             {% endfor %}


### PR DESCRIPTION
Affichage d'un nombre de document dans la liste en fonction de la taille de l'écran : 
- Sur mobile (breakpoint DSFR xs → < 576px) : 1 carte par ligne
- Sur petit écran (breakpoint DSFR sm → ≥ 576px) : 2 cartes par ligne
- Sur écran moyen (breakpoint DSFR md → ≥ 768px) : 3 cartes par ligne
- Sur grand écran (breakpoint DSFR lg et plus → lg : ≥ 992px) : 4 cartes par ligne
