### PR TITLE
Ajout automatique de la structure lors de l'ajout d'un agent

### DIFF
--- a/core/factories.py
+++ b/core/factories.py
@@ -56,8 +56,8 @@ class AgentFactory(DjangoModelFactory):
             "",
         ]
     )
-    telephone = factory.Faker("phone_number")
-    mobile = factory.Faker("phone_number")
+    telephone = factory.Faker("phone_number", locale="fr_FR")
+    mobile = factory.Faker("phone_number", locale="fr_FR")
 
 
 class ContactAgentFactory(DjangoModelFactory):

--- a/core/models.py
+++ b/core/models.py
@@ -103,6 +103,11 @@ class Contact(models.Model):
             str(self.structure) if self.structure else f"{self.agent.nom} {self.agent.prenom} ({self.agent.structure})"
         )
 
+    def get_structure_contact(self):
+        """Retourne le contact de la structure associée si ce contact est lié à un agent."""
+        if self.agent:
+            return self.agent.structure.contact_set.first()
+
 
 class FinSuiviContact(models.Model):
     content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)

--- a/core/views.py
+++ b/core/views.py
@@ -146,6 +146,8 @@ class ContactSelectionView(PreventActionIfVisibiliteBrouillonMixin, FormView):
         contacts = form.cleaned_data["contacts"]
         for contact in contacts:
             fiche.contacts.add(contact)
+            if structure_contact := contact.get_structure_contact():
+                fiche.contacts.add(structure_contact)
 
         message = ngettext(
             "Le contact a été ajouté avec succès.", "Les %(count)d contacts ont été ajoutés avec succès.", len(contacts)


### PR DESCRIPTION
## Description
Sur une fiche évènement, lorsqu'un agent est ajouté comme contact d'une fiche, sa structure est automatiquement ajouté à la liste des contacts.

## Changements
- Ajout de la méthode `get_structure_contact()` sur le modèle `Contact`
- Modification du `form_valid()` pour ajouter le contact structure automatiquement
- Ajout de tests pour vérifier :
  - L'ajout du contact structure lors de l'ajout d'un contact agent (`test_add_agent_contact_adds_structure_contact`)
  - La non-duplication du contact structure lors de l'ajout de plusieurs agents de la même structure (`test_add_multiple_agent_contacts_adds_structure_contact_once`)
  - Ajout du formatage français des numéros de téléphone dans `AgentFactory` pour générer des numéros au format français plutôt que des séquences arbitraires.
