### PR TITLE
Améliorer la vue de liste sur petits écrans

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -22,6 +22,12 @@ class DSFRForm(forms.Form):
     input_to_class["SelectMultiple"] = "fr-select"
     input_to_class["SelectWithAttributeField"] = "fr-select"
     input_to_class["DSFRRadioButton"] = ""
+    manual_render_fields = []
+
+    def get_context(self):
+        context = super().get_context()
+        context["manual_render_fields"] = self.manual_render_fields
+        return context
 
     def as_dsfr_div(self):
         return self.render("core/_dsfr_div.html")

--- a/core/templates/core/_dsfr_div.html
+++ b/core/templates/core/_dsfr_div.html
@@ -4,17 +4,19 @@
     <div>{% for field in hidden_fields %}{{ field }}{% endfor %}</div>
   {% endif %}
   {% for field, errors in fields %}
-    {{ errors }}
-    <div {% with classes=field.css_classes %}class="{{ classes }} fr-fieldset__element"{% endwith %}>
-      {% if field.label %}{{ field.label_tag }}{% endif %}
-      {{ field }}
-      {% if field.help_text %}
-        <span class="helptext fr-hint-text"{% if field.auto_id %} id="{{ field.auto_id }}_helptext"{% endif %}>{{ field.help_text|safe }}</span>
-      {% endif %}
-      {% if forloop.last %}
-        {% for field in hidden_fields %}{{ field }}{% endfor %}
-      {% endif %}
-    </div>
+    {% if field.name not in manual_render_fields %}
+      {{ errors }}
+      <div {% with classes=field.css_classes %}class="{{ classes }} fr-fieldset__element"{% endwith %}>
+        {% if field.label %}{{ field.label_tag }}{% endif %}
+        {{ field }}
+        {% if field.help_text %}
+          <span class="helptext fr-hint-text"{% if field.auto_id %} id="{{ field.auto_id }}_helptext"{% endif %}>{{ field.help_text|safe }}</span>
+        {% endif %}
+        {% if forloop.last %}
+          {% for field in hidden_fields %}{{ field }}{% endfor %}
+        {% endif %}
+      </div>
+    {% endif %}
   {% endfor %}
   {% if not fields and not errors %}
     {% for field in hidden_fields %}{{ field }}{% endfor %}

--- a/sv/filters.py
+++ b/sv/filters.py
@@ -1,10 +1,15 @@
 import django_filters
+from django.forms import forms
 
 from core.fields import DSFRRadioButton
 from core.forms import DSFRForm
 from seves import settings
 from .models import FicheDetection, Region, OrganismeNuisible, Etat
 from django.forms.widgets import DateInput, TextInput
+
+
+class FicheFilterForm(DSFRForm, forms.Form):
+    manual_render_fields = ["type_fiche"]
 
 
 class FicheFilter(django_filters.FilterSet):
@@ -18,7 +23,6 @@ class FicheFilter(django_filters.FilterSet):
         label="Type",
         widget=DSFRRadioButton(attrs={"class": "fr-fieldset__element--inline"}),
         empty_label=None,
-        initial="Détection",
     )
     lieux__departement__region = django_filters.ModelChoiceFilter(
         label="Région", queryset=Region.objects.all(), empty_label=settings.SELECT_EMPTY_CHOICE, method="filter_region"
@@ -50,10 +54,15 @@ class FicheFilter(django_filters.FilterSet):
             "end_date",
             "evenement__etat",
         ]
-        form = DSFRForm
+        form = FicheFilterForm
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if not self.data.get("type_fiche"):
+            data = self.data.copy()
+            data["type_fiche"] = "detection"
+            self.data = data
+
         if self.data.get("numero"):
             try:
                 _annee, _numero = map(int, self.data.get("numero").split("."))

