### PR TITLE
Ne pas permettre à l'AC de notifier à l'AC

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -441,7 +441,7 @@ class ACNotificationView(PreventActionIfVisibiliteBrouillonMixin, View):
 
     def post(self, request):
         try:
-            self.obj.notify_ac(sender=self.request.user.agent.contact_set.get())
+            self.obj.notify_ac(user=self.request.user)
             messages.success(request, "L'administration centrale a été notifiée avec succès")
         except AttributeError:
             messages.error(request, "Ce type d'objet n'est pas compatible avec une notification à l'AC.")

--- a/sv/templates/sv/_evenement_action_navigation.html
+++ b/sv/templates/sv/_evenement_action_navigation.html
@@ -5,9 +5,9 @@
                 aria-expanded="false" title="Sélectionner une action">Actions</button>
         <div class="fr-collapse fr-translate__menu fr-menu" id="action-1">
             <ul class="fr-menu__list">
-                {% if not evenement.is_draft %}
+                {% if not evenement.is_draft and not user.agent.structure.is_ac %}
                     <li>
-                        {% if evenement.can_notifiy %}
+                        {% if can_be_ac_notified %}
                             <form action="{% url 'notify-ac' %}" method="post">
                                 <button class="fr-translate__language fr-nav__link" href="#" type="submit"><span class="fr-icon-notification-3-fill fr-mr-2v fr-icon--sm" aria-hidden="true">
                                     {% csrf_token %}

--- a/sv/views.py
+++ b/sv/views.py
@@ -133,6 +133,7 @@ class EvenementDetailView(
         context["can_update_visibilite"] = self.get_object().can_update_visibilite(self.request.user)
         context["visibilite_form"] = EvenementVisibiliteUpdateForm(obj=self.get_object())
         context["can_be_cloturer"] = self.object.can_be_cloturer_by(self.request.user)
+        context["can_be_ac_notified"] = self.object.can_notifiy(self.request.user)
         context["latest_version"] = self.object.latest_version
         fiche_zone = self.get_object().fiche_zone_delimitee
         if fiche_zone:


### PR DESCRIPTION
- Changement niveau UI pour cacher le bouton
- Vérification côté backend pour empécher l'action

@tglatt comme demandé dans le ticket mais je ne suis pas sur de comprendre nos règle actuelles. Pourquoi en brouillon le bouton est masqué et non pas grisé comme dans les autres cas ?