### PR TITLE
Fix affichage commune dans la carte et modal du formulaire Lieu (fiche détection)

### DIFF
--- a/sv/forms.py
+++ b/sv/forms.py
@@ -31,11 +31,21 @@ class EvenementVisibiliteUpdateForm(VisibiliteUpdateBaseForm, forms.ModelForm):
         fields = ["visibilite"]
 
 
+class DepartementModelChoiceField(forms.ModelChoiceField):
+    def prepare_value(self, value):
+        try:
+            if str(value).isdigit():
+                return Departement.objects.get(id=value).numero
+        except Departement.DoesNotExist:
+            pass
+        return super().prepare_value(value)
+
+
 class LieuForm(DSFRForm, WithDataRequiredConversionMixin, forms.ModelForm):
     nom = forms.CharField(widget=forms.TextInput(), required=True)
     commune = forms.CharField(widget=forms.HiddenInput(), required=False)
     code_insee = forms.CharField(widget=forms.HiddenInput(), required=False)
-    departement = forms.ModelChoiceField(
+    departement = DepartementModelChoiceField(
         queryset=Departement.objects.all(),
         to_field_name="numero",
         required=False,

--- a/sv/static/sv/fichedetection_lieux_form.js
+++ b/sv/static/sv/fichedetection_lieux_form.js
@@ -78,7 +78,7 @@ function buildLieuCardFromModal(element){
     return {
         "id": element.dataset.id,
         "nom": element.querySelector(`[id^="id_lieux-"][id$="-nom"]`).value,
-        "commune": element.querySelector(`[id^="commune-select-"]`).value,
+        "commune": element.querySelector(`[id^="id_lieux-"][id$="-commune"]`).value,
     }
 }
 
@@ -102,6 +102,21 @@ function saveLieu(event){
     modal.querySelector(".fr-modal__title").textContent = "Modifier le lieu"
 }
 
+function setupPreselection(choicesCommunes, communeInput, departementInput, inseeInput) {
+    if (communeInput.value) {
+        choicesCommunes.setChoiceByValue(communeInput.value);
+        choicesCommunes.setChoices([{
+            value: communeInput.value,
+            label: `${communeInput.value} (${departementInput.value})`,
+            selected: true,
+            customProperties: {
+                departementCode: departementInput.value,
+                inseeCode: inseeInput.value
+            }
+        }], 'value', 'label', true);
+    }
+}
+
 function setUpCommune(element) {
     const choicesCommunes = new Choices(element, {
         removeItemButton: true,
@@ -114,6 +129,13 @@ function setUpCommune(element) {
         itemSelectText: '',
     });
 
+    const currentModal = element.closest("dialog");
+    const communeInput = currentModal.querySelector('[id$=commune]');
+    const inseeInput = currentModal.querySelector('[id$=code_insee]');
+    const departementInput = currentModal.querySelector('[id$=departement]');
+
+    setupPreselection(choicesCommunes, communeInput, departementInput, inseeInput);
+
     choicesCommunes.input.element.addEventListener('input', function (event) {
         const query = choicesCommunes.input.element.value
         if (query.length > 2) {
@@ -125,10 +147,9 @@ function setUpCommune(element) {
     })
 
     choicesCommunes.passedElement.element.addEventListener("choice", (event)=> {
-        const currentModal = event.target.closest("dialog")
-        currentModal.querySelector('[id$=commune]').value = event.detail.choice.value
-        currentModal.querySelector('[id$=insee]').value = event.detail.choice.customProperties.inseeCode
-        currentModal.querySelector('[id$=departement]').value = event.detail.choice.customProperties.departementCode
+        communeInput.value = event.detail.choice.value
+        inseeInput.value = event.detail.choice.customProperties.inseeCode
+        departementInput.value = event.detail.choice.customProperties.departementCode
     })
 }
 

--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -7,7 +7,7 @@ from playwright.sync_api import Page, expect
 from core.constants import AC_STRUCTURE
 from sv.constants import REGIONS, DEPARTEMENTS, STRUCTURE_EXPLOITANT
 from .test_utils import FicheDetectionFormDomElements, LieuFormDomElements, PrelevementFormDomElements
-from ..factories import FicheDetectionFactory
+from ..factories import FicheDetectionFactory, LieuFactory
 from ..models import (
     FicheDetection,
     Lieu,
@@ -556,6 +556,17 @@ def test_delete_multiple_lieux(
 
     fd = FicheDetection.objects.get(id=fiche_detection_with_two_lieux.id)
     assert fd.lieux.count() == 0
+
+
+def test_commune_display_in_card_and_edit_modal(live_server, page: Page):
+    fiche_detection = FicheDetectionFactory()
+    lieu = LieuFactory(fiche_detection=fiche_detection)
+
+    page.goto(f"{live_server.url}{fiche_detection.get_update_url()}")
+    expect(page.get_by_text(lieu.commune, exact=True)).to_be_visible()
+
+    page.get_by_role("button", name="Modifier le lieu").click()
+    expect(page.get_by_text(f"{lieu.commune} ({lieu.departement.numero})Remove item"))
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Fix: dans le formulaire de modification d’un lieu, lorsqu’il y a une commune enregistrée pour un lieu, elle ne s’affiche pas dans la carte et dans le champ lors de l’ouverture de la modal