--- a/sv/static/sv/fiche_list.css
+++ b/sv/static/sv/fiche_list.css
@@ -5,14 +5,30 @@ body{
 .fiches__header {
     background-color: var(--background-open-blue-france);
 }
+.fiche__header--title h2{
+    display: inline-block;
+}
+.fiche__header--type {
+    background-color: var(--background-contrast-grey) !important;
+    display: inline-block;
+}
+.fiche__header--type .fr-fieldset__element{
+    margin-bottom: 0px !important;
+}
+.fiche__header--actions {
+    display: flex;
+    justify-content: flex-end;
+}
 
 .fiches__search-form {
     display: flex;
+    flex-wrap: wrap;
     align-items: flex-end;
     gap: 0.5rem;
 }
 .fiches__search-form .fr-fieldset__element{
-    flex: 1 !important;
+    flex: 1 1 200px;
+    max-width: 300px;
 }
 .fiches__search-form input, .fiches__search-form select, .fiches__search-form .fr-radio-group {
     margin-top: .5rem;

--- a/sv/static/sv/fiche_list.js
+++ b/sv/static/sv/fiche_list.js
@@ -18,10 +18,12 @@ document.addEventListener('DOMContentLoaded', function() {
     });
     document.getElementById("id_type_fiche_0").addEventListener("click", event =>{
         document.getElementById('id_lieux__departement__region').disabled = false
+        event.target.closest("form").submit()
     })
     document.getElementById("id_type_fiche_1").addEventListener("click", event =>{
         document.getElementById('id_lieux__departement__region').disabled = true
         document.getElementById('id_lieux__departement__region').selectedIndex = 0
+        event.target.closest("form").submit()
     })
     if (new URLSearchParams(window.location.search).get('type_fiche') === "zone"){
         document.getElementById('id_lieux__departement__region').disabled = true

--- a/sv/templates/sv/fiche_list.html
+++ b/sv/templates/sv/fiche_list.html
@@ -15,17 +15,27 @@
 
 {% block content %}
     {% include "sv/_extract_modal.html" %}
+    <form id="search-form" method="get" >
+        <div class="fiches__header fr-p-4v">
+            <div class="fiche__header--title">
+                <h2 class="fr-h3">Rechercher une fiche</h2>
+                <span class="fiche__header--type fr-py-1w">
+                    <div class=" fr-fieldset__element">
+                        {{ filter.form.type_fiche }}
+                    </div>
+                </span>
+            </div>
 
-    <div class="fiches__header fr-p-4v">
-        <h2 class="fr-h3">Rechercher une fiche</h2>
-        <form id="search-form" method="get" class="fiches__search-form">
-            {{ filter.form.as_dsfr_div }}
-            <div class="fr-fieldset__element">
-                <button type="reset" class="fr-btn fr-btn--secondary">Effacer</button>
+            <div class="fiches__search-form">
+                {{ filter.form.as_dsfr_div }}
+            </div>
+            <div class="fr-fieldset__element fiche__header--actions">
+                <button type="reset" class="fr-btn fr-btn--tertiary-no-outline fr-mr-2w">Effacer</button>
                 <button type="submit" class="fr-btn">Rechercher</button>
             </div>
-        </form>
-    </div>
+        </div>
+    </form>
+
 
     <div class="fiches__list-container">
         <div class="fiches__list-header">


### PR DESCRIPTION
- Déplacement des boutons de type de fiche pour libérer de la place et uniformiser le comportement avec les futurs domaines
- Pré-sélection d'un type de fiche et submit automatique en cas de changement
- Divers changement de style pour que les champs aillent à la ligne sur petits écrans

Concernant le test de vérification de l'auto-submit du form, je n'ai pas trouvé d'autre moyen de vérifier que la page avait été rechargée:
- J'ai essayé `expect_request` qui semble fonctionner uniquement pour les requêtes au sein de la page
- `wait_for_load_state` reste vrai même sans rechargement, probablement car le document est déjà dans l'état "loaded"
- Une autre solution aurait été d'ajouter un paramètre dans l'url et de vérifier sa disparition lors du rechargement

Ajout d'un mécanisme qui permet de rendre tout un formulaire en "style DSFR" sauf un ou plusieurs champs. Ce mécanisme me permet de rendre manuellement le champ de type de fiches sans avoir a rendre manuellement l'intégralité du formulaire.