### PR TITLE
Gestion du swith détail/synthèse sur la page détail de la fiche évènement

### DIFF
--- a/sv/static/sv/evenement_details.js
+++ b/sv/static/sv/evenement_details.js
@@ -12,8 +12,21 @@ function showOnlyActionsForDetection(detectionId){
     )
 }
 
+function toggleViewMode(event) {
+    const detailContent = document.getElementById('detail-content');
+    const viewMode = event.target.value;
+    detailContent.classList.toggle('fr-hidden', viewMode === 'synthese');
+}
+
+function initViewModeButtons() {
+    const detailBtn = document.getElementById('detail-btn');
+    const syntheseBtn = document.getElementById('synthese-btn');
+    detailBtn.addEventListener('change', toggleViewMode);
+    syntheseBtn.addEventListener('change', toggleViewMode);
+}
 
 document.addEventListener('DOMContentLoaded', function() {
+    initViewModeButtons();
     document.querySelectorAll(".no-tab-look .fr-tabs__panel").forEach(element =>{
         element.addEventListener('dsfr.conceal', event=>{
             const tabId = event.explicitOriginalTarget.getAttribute("id").replace("tabpanel-", "").replace("-panel", "")

--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -24,11 +24,11 @@
                     <fieldset class="fr-segmented">
                         <div class="fr-segmented__elements">
                             <div class="fr-segmented__element">
-                                <input value="1" checked type="radio" id="detail-btn" name="segmented-2215">
+                                <input value="detail" checked type="radio" id="detail-btn" name="segmented-2215">
                                 <label class="fr-label" for="detail-btn"><i class="ri-expand-vertical-fill fr-mr-1w"></i>Détail</label>
                             </div>
                             <div class="fr-segmented__element">
-                                <input value="2" type="radio" id="synthese-btn" name="segmented-2215">
+                                <input value="synthese" type="radio" id="synthese-btn" name="segmented-2215">
                                 <label class="fr-label" for="synthese-btn"><i class="ri-collapse-vertical-fill fr-mr-1w"></i>Synthèse</label>
                             </div>
                         </div>
@@ -59,58 +59,61 @@
             </div>
         </div>
 
-        <div class="fr-tabs">
-            <ul class="fr-tabs__list" role="tablist" aria-label="Navigation entre zone et détections">
-                <li role="presentation">
-                    <button id="tabpanel-404" class="fr-tabs__tab" tabindex="0" role="tab" aria-selected="true" aria-controls="tabpanel-404-panel">Détections</button>
-                </li>
-                <li role="presentation">
-                    <button id="tabpanel-405" class="fr-tabs__tab" tabindex="-1" role="tab" aria-selected="false" aria-controls="tabpanel-405-panel">Zone</button>
-                </li>
-            </ul>
-            <div id="tabpanel-404-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-404" tabindex="0">
-                <div>
-                    <div class="fr-tabs no-tab-look">
-                        <ul class="fr-tabs__list fr-mb-2v" role="tablist" aria-label="Liste des détection">
+        <div id="detail-content">
+            <div class="fr-tabs">
+                <ul class="fr-tabs__list" role="tablist" aria-label="Navigation entre zone et détections">
+                    <li role="presentation">
+                        <button id="tabpanel-404" class="fr-tabs__tab" tabindex="0" role="tab" aria-selected="true" aria-controls="tabpanel-404-panel">Détections</button>
+                    </li>
+                    <li role="presentation">
+                        <button id="tabpanel-405" class="fr-tabs__tab" tabindex="-1" role="tab" aria-selected="false" aria-controls="tabpanel-405-panel">Zone</button>
+                    </li>
+                </ul>
+                <div id="tabpanel-404-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-404" tabindex="0">
+                    <div>
+                        <div class="fr-tabs no-tab-look">
+                            <ul class="fr-tabs__list fr-mb-2v" role="tablist" aria-label="Liste des détection">
+                                {% for fichedetection in evenement.detections.all %}
+                                    <li role="presentation">
+                                        <button id="tabpanel-{{ fichedetection.pk }}" class="fr-tag fr-mx-1w" tabindex="0" role="tab" aria-selected="true" aria-controls="tabpanel-{{ fichedetection.pk }}-panel">{{ fichedetection }}</button>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+
                             {% for fichedetection in evenement.detections.all %}
-                                <li role="presentation">
-                                    <button id="tabpanel-{{ fichedetection.pk }}" class="fr-tag fr-mx-1w" tabindex="0" role="tab" aria-selected="true" aria-controls="tabpanel-{{ fichedetection.pk }}-panel">{{ fichedetection }}</button>
-                                </li>
+                                <div id="detection-actions-{{ fichedetection.pk }}" {% if not forloop.first %}class="fr-hidden"{% endif %}>
+                                    <button class="fr-btn fr-btn--delete fr-mr-2w" data-fr-opened="false" aria-controls="fr-modal-delete-detection-{{ fichedetection.pk }}">
+                                        Supprimer la détection
+                                    </button>
+                                    {% include "sv/_delete_fiche_modal.html" with prefix="detection" content_type=fiche_detection_content_type object_pk=fichedetection.pk %}
+                                    <button class="fr-btn fr-btn--secondary fr-mr-2w">
+                                        <a href="{% url 'fiche-detection-modification' fichedetection.pk %}"><span class="fr-icon-edit-fill">Modifier</span></a>
+                                    </button>
+                                </div>
                             {% endfor %}
-                        </ul>
-
-                        {% for fichedetection in evenement.detections.all %}
-                            <div id="detection-actions-{{ fichedetection.pk }}" {% if not forloop.first %}class="fr-hidden"{% endif %}>
-                                <button class="fr-btn fr-btn--delete fr-mr-2w" data-fr-opened="false" aria-controls="fr-modal-delete-detection-{{ fichedetection.pk }}">
-                                    Supprimer la détection
-                                </button>
-                                {% include "sv/_delete_fiche_modal.html" with prefix="detection" content_type=fiche_detection_content_type object_pk=fichedetection.pk %}
-                                <button class="fr-btn fr-btn--secondary fr-mr-2w">
-                                    <a href="{% url 'fiche-detection-modification' fichedetection.pk %}"><span class="fr-icon-edit-fill">Modifier</span></a>
-                                </button>
-                            </div>
-                        {% endfor %}
 
 
-                        {% for fichedetection in evenement.detections.all %}
-                            <div id="tabpanel-{{ fichedetection.pk }}-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-{{ fichedetection.pk }}" tabindex="0">
-                                {% include "sv/_fichedetection_detail.html" %}
-                            </div>
-                        {% endfor %}
+                            {% for fichedetection in evenement.detections.all %}
+                                <div id="tabpanel-{{ fichedetection.pk }}-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-{{ fichedetection.pk }}" tabindex="0">
+                                    {% include "sv/_fichedetection_detail.html" %}
+                                </div>
+                            {% endfor %}
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div id="tabpanel-405-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-405" tabindex="0">
-                {% if evenement.fiche_zone_delimitee %}
-                    {% include "sv/fichezonedelimitee_detail.html" with fiche=evenement.fiche_zone_delimitee %}
-                {% else %}
-                    Il n'y a pas de zone délimitée pour cet événement
+                <div id="tabpanel-405-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-405" tabindex="0">
+                    {% if evenement.fiche_zone_delimitee %}
+                        {% include "sv/fichezonedelimitee_detail.html" with fiche=evenement.fiche_zone_delimitee %}
+                    {% else %}
+                        Il n'y a pas de zone délimitée pour cet événement
 
-                {% endif %}
+                    {% endif %}
+                </div>
             </div>
+
+            {% include "sv/_list_free_links.html" with classes="fr-mt-8v" object=evenement %}
         </div>
 
-        {% include "sv/_list_free_links.html" with classes="fr-mt-8v" object=evenement %}
         {% if not evenement.is_draft %}
             {% include "core/_fiche_bloc_commun.html" %}
         {% endif %}

--- a/sv/tests/test_evenement_details.py
+++ b/sv/tests/test_evenement_details.py
@@ -1,7 +1,7 @@
 from playwright.sync_api import expect, Page
 
 from core.models import Visibilite
-from sv.factories import EvenementFactory, FicheZoneFactory
+from sv.factories import EvenementFactory, FicheZoneFactory, FicheDetectionFactory
 
 
 def test_cant_add_zone_if_already_one(live_server, page: Page):
@@ -24,3 +24,21 @@ def test_can_publish_evenement(live_server, page: Page):
     page.get_by_role("button", name="Actions").click()
     publish_btn = page.get_by_text("Publier l'événement", exact=True)
     expect(publish_btn).not_to_be_visible()
+
+
+def test_detail_synthese_switch(live_server, page):
+    evenement = EvenementFactory()
+    FicheDetectionFactory(evenement=evenement)
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+
+    detail_radio = page.locator("#detail-btn")
+    expect(detail_radio).to_be_checked()
+    detail_content = page.locator("#detail-content")
+    expect(detail_content).to_be_visible()
+
+    synthese_radio = page.locator("#synthese-btn")
+    synthese_radio.click(force=True)
+    expect(detail_content).to_be_hidden()
+
+    detail_radio.click(force=True)
+    expect(detail_content).to_be_visible()


### PR DESCRIPTION
Cette PR ajoute la possibilité de basculer entre une vue détaillée et une vue synthétique sur le détail de la fiche évènement.