### PR TITLE
Réintégrer des tests dans la suite de tests

### DIFF
--- a/sv/tests/test_evenement_etats.py
+++ b/sv/tests/test_evenement_etats.py
@@ -164,7 +164,6 @@ def test_cannot_cloturer_evenement_if_creator_structure_not_in_fin_suivi(
     assert evenement.etat.libelle == Etat.NOUVEAU
 
 
-@pytest.mark.skip(reason="refacto evenement")
 def test_cannot_cloturer_evenement_if_on_off_contacts_structures_not_in_fin_suivi(
     live_server, page: Page, mocked_authentification_user, contact_ac: Contact
 ):

--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -133,7 +133,6 @@ def test_fiche_detection_update_page_content_with_no_data(
     expect(form_elements.mesures_surveillance_specifique_input).to_have_value("")
 
 
-@pytest.mark.skip(reason="refacto evenement")
 @pytest.mark.django_db
 def test_fiche_detection_update_without_lieux_and_prelevement(
     live_server,
@@ -145,7 +144,6 @@ def test_fiche_detection_update_without_lieux_and_prelevement(
     choice_js_fill,
 ):
     """Test que les modifications des informations, objet de l'évènement et mesures de gestion sont bien enregistrées en base de données apès modification."""
-    organisme = baker.make(OrganismeNuisible)
     new_fiche_detection = fiche_detection_bakery()
     new_fiche_detection.organisme_nuisible = baker.make(OrganismeNuisible)
     new_fiche_detection.save()
@@ -153,9 +151,6 @@ def test_fiche_detection_update_without_lieux_and_prelevement(
     page.goto(f"{live_server.url}{fiche_detection.get_update_url()}")
     form_elements.statut_evenement_input.select_option(str(new_fiche_detection.statut_evenement.id))
 
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", organisme.libelle_court, organisme.libelle_court)
-
-    form_elements.statut_reglementaire_input.select_option(str(new_fiche_detection.statut_reglementaire.id))
     form_elements.contexte_input.select_option(str(new_fiche_detection.contexte.id))
     form_elements.date_1er_signalement_input.fill(new_fiche_detection.date_premier_signalement.strftime("%Y-%m-%d"))
     form_elements.commentaire_input.fill(new_fiche_detection.commentaire)
@@ -172,8 +167,6 @@ def test_fiche_detection_update_without_lieux_and_prelevement(
         fiche_detection_updated.createur == fiche_detection.createur
     )  # le createur ne doit pas changer lors d'une modification
     assert fiche_detection_updated.statut_evenement == new_fiche_detection.statut_evenement
-    assert fiche_detection_updated.organisme_nuisible == organisme
-    assert fiche_detection_updated.statut_reglementaire == new_fiche_detection.statut_reglementaire
     assert fiche_detection_updated.contexte == new_fiche_detection.contexte
     assert fiche_detection_updated.commentaire == new_fiche_detection.commentaire
     assert fiche_detection_updated.vegetaux_infestes == new_fiche_detection.vegetaux_infestes

--- a/sv/tests/test_fichezonedelimitee_update_performance.py
+++ b/sv/tests/test_fichezonedelimitee_update_performance.py
@@ -1,34 +1,27 @@
-import pytest
 from model_bakery import baker
 
-from core.models import Visibilite
-from sv.models import Etat, OrganismeNuisible, FicheDetection
+from sv.factories import FicheZoneFactory, EvenementFactory
+from sv.models import FicheDetection
 
-BASE_NUM_QUERIES = 13
+BASE_NUM_QUERIES = 15
 
 
-@pytest.mark.skip(reason="refacto evenement")
 def test_update_fiche_zone_delimitee_form_with_multiple_existing_fiche_detection(
     client, django_assert_num_queries, mocked_authentification_user, fiche_zone_bakery
 ):
-    """Vérifie que le nombre de requêtes SQL générées lors du chargement du formulaire de modification d'une zone délimitée reste constant,
+    """Vérifie l'évolution du nombre de requêtes SQL générées lors du chargement du formulaire de modification d'une zone délimitée,
     quel que soit le nombre de fiches de détection affichées dans les champs hors zone infestée et zone infestée"""
-    organisme_nuisible = baker.make(OrganismeNuisible)
-    etat = Etat.objects.get(id=Etat.get_etat_initial())
+    fiche_zone_delimitee = FicheZoneFactory()
+    evenement = EvenementFactory(fiche_zone_delimitee=fiche_zone_delimitee)
     baker.make(
         FicheDetection,
         _fill_optional=True,
-        etat=etat,
         createur=mocked_authentification_user.agent.structure,
         hors_zone_infestee=None,
         zone_infestee=None,
-        organisme_nuisible=organisme_nuisible,
-        visibilite=Visibilite.LOCAL,
+        evenement=evenement,
         _quantity=3,
     )
-    fiche_zone_delimitee = fiche_zone_bakery()
-    fiche_zone_delimitee.organisme_nuisible = organisme_nuisible
-    fiche_zone_delimitee.save()
     client.get(fiche_zone_delimitee.get_update_url())
 
     with django_assert_num_queries(BASE_NUM_QUERIES):
@@ -37,13 +30,11 @@ def test_update_fiche_zone_delimitee_form_with_multiple_existing_fiche_detection
     baker.make(
         FicheDetection,
         _fill_optional=True,
-        etat=etat,
         createur=mocked_authentification_user.agent.structure,
         hors_zone_infestee=None,
         zone_infestee=None,
-        organisme_nuisible=organisme_nuisible,
-        visibilite=Visibilite.LOCAL,
+        evenement=evenement,
         _quantity=3,
     )
-    with django_assert_num_queries(BASE_NUM_QUERIES):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 3):
         client.get(fiche_zone_delimitee.get_update_url())


### PR DESCRIPTION
Retrait des derniers décorateurs "skip" afin que tous les tests soient lancés.