### PR TITLE
Reprise de la modale de visualisation d'un prélèvement

### DIFF
--- a/sv/templates/sv/fichedetection_detail_prelevement.html
+++ b/sv/templates/sv/fichedetection_detail_prelevement.html
@@ -12,8 +12,35 @@
                         </div>
                         <div class="fr-grid-row fr-mb-2w">
                             <div class="fr-col-offset-1"></div>
-                            <div class="fr-col-5 detail-prelevement__label">Type de prélèvement</div>
-                            <div class="fr-col-6 {% if prelevement.is_officiel %}fr-icon-check-line{% endif %}" data-testid="prelevement-{{prelevement_index}}-type">Prélèvement {% if prelevement.is_officiel %}officiel{% else %}non officiel{% endif %}</div>
+                            <div class="fr-col-5 detail-prelevement__label">Type</div>
+                            <div class="fr-col-6" data-testid="prelevement-{{prelevement_index}}-type-analyse">{{prelevement.get_type_analyse_display}}</div>
+                        </div>
+                        <div class="fr-grid-row fr-mb-2w">
+                            <div class="fr-col-offset-1"></div>
+                            <div class="fr-col-5 detail-prelevement__label">Prélèvement officiel</div>
+                            <div class="fr-col-6 {% if prelevement.is_officiel %}fr-icon-check-line{% endif %}" data-testid="prelevement-{{prelevement_index}}-is-officiel">
+                                {{ prelevement.is_officiel|yesno:"oui,non" }}
+                            </div>
+                        </div>
+                        <div class="fr-grid-row fr-mb-2w">
+                            <div class="fr-col-offset-1"></div>
+                            <div class="fr-col-5 detail-prelevement__label">N° RI</div>
+                            <div class="fr-col-6" data-testid="prelevement-{{prelevement_index}}-numero-rapport-inspection">{{prelevement.numero_rapport_inspection|default:"nc."}}</div>
+                        </div>
+                        <div class="fr-grid-row fr-mb-2w">
+                            <div class="fr-col-offset-1"></div>
+                            <div class="fr-col-5 detail-prelevement__label">Laboratoire</div>
+                            <div class="fr-col-6" data-testid="prelevement-{{prelevement_index}}-laboratoire">{{prelevement.laboratoire|default:"nc."}}</div>
+                        </div>
+                        <div class="fr-grid-row fr-mb-2w">
+                            <div class="fr-col-offset-1"></div>
+                            <div class="fr-col-5 detail-prelevement__label">N° d'échantillon</div>
+                            <div class="fr-col-6" data-testid="prelevement-{{prelevement_index}}-numero-echantillon">{{prelevement.numero_echantillon|default:"nc."}}</div>
+                        </div>
+                        <div class="fr-grid-row fr-mb-2w">
+                            <div class="fr-col-offset-1"></div>
+                            <div class="fr-col-5 detail-prelevement__label">Lieu</div>
+                            <div class="fr-col-6" data-testid="prelevement-{{prelevement_index}}-lieu">{{prelevement.lieu}}</div>
                         </div>
                         <div class="fr-grid-row fr-mb-2w">
                             <div class="fr-col-offset-1"></div>
@@ -22,17 +49,12 @@
                         </div>
                         <div class="fr-grid-row fr-mb-2w">
                             <div class="fr-col-offset-1"></div>
-                            <div class="fr-col-5 detail-prelevement__label">Numéro d'échantillon</div>
-                            <div class="fr-col-6" data-testid="prelevement-{{prelevement_index}}-numero-echantillon">{{prelevement.numero_echantillon|default:"nc."}}</div>
-                        </div>
-                        <div class="fr-grid-row fr-mb-2w">
-                            <div class="fr-col-offset-1"></div>
                             <div class="fr-col-5 detail-prelevement__label">Date de prélèvement</div>
                             <div class="fr-col-6" data-testid="prelevement-{{prelevement_index}}-date-prelevement">{{prelevement.date_prelevement|date:"d/m/Y"|default:"nc."}}</div>
                         </div>
                         <div class="fr-grid-row fr-mb-2w">
                             <div class="fr-col-offset-1"></div>
-                            <div class="fr-col-5 detail-prelevement__label">Matrice prélevée</div>
+                            <div class="fr-col-5 detail-prelevement__label">Nature de l'objet</div>
                             <div class="fr-col-6" data-testid="prelevement-{{prelevement_index}}-matrice-prelevee">{{prelevement.matrice_prelevee|default:"nc."}}</div>
                         </div>
                         <div class="fr-grid-row fr-mb-2w">
@@ -47,26 +69,9 @@
                         </div>
                         <div class="fr-grid-row fr-mb-2w">
                             <div class="fr-col-offset-1"></div>
-                            <div class="fr-col-5 detail-prelevement__label">Résultat</div>
+                            <div class="fr-col-5 detail-prelevement__label">Conclusion</div>
                             <div class="fr-col-6" data-testid="prelevement-{{prelevement_index}}-resultat">{{prelevement.get_resultat_display|default:"nc."}}</div>
                         </div>
-                        <div class="fr-grid-row fr-mb-2w">
-                            <div class="fr-col-offset-1"></div>
-                            <div class="fr-col-5 detail-prelevement__label">Type d'analyse</div>
-                            <div class="fr-col-6" data-testid="prelevement-{{prelevement_index}}-type-analyse">{{prelevement.get_type_analyse_display|default:"nc."}}</div>
-                        </div>
-                        <div class="fr-grid-row fr-mb-2w">
-                            <div class="fr-col-offset-1"></div>
-                            <div class="fr-col-5 detail-prelevement__label">Laboratoire</div>
-                            <div class="fr-col-6" data-testid="prelevement-{{prelevement_index}}-laboratoire">{{prelevement.laboratoire|default:"nc."}}</div>
-                        </div>
-                        {% if prelevement.is_officiel %}
-                            <div class="fr-grid-row fr-mb-2w">
-                                <div class="fr-col-offset-1"></div>
-                                <div class="fr-col-5 detail-prelevement__label">Numéro Rapport d'inspection</div>
-                                <div class="fr-col-6" data-testid="prelevement-{{prelevement_index}}-numero-rapport-inspection">{{prelevement.numero_rapport_inspection|default:"nc."}}</div>
-                            </div>
-                        {% endif %}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Reprise de la modale de visualisation d'un prélèvement pour que les champs soient dans l’ordre du formulaire et avec les mêmes noms.
J'ai supprimé le test `test_prelevement_non_officiel_details` car redondant avec `test_prelevement_details`.
Utilisation des factory dans `test_prelevement_non_officiel_details_second_prelevement`.