### PR TITLE
Améliorer l'interface de cloture d'un événement

### DIFF
--- a/sv/templates/sv/_cloturer_modal.html
+++ b/sv/templates/sv/_cloturer_modal.html
@@ -1,33 +1,34 @@
-<dialog aria-labelledby="fr-modal-cloturer-fiche-title" id="fr-modal-cloturer-fiche" class="fr-modal" role="dialog">
+<dialog aria-labelledby="fr-modal-cloturer-evenement-title" id="fr-modal-cloturer-evenement" class="fr-modal" role="dialog">
     <div class="fr-container fr-container--fluid fr-container-md">
         <div class="fr-grid-row fr-grid-row--center">
             <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
                 <div class="fr-modal__body">
                     <div class="fr-modal__header">
-                        <button class="fr-btn--close fr-btn" aria-controls="fr-modal-cloturer-fiche">Fermer</button>
+                        <button class="fr-btn--close fr-btn" aria-controls="fr-modal-cloturer-evenement">Fermer</button>
                     </div>
                     <div class="fr-modal__content">
-                        <h1 id="fr-modal-cloturer-fiche-title" class="fr-modal__title">
+                        <h1 id="fr-modal-cloturer-evenement-title" class="fr-modal__title">
                             <span class="fr-icon-arrow-right-line fr-icon--lg"></span>
-                            Clôturer une fiche
+                            Clôturer un événement
                         </h1>
-                        {% if can_cloturer_fiche %}
-                            <p>Étes-vous sûr.e de vouloir clôturer la fiche {{ fiche.numero }} ?</p>
+                        {% if can_cloturer_evenement %}
+                            <p>Étes-vous sûr.e de vouloir clôturer l'événement {{ evenement.numero }} ?</p>
                         {% else %}
-                            <p>Vous ne pouvez pas clôturer la fiche n° {{ fiche.numero }} car les structures suivantes n'ont pas signalées la fin de suivi : </p>
+                            <p>Vous ne pouvez pas clôturer l'événement n°{{ evenement.numero }} car les structures suivantes n'ont pas signalées la fin de suivi : </p>
                             <ul>
                                 {% for contact in contacts_not_in_fin_suivi %}
                                     <li>{{ contact.structure }}</li>
                                 {% endfor %}
+                            </ul>
                         {% endif %}
                     </div>
-                    {% if can_cloturer_fiche %}
+                    {% if can_cloturer_evenement %}
                         <div class="fr-modal__footer">
                             <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-cloturer-fiche">
+                                <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-cloturer-evenement">
                                     Annuler
                                 </button>
-                                <form method="post" action="{% url 'fiche-cloturer' evenement.pk %}">
+                                <form method="post" action="{% url 'evenement-cloturer' evenement.pk %}">
                                     {% csrf_token %}
                                     <input type="hidden" name="content_type_id" value="{{ content_type.pk }}">
                                     <button type="submit" class="fr-btn">Confirmer la clôture</button>

--- a/sv/templates/sv/_evenement_action_navigation.html
+++ b/sv/templates/sv/_evenement_action_navigation.html
@@ -21,7 +21,7 @@
                     </li>
 
                     {% if user.agent.structure.is_ac and not evenement.etat.is_cloture %}
-                        <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-cloturer-fiche"><span class="fr-icon-close-circle-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Clôturer l'événement</a></li>
+                        <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-cloturer-evenement"><span class="fr-icon-close-circle-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Clôturer l'événement</a></li>
                     {% endif %}
 
                 {% endif %}

