### PR TITLE
Ajoute la gestion du cas HECTARE dans la sélection des unités de surface (fix un test qui fail en CI)

### DIFF
--- a/sv/tests/test_utils.py
+++ b/sv/tests/test_utils.py
@@ -378,6 +378,7 @@ class FicheZoneDelimiteeFormPage:
         self.surface_tampon_totale = page.get_by_label("Surface tampon totale")
         self.surface_tampon_totale_unite_m2 = page.get_by_label("m2", exact=True).first
         self.surface_tampon_totale_unite_km2 = page.get_by_label("km2", exact=True).first
+        self.surface_tampon_totale_unite_ha = page.get_by_label("ha", exact=True).first
 
         # Détections hors zone infestée
         self.detections_hors_zone_infestee = page.locator(
@@ -415,6 +416,8 @@ class FicheZoneDelimiteeFormPage:
                 self.surface_tampon_totale_unite_m2.click(force=True)
             case FicheZoneDelimitee.UnitesSurfaceTamponTolale.KILOMETRE_CARRE:
                 self.surface_tampon_totale_unite_km2.click(force=True)
+            case FicheZoneDelimitee.UnitesSurfaceTamponTolale.HECTARE:
+                self.surface_tampon_totale_unite_ha.click(force=True)
 
     def _select_unite_surface_infestee_totale(self, unite: ZoneInfestee.UnitesSurfaceInfesteeTotale, index: int):
         match unite:


### PR DESCRIPTION
## Description
Correction d'un test instable qui échouait en CI uniquement. Le test `test_fichezonedelimitee_update_without_zone_infestee_form_submit` échouait de manière aléatoire lorsque la factory générait `HECTARE` comme unité de surface via `FuzzyChoice`.

## Problème
La méthode `_select_unite_surface_tampon_totale` ne gérait pas le cas où l'unité de surface était en hectares dans son pattern matching, alors que cette valeur pouvait être générée par la factory.

## Solution
Ajout du cas `HECTARE` dans le pattern matching de la méthode `_select_unite_surface_tampon_totale`.
