### PR TITLE
Correction bug lors de la création de fiche détection avec événement existant

### DIFF
--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -12,7 +12,7 @@ from sv.constants import REGIONS, DEPARTEMENTS
 from sv.constants import STATUTS_EVENEMENT, STATUTS_REGLEMENTAIRES, CONTEXTES
 from .conftest import check_select_options
 from .test_utils import FicheDetectionFormDomElements, LieuFormDomElements, PrelevementFormDomElements
-from ..factories import LaboratoireFactory
+from ..factories import LaboratoireFactory, EvenementFactory
 from ..models import (
     FicheDetection,
     StatutEvenement,
@@ -506,3 +506,15 @@ def test_laboratoire_enable_for_analyse_premiere_intention(
     laboratoires = Laboratoire.objects.all()
     for labo in laboratoires:
         expect(prelevement_form_elements.laboratoire_input.locator(f'option[value="{labo.pk}"]')).not_to_be_disabled()
+
+
+@pytest.mark.django_db
+def test_can_add_fiche_detection_from_existing_evenement(live_server, page: Page):
+    evenement = EvenementFactory()
+
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    page.get_by_role("link", name="Ajouter une détection").click()
+    page.get_by_role("button", name="Enregistrer").click()
+
+    page.wait_for_timeout(600)
+    assert FicheDetection.objects.count() == 1

--- a/sv/views.py
+++ b/sv/views.py
@@ -194,7 +194,17 @@ class FicheDetectionCreateView(WithStatusToOrganismeNuisibleMixin, WithPreleveme
     def post(self, request, *args, **kwargs):
         form = self.get_form()
         lieu_formset = LieuFormSet(request.POST)
-        evenement_form = EvenementForm(request.POST, user=self.request.user)
+
+        if request.POST.get("evenement"):
+            evenement = Evenement.objects.get(pk=request.POST.get("evenement"))
+            evenement_data = {
+                "organisme_nuisible": evenement.organisme_nuisible.pk,
+                "statut_reglementaire": evenement.statut_reglementaire.pk,
+            }
+            evenement_form = EvenementForm(evenement_data, user=self.request.user)
+        else:
+            evenement_form = EvenementForm(request.POST, user=self.request.user)
+
         if not form.is_valid():
             return self.form_invalid(form)
 


### PR DESCRIPTION
Corrige un bug dans la création de fiche détection où le formulaire échouait lors de la validation avec un événement existant. 

Le problème provenait du formulaire `EvenementForm` qui nécessitait les champs `organisme_nuisible` et `statut_reglementaire` même lors de la réutilisation d'un événement existant. 
La correction consiste à pré-remplir ces champs avec les valeurs de l'événement existant lors de la soumission du formulaire.