### PR TITLE
Persistance du mode d'affichage (détail/synthèse) sur le détail de la fiche Évènement

### DIFF
--- a/sv/static/sv/evenement_details.js
+++ b/sv/static/sv/evenement_details.js
@@ -1,3 +1,5 @@
+import {ViewManager, evenementViewModeConfig} from './view_manager.js';
+
 function showOnlyActionsForDetection(detectionId){
     document.querySelectorAll('[id^="detection-actions-"]').forEach(actionElement =>{
 
@@ -12,21 +14,10 @@ function showOnlyActionsForDetection(detectionId){
     )
 }
 
-function toggleViewMode(event) {
-    const detailContent = document.getElementById('detail-content');
-    const viewMode = event.target.value;
-    detailContent.classList.toggle('fr-hidden', viewMode === 'synthese');
-}
-
-function initViewModeButtons() {
-    const detailBtn = document.getElementById('detail-btn');
-    const syntheseBtn = document.getElementById('synthese-btn');
-    detailBtn.addEventListener('change', toggleViewMode);
-    syntheseBtn.addEventListener('change', toggleViewMode);
-}
-
 document.addEventListener('DOMContentLoaded', function() {
-    initViewModeButtons();
+    const viewManager = new ViewManager(evenementViewModeConfig);
+    viewManager.initialize();
+
     document.querySelectorAll(".no-tab-look .fr-tabs__panel").forEach(element =>{
         element.addEventListener('dsfr.conceal', event=>{
             const tabId = event.explicitOriginalTarget.getAttribute("id").replace("tabpanel-", "").replace("-panel", "")

--- a/sv/static/sv/view_manager.js
+++ b/sv/static/sv/view_manager.js
@@ -1,0 +1,85 @@
+export class ViewManager {
+    #config;
+    #elements = {};
+
+    constructor(config) {
+        this.#validateConfig(config);
+        this.#config = { ...config };
+    }
+
+    #validateConfig(config) {
+        const requiredFields = ['storageKeyPrefix', 'modes', 'selectors'];
+        requiredFields.forEach(field => {
+            if (!config[field]) {
+                throw new Error(`Missing required config field: ${field}`);
+            }
+        });
+    }
+
+    #getFicheId() {
+        return this.#elements.ficheContainer.dataset.ficheId;
+    }
+
+    #getElements() {
+        this.#elements = {
+            detailBtn: document.getElementById(this.#config.selectors.DETAIL_BTN),
+            syntheseBtn: document.getElementById(this.#config.selectors.SYNTHESE_BTN),
+            detailContent: document.getElementById(this.#config.selectors.DETAIL_CONTENT),
+            ficheContainer: document.querySelector('[data-fiche-id]')
+        };
+    }
+
+    #getStorageKey(id) {
+        return `${this.#config.storageKeyPrefix}_${id}`;
+    }
+
+    #save(mode, id) {
+        localStorage.setItem(this.#getStorageKey(id), mode);
+    }
+
+    #get(id) {
+        return localStorage.getItem(this.#getStorageKey(id));
+    }
+
+    #toggleView(mode) {
+        this.#save(mode, this.#getFicheId());
+        this.#elements.detailContent.classList.toggle('fr-hidden', mode === this.#config.modes.SYNTHESE);
+    }
+
+    #initViewState() {
+        const savedViewMode = this.#get(this.#getFicheId());
+        const isSynthese = savedViewMode === this.#config.modes.SYNTHESE;
+
+        this.#elements.detailBtn.checked = !isSynthese;
+        this.#elements.syntheseBtn.checked = isSynthese;
+        this.#elements.detailContent.classList.toggle('fr-hidden', isSynthese);
+    }
+
+    #initViewModeButtons() {
+        this.#elements.detailBtn.addEventListener('change', this.#handleViewToggle);
+        this.#elements.syntheseBtn.addEventListener('change', this.#handleViewToggle);
+    }
+
+    #handleViewToggle = (event) => {
+        this.#toggleView(event.target.value);
+    }
+
+    initialize() {
+        this.#getElements();
+        this.#initViewState();
+        this.#initViewModeButtons();
+    }
+}
+
+export const evenementViewModeConfig = {
+    storageKeyPrefix: 'evenementViewMode',
+    modes: {
+        DETAIL: 'detail',
+        SYNTHESE: 'synthese'
+    },
+    selectors: {
+        DETAIL_BTN: 'detail-btn',
+        SYNTHESE_BTN: 'synthese-btn',
+        DETAIL_CONTENT: 'detail-content'
+    }
+};

--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript" src="{% static 'sv/evenement_details.js' %}"></script>
+    <script type="module" src="{% static 'sv/evenement_details.js' %}"></script>
 {% endblock %}
 
 {% block content %}
@@ -20,7 +20,7 @@
             <div class="evenement-top-row">
                 <h1 class="fr-mb-0-5v">Événement {% if evenement.numero %}{{ evenement.numero }}{%  endif %}</h1>
 
-                <div>
+                <div data-fiche-id="{{ evenement.pk }}">
                     <fieldset class="fr-segmented">
                         <div class="fr-segmented__elements">
                             <div class="fr-segmented__element">

--- a/sv/tests/test_evenement_details.py
+++ b/sv/tests/test_evenement_details.py
@@ -110,3 +110,38 @@ def test_evenement_can_view_basic_data(live_server, page: Page):
     expect(page.get_by_text(evenement.organisme_nuisible.code_oepp)).to_be_visible()
     expect(page.get_by_text(evenement.statut_reglementaire.libelle)).to_be_visible()
     expect(page.get_by_text("Dernière mise à jour le ")).to_be_visible()
+
+
+def test_view_mode_default_is_detail(live_server, page):
+    fiche_detection = FicheDetectionFactory()
+    page.goto(f"{live_server.url}{fiche_detection.evenement.get_absolute_url()}")
+    expect(page.locator("#detail-btn")).to_be_checked()
+    expect(page.locator("#detail-content")).to_be_visible()
+
+
+def test_view_mode_persistence_per_fiche(live_server, page):
+    evenement1 = EvenementFactory()
+    evenement2 = EvenementFactory()
+    FicheDetectionFactory(evenement=evenement1)
+    FicheDetectionFactory(evenement=evenement2)
+
+    # Changer en mode synthèse pour le premier événement
+    page.goto(f"{live_server.url}{evenement1.get_absolute_url()}")
+    detail_content1 = page.locator("#detail-content")
+    synthese_radio1 = page.locator("#synthese-btn")
+    synthese_radio1.click(force=True)
+    expect(detail_content1).to_be_hidden()
+
+    # Vérifier que le second événement n'est pas impacté
+    page.goto(f"{live_server.url}{evenement2.get_absolute_url()}")
+    detail_radio2 = page.locator("#detail-btn")
+    detail_content2 = page.locator("#detail-content")
+    expect(detail_radio2).to_be_checked()
+    expect(detail_content2).to_be_visible()
+
+    # Revenir au premier événement et vérifier la persistance
+    page.goto(f"{live_server.url}{evenement1.get_absolute_url()}")
+    detail_content1 = page.locator("#detail-content")
+    synthese_radio1 = page.locator("#synthese-btn")
+    expect(synthese_radio1).to_be_checked()
+    expect(detail_content1).to_be_hidden()


### PR DESCRIPTION
## Fonctionnalités implémentées
- Persistance du choix de vue pour chaque fiche événement via localStorage
- Restauration automatique du dernier mode de vue utilisé pour chaque fiche
- Mode détail par défaut pour les nouvelles fiches

## Tests ajoutés
- Test du mode par défaut (détail)
- Test de la persistance du choix pour chaque fiche
- Test de la conservation des préférences après navigation
- Test du rechargement de page

## Technique
Le code a été réorganisé et encapsulé dans un module JS réutilisable (`ViewManager`) qui gère la logique de persistance et le changement de vue, avec une API publique réduite à l'initialisation.