### PR TITLE
S'assurer que les structures sont en contact

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -232,8 +232,10 @@ class MessageCreateView(PreventActionIfVisibiliteBrouillonMixin, WithAddUserCont
 
     def _add_contacts_to_object(self, message):
         for contact in message.recipients.all().union(message.recipients_copy.all()):
-            if contact not in self.obj.contacts.all():
-                self.obj.contacts.add(contact)
+            self.obj.contacts.add(contact)
+
+            if structure := contact.get_structure_contact():
+                self.obj.contacts.add(structure)
 
     def _create_documents(self, form):
         message = form.instance

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -3,7 +3,7 @@ from django.contrib.auth import get_user_model
 from model_bakery import baker
 from playwright.sync_api import Page, expect
 
-from core.factories import ContactAgentFactory
+from core.factories import ContactAgentFactory, ContactStructureFactory
 from core.models import Message, Contact, Agent, Structure, Visibilite
 from sv.factories import EvenementFactory
 
@@ -425,13 +425,21 @@ def test_can_see_more_than_4_search_result_in_recipients_and_recipients_copy_fie
 def test_create_message_adds_agent_and_structure_contacts(
     live_server, page: Page, mocked_authentification_user: User, choice_js_fill
 ):
-    """Test que l'ajout d'un message ajoute l'agent et sa structure comme contacts"""
+    """Test que l'ajout d'un message ajoute l'agent à l'origine du message et sa structure comme contacts ainsi que
+    l'agent et la structure du destinataire et des copies"""
     evenement = EvenementFactory()
 
     # Création du contact destinataire
     contact = ContactAgentFactory()
     contact.agent.user.is_active = True
     contact.agent.user.save()
+    ContactStructureFactory(structure=contact.agent.structure)
+
+    # Création du contact de copie
+    contact_copy = ContactAgentFactory()
+    contact_copy.agent.user.is_active = True
+    contact_copy.agent.user.save()
+    ContactStructureFactory(structure=contact_copy.agent.structure)
 
     # Ajout d'un message
     page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
@@ -440,6 +448,8 @@ def test_create_message_adds_agent_and_structure_contacts(
 
     # Ajout du destinataire
     choice_js_fill(page, ".choices__input--cloned:first-of-type", contact.agent.nom, str(contact.agent))
+    # Ajout de la copie
+    choice_js_fill(page, ".choices__input--cloned:nth-of-type(1)", contact_copy.agent.nom, str(contact_copy.agent))
     page.locator("#id_title").fill("Title of the message")
     page.locator("#id_content").fill("Message de test")
     page.get_by_test_id("fildesuivi-add-submit").click()
@@ -458,13 +468,20 @@ def test_create_message_adds_agent_and_structure_contacts(
     expect(agents_section.get_by_text(str(contact.agent), exact=True)).to_be_visible()
 
     structures_section = page.locator("[data-testid='contacts-structures']")
-    expect(
-        structures_section.get_by_text(str(mocked_authentification_user.agent.structure), exact=True)
-    ).to_be_visible()
+    sender_structure = str(mocked_authentification_user.agent.structure)
+    recipient_structure = str(contact.agent.structure)
+
+    for structure in (sender_structure, recipient_structure):
+        expect(structures_section.get_by_text(structure, exact=True)).to_be_visible()
 
     # Vérification en base de données
+    assert evenement.contacts.count() == 6
     assert evenement.contacts.filter(agent=mocked_authentification_user.agent).exists()
+    assert evenement.contacts.filter(agent=contact.agent).exists()
+    assert evenement.contacts.filter(agent=contact_copy.agent).exists()
     assert evenement.contacts.filter(structure=mocked_authentification_user.agent.structure).exists()
+    assert evenement.contacts.filter(structure=contact.agent.structure).exists()
+    assert evenement.contacts.filter(structure=contact_copy.agent.structure).exists()
 
 
 def test_create_multiple_messages_adds_contacts_once(


### PR DESCRIPTION
Ce commit s'assure que les structures des agent(e)s destinataire et copies d'un message sont bien ajoutées en tant que contact dans la fiche.