### PR TITLE
Suivre les modifications sur l'événement de la fiche Zone

### DIFF
--- a/core/versions.py
+++ b/core/versions.py
@@ -1,0 +1,9 @@
+from django.contrib.contenttypes.models import ContentType
+from reversion.models import Version
+
+
+def get_versions_from_ids(ids, model):
+    if not ids:
+        return []
+    content_type = ContentType.objects.get_for_model(model)
+    return Version.objects.select_related("revision").filter(content_type=content_type, object_id__in=list(ids))

--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -49,6 +49,14 @@
                 </div>
             </div>
             {% include "sv/_evenement_badges.html" %}
+            {% if latest_version %}
+                <div class="fr-pl-1v fr-mt-2v">
+                    Dernière mise à jour le {{ latest_version.revision.date_created }}
+                    {% if latest_version.revision.user %}
+                        par {{ latest_version.revision.user.agent.agent_with_structure }}
+                    {% endif %}
+                </div>
+            {% endif %}
         </div>
 
         <div class="fr-container--fluid">

--- a/sv/tests/test_evenement_details.py
+++ b/sv/tests/test_evenement_details.py
@@ -99,3 +99,14 @@ def test_delete_evenement_will_delete_associated_detections(live_server, page):
     fiche_not_deleted = FicheDetection.objects.get()
     assert fiche_not_deleted == fiche_detection
     assert FicheDetection._base_manager.filter(evenement=evenement).count() == 3
+
+
+def test_evenement_can_view_basic_data(live_server, page: Page):
+    evenement = EvenementFactory()
+    FicheDetectionFactory(evenement=evenement)
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+
+    expect(page.get_by_text(evenement.organisme_nuisible.libelle_court)).to_be_visible()
+    expect(page.get_by_text(evenement.organisme_nuisible.code_oepp)).to_be_visible()
+    expect(page.get_by_text(evenement.statut_reglementaire.libelle)).to_be_visible()
+    expect(page.get_by_text("Dernière mise à jour le ")).to_be_visible()

--- a/sv/tests/test_evenement_performance_details.py
+++ b/sv/tests/test_evenement_performance_details.py
@@ -5,7 +5,7 @@ from core.models import Message, Document, Structure, Contact
 from sv.factories import EvenementFactory, FicheDetectionFactory, PrelevementFactory, FicheZoneFactory
 from sv.models import Lieu, ZoneInfestee
 
-BASE_NUM_QUERIES = 16  # Please note a first call is made without assertion to warm up any possible cache
+BASE_NUM_QUERIES = 17  # Please note a first call is made without assertion to warm up any possible cache
 
 
 @pytest.mark.django_db
@@ -47,11 +47,11 @@ def test_evenement_performances_with_lieux(client, django_assert_num_queries):
     fiche_detection = FicheDetectionFactory(evenement=evenement)
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 3):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 6):
         client.get(evenement.get_absolute_url())
 
     baker.make(Lieu, fiche_detection=fiche_detection, _quantity=3, _fill_optional=True)
-    with django_assert_num_queries(BASE_NUM_QUERIES + 8):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 12):
         client.get(evenement.get_absolute_url())
 
 
@@ -75,12 +75,12 @@ def test_evenement_performances_with_prelevement(client, django_assert_num_queri
     fiche_detection = FicheDetectionFactory(evenement=evenement)
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 3):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 6):
         client.get(evenement.get_absolute_url())
 
     PrelevementFactory.create_batch(3, lieu__fiche_detection=fiche_detection)
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 6):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 11):
         client.get(evenement.get_absolute_url())
 
 
@@ -123,5 +123,5 @@ def test_fiche_zone_delimitee_with_multiple_zone_infestee(
 
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 16):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 28):
         client.get(evenement.get_absolute_url())

--- a/sv/views.py
+++ b/sv/views.py
@@ -128,6 +128,7 @@ class EvenementDetailView(
         context["fiche_zone_content_type"] = ContentType.objects.get_for_model(FicheZoneDelimitee)
         context["can_update_visibilite"] = self.get_object().can_update_visibilite(self.request.user)
         context["can_be_cloturer"] = self.object.can_be_cloturer_by(self.request.user)
+        context["latest_version"] = self.object.latest_version
         fiche_zone = self.get_object().fiche_zone_delimitee
         if fiche_zone:
             context["detections_hors_zone_infestee"] = fiche_zone.fichedetection_set.select_related("numero").all()


### PR DESCRIPTION
Permet de suivre les modifications d'un objets et des objets liés pour l'événement et la fiche zone. Affiche la dernière modification sur la page de l'événement.