### PR TITLE
Correction de l'erreur 500 lors de la suppression d'un lieu et d'un prélèvement lié

### DIFF
--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -494,6 +494,36 @@ def test_delete_lieu(
 
 
 @pytest.mark.django_db
+def test_delete_lieu_with_prelevement(
+    live_server,
+    page: Page,
+    fiche_detection_with_one_lieu_and_one_prelevement: FicheDetection,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+):
+    fiche = fiche_detection_with_one_lieu_and_one_prelevement
+    lieu = fiche.lieux.first()
+    lieu_id = lieu.id
+    prelevement_id = lieu.prelevements.first().id
+
+    page.goto(f"{live_server.url}{fiche.get_update_url()}")
+
+    page.locator("ul").filter(has_text="Supprimer le prélèvement").get_by_role("button").nth(1).click()
+    page.locator("#modal-delete-prelevement-confirmation").get_by_role("button", name="Supprimer").click()
+
+    page.get_by_role("button", name="Supprimer le lieu").first.click()
+    page.get_by_role("button", name="Supprimer", exact=True).click()
+
+    form_elements.save_update_btn.click()
+    page.wait_for_timeout(600)
+
+    with pytest.raises(ObjectDoesNotExist):
+        Lieu.objects.get(id=lieu_id)
+    with pytest.raises(ObjectDoesNotExist):
+        Prelevement.objects.get(id=prelevement_id)
+
+
+@pytest.mark.django_db
 def test_delete_one_lieu_from_set_of_lieux(
     live_server,
     page: Page,

--- a/sv/view_mixins.py
+++ b/sv/view_mixins.py
@@ -43,8 +43,13 @@ class WithPrelevementHandlingMixin:
             form_is_empty = not any(form_data.values())
 
             if form_is_empty and prelevement_id:
-                prelevement = Prelevement.objects.get(id=prelevement_id)
-                prelevement.delete()
+                try:
+                    # Cas 1 : Suppression d'un prélèvement uniquement (le lieu n'est pas supprimé)
+                    prelevement = Prelevement.objects.get(id=prelevement_id)
+                    prelevement.delete()
+                except Prelevement.DoesNotExist:
+                    # Cas 2 : Le prélèvement a déjà été supprimé car son lieu a été supprimé (cascade)
+                    pass
                 continue
 
             if prelevement_id:


### PR DESCRIPTION
## Problème
Lors de la modification d'une fiche de détection, une erreur 500 apparaît dans le cas suivant :
- Je modifie une fiche
- Je supprime un prélèvement
- Je supprime son lieu associé
- Je sauvegarde les modifications

L'erreur se produit car nous essayons de supprimer un prélèvement qui n'existe plus (il a déjà été supprimé au moment de la suppression du lieu à cause de la cascade).

## Solution
Ajout d'un try/except dans la méthode `_save_prelevement_if_not_empty` du `WithPrelevementHandlingMixin` pour gérer deux scénarios de suppression :
1. L'utilisateur supprime uniquement un prélèvement (le lieu n'est pas supprimé)
2. L'utilisateur supprime un lieu, ce qui entraîne la suppression en cascade de ses prélèvements

Lorsque le prélèvement a déjà été supprimé via la cascade, nous ignorons l'exception DoesNotExist car c'est un comportement attendu.

Ajout du test `test_delete_lieu_with_prelevement`.

Ticket Notion : https://www.notion.so/incubateur-masa/BUG-Modification-de-la-fiche-17-169de24614be8017a2ffdad71800ec38?pvs=4