--- a/sv/tests/test_evenement_etats.py
+++ b/sv/tests/test_evenement_etats.py
@@ -107,12 +107,12 @@ def test_can_cloturer_evenement_if_creator_structure_in_fin_suivi(
     page.get_by_role("link", name="Clôturer l'événement").click()
     page.get_by_role("button", name="Confirmer la clôture").click()
 
-    expect(page.get_by_text(f"La fiche n° {evenement.numero} a bien été clôturée.")).to_be_visible()
+    expect(page.get_by_text(f"L'événement n°{evenement.numero} a bien été clôturé.")).to_be_visible()
     expect(page.get_by_text("clôturé", exact=True)).to_be_visible()
     page.get_by_role("button", name="Actions").click()
     expect(page.get_by_role("link", name="Clôturer l'événement")).not_to_be_visible()
     evenement.refresh_from_db()
-    evenement.etat == Etat.objects.get(libelle=Etat.CLOTURE)
+    assert evenement.etat.libelle == Etat.CLOTURE
 
 
 def test_can_cloturer_evenement_if_contacts_structures_in_fin_suivi(
@@ -143,7 +143,6 @@ def test_can_cloturer_evenement_if_contacts_structures_in_fin_suivi(
     assert evenement.etat == Etat.objects.get(libelle=Etat.CLOTURE)
 
 
-@pytest.mark.skip(reason="refacto evenement")
 def test_cannot_cloturer_evenement_if_creator_structure_not_in_fin_suivi(
     live_server, page: Page, mocked_authentification_user, contact_ac: Contact
 ):
@@ -156,14 +155,13 @@ def test_cannot_cloturer_evenement_if_creator_structure_not_in_fin_suivi(
     page.get_by_role("button", name="Actions").click()
     page.get_by_role("link", name="Clôturer l'événement").click()
 
-    expect(page.get_by_label("Clôturer une fiche").get_by_role("paragraph")).to_contain_text(
-        f"Vous ne pouvez pas clôturer la fiche n° {evenement.numero} car les structures suivantes n'ont pas signalées la fin de suivi :"
+    cloturer_element = page.get_by_label("Clôturer un événement")
+    expect(cloturer_element.get_by_role("paragraph")).to_contain_text(
+        f"Vous ne pouvez pas clôturer l'événement n°{evenement.numero} car les structures suivantes n'ont pas signalées la fin de suivi :"
     )
-    expect(page.get_by_label("Clôturer une fiche").get_by_role("listitem")).to_contain_text(
-        contact_ac.structure.libelle
-    )
+    expect(cloturer_element.get_by_role("listitem")).to_contain_text(contact_ac.structure.libelle)
     evenement.refresh_from_db()
-    assert evenement.etat == Etat.objects.get(libelle=Etat.NOUVEAU)
+    assert evenement.etat.libelle == Etat.NOUVEAU
 
 
 @pytest.mark.skip(reason="refacto evenement")
@@ -189,10 +187,12 @@ def test_cannot_cloturer_evenement_if_on_off_contacts_structures_not_in_fin_suiv
     page.get_by_role("button", name="Actions").click()
     page.get_by_role("link", name="Clôturer l'événement").click()
 
-    expect(page.get_by_label("Clôturer une fiche").get_by_role("paragraph")).to_contain_text(
-        f"Vous ne pouvez pas clôturer la fiche n° {evenement.numero} car les structures suivantes n'ont pas signalées la fin de suivi :"
+    expect(page.get_by_label("Clôturer un événement").get_by_role("paragraph")).to_contain_text(
+        f"Vous ne pouvez pas clôturer l'événement n°{evenement.numero} car les structures suivantes n'ont pas signalées la fin de suivi :"
     )
-    expect(page.get_by_label("Clôturer une fiche").get_by_role("listitem")).to_contain_text(contact2.structure.libelle)
+    expect(page.get_by_label("Clôturer un événement").get_by_role("listitem")).to_contain_text(
+        contact2.structure.libelle
+    )
     evenement.refresh_from_db()
     assert evenement.etat == Etat.objects.get(libelle=Etat.NOUVEAU)
 

--- a/sv/urls.py
+++ b/sv/urls.py
@@ -6,7 +6,7 @@ from .views import (
     FicheDetectionCreateView,
     FicheDetectionUpdateView,
     FicheDetectionExportView,
-    FicheCloturerView,
+    EvenementCloturerView,
     EvenementVisibiliteUpdateView,
     FicheZoneDelimiteeCreateView,
     FicheZoneDelimiteeUpdateView,
@@ -40,9 +40,9 @@ urlpatterns = [
         name="fiche-detection-modification",
     ),
     path(
-        "fiches/<int:pk>/cloturer/",
-        FicheCloturerView.as_view(),
-        name="fiche-cloturer",
+        "evenement/<int:pk>/cloturer/",
+        EvenementCloturerView.as_view(),
+        name="evenement-cloturer",
     ),
     path(
         "evenement/<int:pk>/visibilite/",

--- a/sv/views.py
+++ b/sv/views.py
@@ -120,7 +120,7 @@ class EvenementDetailView(
         fin_suivi_contacts_ids = self.get_object().fin_suivi.values_list("contact", flat=True)
         contacts_not_in_fin_suivi = contacts_structure_fiche.exclude(id__in=fin_suivi_contacts_ids)
         context["contacts_not_in_fin_suivi"] = contacts_not_in_fin_suivi
-        context["can_cloturer_fiche"] = len(contacts_not_in_fin_suivi) == 0
+        context["can_cloturer_evenement"] = len(contacts_not_in_fin_suivi) == 0
         return context
 
 
@@ -294,31 +294,31 @@ class FicheDetectionExportView(View):
         return response
 
 
-class FicheCloturerView(View):
+class EvenementCloturerView(View):
     def post(self, request, pk):
         data = self.request.POST
         content_type = ContentType.objects.get(pk=data["content_type_id"]).model_class()
-        fiche = content_type.objects.get(pk=pk)
-        redirect_url = fiche.get_absolute_url()
-        if not fiche.can_be_cloturer_by(request.user):
-            messages.error(request, "Vous n'avez pas les droits pour clôturer cette fiche.")
+        evenement = content_type.objects.get(pk=pk)
+        redirect_url = evenement.get_absolute_url()
+        if not evenement.can_be_cloturer_by(request.user):
+            messages.error(request, "Vous n'avez pas les droits pour clôturer cet événement.")
             return redirect(redirect_url)
-        if fiche.is_already_cloturer():
-            messages.error(request, f"La fiche n° {fiche.numero} est déjà clôturée.")
+        if evenement.is_already_cloturer():
+            messages.error(request, f"L'événement n°{evenement.numero} est déjà clôturé.")
             return redirect(redirect_url)
 
-        contacts_structure_fiche = fiche.contacts.exclude(structure__isnull=True).select_related("structure")
-        fin_suivi_contacts_ids = fiche.fin_suivi.values_list("contact", flat=True)
+        contacts_structure_fiche = evenement.contacts.exclude(structure__isnull=True).select_related("structure")
+        fin_suivi_contacts_ids = evenement.fin_suivi.values_list("contact", flat=True)
         contacts_not_in_fin_suivi = contacts_structure_fiche.exclude(id__in=fin_suivi_contacts_ids)
         if contacts_not_in_fin_suivi:
             messages.error(
                 request,
-                f"La fiche  n° {fiche.numero} ne peut pas être clôturée car les structures suivantes n'ont pas signalées la fin de suivi : {', '.join([str(contact) for contact in contacts_not_in_fin_suivi])}",
+                f"L'événement n°{evenement.numero} ne peut pas être clôturé car les structures suivantes n'ont pas signalées la fin de suivi : {', '.join([str(contact) for contact in contacts_not_in_fin_suivi])}",
             )
             return redirect(redirect_url)
 
-        fiche.cloturer()
-        messages.success(request, f"La fiche n° {fiche.numero} a bien été clôturée.")
+        evenement.cloturer()
+        messages.success(request, f"L'événement n°{evenement.numero} a bien été clôturé.")
         return redirect(redirect_url)
 
 


### PR DESCRIPTION
Corrige le vocabulaire utilisé pour coller au modèle fiche. Remet en place un test existant avant le changement de l'événement.