### PR TITLE
Corrige l'erreur lors de la mise à jour d'une fiche zone délimitée

### DIFF
--- a/sv/factories.py
+++ b/sv/factories.py
@@ -195,6 +195,7 @@ class FicheZoneFactory(DjangoModelFactory):
     date_creation = factory.Faker("date_this_decade")
     numero = factory.SubFactory("sv.factories.NumeroFicheFactory")
 
+    commentaire = factory.Faker("paragraph")
     rayon_zone_tampon = factory.fuzzy.FuzzyFloat(1, 100, precision=2)
     unite_rayon_zone_tampon = factory.fuzzy.FuzzyChoice(FicheZoneDelimitee.UnitesRayon)
     surface_tampon_totale = factory.fuzzy.FuzzyFloat(1, 100, precision=2)

--- a/sv/views.py
+++ b/sv/views.py
@@ -537,6 +537,7 @@ class FicheZoneDelimiteeUpdateView(WithAddUserContactsMixin, UpdateView):
 
     def get_initial(self):
         initial = super().get_initial()
+        initial["evenement"] = self.object.evenement
         initial["organisme_nuisible"] = self.object.evenement.organisme_nuisible
         initial["statut_reglementaire"] = self.object.evenement.statut_reglementaire
         initial["detections_hors_zone"] = list(


### PR DESCRIPTION
## Problème
Lors de la mise à jour d'une fiche zone délimitée liée à un événement en brouillon, une erreur `AttributeError` se produit car l'événement n'est pas accessible dans le formulaire pour obtenir le numéro.

## Solution
Ajout de l'événement dans les données initiales (`initial`) de la vue `FicheZoneDelimiteeUpdateView`

## Test
- Vérifier qu'une fiche zone délimitée peut être mise à jour sans erreur avec un événement en brouillon -> `test_can_update_fiche_zone_if_evenement_brouillon`
- Ajout du champ `commentaire` dans la factory `FicheZoneFactory`