### PR TITLE
Limiter l'ajout de structure avec un user actif

### DIFF
--- a/core/factories.py
+++ b/core/factories.py
@@ -56,8 +56,8 @@ class AgentFactory(DjangoModelFactory):
             "",
         ]
     )
-    telephone = factory.Faker("phone_number")
-    mobile = factory.Faker("phone_number")
+    telephone = factory.Faker("phone_number", locale="fr_FR")
+    mobile = factory.Faker("phone_number", locale="fr_FR")
 
 
 class ContactAgentFactory(DjangoModelFactory):

--- a/core/forms.py
+++ b/core/forms.py
@@ -1,6 +1,8 @@
 import math
+from collections import defaultdict
 from copy import copy
 
+from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
@@ -8,9 +10,6 @@ from django.utils.safestring import mark_safe
 
 from core.fields import DSFRCheckboxSelectMultiple, DSFRRadioButton
 from core.models import Document, Contact, Message, Structure, Visibilite
-from core.constants import SERVICE_ACCOUNT_NAME
-from django import forms
-from collections import defaultdict
 
 User = get_user_model()
 
@@ -99,7 +98,7 @@ class ContactAddForm(DSFRForm, forms.Form):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.fields["structure"].queryset = Structure.objects.has_at_least_one_active_contact()
+        self.fields["structure"].queryset = Structure.objects.can_be_contacted()
 
 
 class ContactSelectionForm(forms.Form):
@@ -274,7 +273,7 @@ class StructureAddForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        niveau1_choices = Structure.objects.exclude(niveau1=SERVICE_ACCOUNT_NAME).exclude(contact__email="")
+        niveau1_choices = Structure.objects.can_be_contacted()
         niveau1_choices = niveau1_choices.values_list("niveau1", flat=True).distinct().order_by("niveau1")
         self.fields["structure_niveau1"].choices = [(niveau1, niveau1) for niveau1 in niveau1_choices]
         self.fields["structure_niveau1"].initial = niveau1_choices.first()

--- a/core/managers.py
+++ b/core/managers.py
@@ -1,7 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Case, When, Value, IntegerField, QuerySet, Q
 
-from core.constants import MUS_STRUCTURE, BSV_STRUCTURE, AC_STRUCTURE
+from core.constants import MUS_STRUCTURE, BSV_STRUCTURE, AC_STRUCTURE, SERVICE_ACCOUNT_NAME
 
 
 class DocumentQueryset(QuerySet):
@@ -97,3 +97,6 @@ class LienLibreQueryset(QuerySet):
 class StructureQueryset(QuerySet):
     def has_at_least_one_active_contact(self):
         return self.filter(agent__user__is_active=True).distinct()
+
+    def can_be_contacted(self):
+        return self.has_at_least_one_active_contact().exclude(niveau1=SERVICE_ACCOUNT_NAME).exclude(contact__email="")


### PR DESCRIPTION
Ce commit permet de limiter l'ajout de structures au fil de suivi aux structures ayant au moins un utilisateur actif dans SEVES.