### PR TITLE
Afficher les dates de dernières modifiations

### DIFF
--- a/sv/static/sv/common.css
+++ b/sv/static/sv/common.css
@@ -2,7 +2,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 2rem;
+    margin-bottom: 1.5rem;
 }
 
 .fiche-action {

--- a/sv/static/sv/evenement_details.css
+++ b/sv/static/sv/evenement_details.css
@@ -16,6 +16,9 @@
     width: 60% !important;
     order: 0 !important;
 }
+.no-tab-look::before{
+    box-shadow: none !important;
+}
 [id^="detection-actions-"] {
     display: flex;
     justify-content: flex-end;
@@ -49,4 +52,8 @@
 .fr-tag.selected {
     background-color: var(--background-action-high-blue-france);
     color: var(--text-inverted-blue-france);
+}
+.last-modification {
+    color: var(--text-mention-grey);
+    margin-bottom: 0.5rem;
 }

--- a/sv/templates/sv/_fichedetection_detail.html
+++ b/sv/templates/sv/_fichedetection_detail.html
@@ -1,10 +1,7 @@
 {% load static %}
 {% load etat_tags %}
 
-
-
-
-
+{% include "sv/_latest_revision.html" with latest_revision=fichedetection.latest_version %}
 <div class="fiche-detail">
     <div class="fiche-detail__container">
         <!-- Informations -->

--- a/sv/templates/sv/_latest_revision.html
+++ b/sv/templates/sv/_latest_revision.html
@@ -1,0 +1,8 @@
+{% if latest_version %}
+    <div class="fr-pl-1v fr-mt-2v last-modification fr-text--xs">
+        Dernière mise à jour le {{ latest_version.revision.date_created }}
+        {% if latest_version.revision.user %}
+            par {{ latest_version.revision.user.agent.agent_with_structure }}
+        {% endif %}
+    </div>
+{% endif %}

--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -49,18 +49,11 @@
                 </div>
             </div>
             {% include "sv/_evenement_badges.html" %}
-            {% if latest_version %}
-                <div class="fr-pl-1v fr-mt-2v">
-                    Dernière mise à jour le {{ latest_version.revision.date_created }}
-                    {% if latest_version.revision.user %}
-                        par {{ latest_version.revision.user.agent.agent_with_structure }}
-                    {% endif %}
-                </div>
-            {% endif %}
+            {% include "sv/_latest_revision.html" %}
         </div>
 
-        <div class="fr-container--fluid">
-            <div class="fr-grid-row fr-grid-row--gutters fr-my-2w">
+        <div class="fr-container--fluid fr-mb-2w">
+            <div class="fr-grid-row fr-grid-row--gutters ">
                 <div class="fr-col-5"><div class="white-container--lite"><span class="bold fr-mr-2v">Organisme nuisible</span> {{ evenement.organisme_nuisible }}</div></div>
                 <div class="fr-col-5"><div class="white-container--lite"><span class="bold fr-mr-2v">Status réglementaire</span> {{ evenement.statut_reglementaire }}</div></div>
                 <div class="fr-col-2"><div class="white-container--lite"><span class="bold fr-mr-2v">Code OEPP</span> {{ evenement.organisme_nuisible.code_oepp }}</div></div>
@@ -80,7 +73,7 @@
                 <div id="tabpanel-404-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="tabpanel-404" tabindex="0">
                     <div>
                         <div class="fr-tabs no-tab-look">
-                            <ul class="fr-tabs__list fr-mb-2v" role="tablist" aria-label="Liste des détection">
+                            <ul class="fr-tabs__list" role="tablist" aria-label="Liste des détection">
                                 {% for fichedetection in evenement.detections.all %}
                                     <li role="presentation">
                                         <button id="tabpanel-{{ fichedetection.pk }}" class="fr-tag fr-mx-1w {% if forloop.first %}selected{% endif %}" tabindex="0" role="tab" aria-selected="true" aria-controls="tabpanel-{{ fichedetection.pk }}-panel">{{ fichedetection }}</button>

--- a/sv/templates/sv/fichezonedelimitee_detail.html
+++ b/sv/templates/sv/fichezonedelimitee_detail.html
@@ -1,12 +1,10 @@
 {% load static %}
 {% load remove_trailing_zero %}
+
 <div class="fiche-header">
     <div>
-        <h2 class="fr-mb-0-5v">Zone délimitée n° {{ fiche.numero }}</h2>
+        {% include "sv/_latest_revision.html" with latest_revision=fiche.latest_version %}
     </div>
-
-
-
     <div class="fiche-action">
         <button class="fr-btn fr-btn--delete fr-mr-2w" data-fr-opened="false" aria-controls="fr-modal-delete-zone-{{ fiche.pk }}">
             Supprimer la zone

--- a/sv/tests/test_evenement_details.py
+++ b/sv/tests/test_evenement_details.py
@@ -122,7 +122,6 @@ def test_delete_evenement_will_delete_associated_detections(live_server, page):
 
 def test_evenement_can_view_basic_data(live_server, page: Page):
     evenement = EvenementFactory()
-    FicheDetectionFactory(evenement=evenement)
     page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
 
     expect(page.get_by_text(evenement.organisme_nuisible.libelle_court)).to_be_visible()

--- a/sv/tests/test_evenement_performance_details.py
+++ b/sv/tests/test_evenement_performance_details.py
@@ -47,11 +47,11 @@ def test_evenement_performances_with_lieux(client, django_assert_num_queries):
     fiche_detection = FicheDetectionFactory(evenement=evenement)
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 6):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 9):
         client.get(evenement.get_absolute_url())
 
     baker.make(Lieu, fiche_detection=fiche_detection, _quantity=3, _fill_optional=True)
-    with django_assert_num_queries(BASE_NUM_QUERIES + 12):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 16):
         client.get(evenement.get_absolute_url())
 
 
@@ -75,12 +75,12 @@ def test_evenement_performances_with_prelevement(client, django_assert_num_queri
     fiche_detection = FicheDetectionFactory(evenement=evenement)
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 6):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 9):
         client.get(evenement.get_absolute_url())
 
     PrelevementFactory.create_batch(3, lieu__fiche_detection=fiche_detection)
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 11):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 16):
         client.get(evenement.get_absolute_url())
 
 
@@ -123,5 +123,5 @@ def test_fiche_zone_delimitee_with_multiple_zone_infestee(
 
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 28):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 39):
         client.get(evenement.get_absolute_url())

--- a/sv/tests/test_fichezonedelimitee_detail.py
+++ b/sv/tests/test_fichezonedelimitee_detail.py
@@ -17,7 +17,6 @@ def test_fichezonedelimitee_with_zoneinfestee_detail(live_server, fiche_zone, pa
     page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
     page.get_by_role("tab", name="Zone").click()
 
-    expect(page.get_by_role("heading", name=f"Zone délimitée n° {fiche_zone_delimitee.numero}")).to_be_visible()
     expect(page.get_by_text(fiche_zone_delimitee.commentaire)).to_be_visible()
     expect(
         page.get_by_text(f"{fiche_zone_delimitee.rayon_zone_tampon} {fiche_zone_delimitee.unite_rayon_zone_tampon}")


### PR DESCRIPTION
Pour tous les objets d'un événement afficher la date et l'auteur de la dernière modification.
Les performances pourraient être améliorables en évitant de tout re-calculer dans la property `latest_version` de l'événement. Dans la mesure où on affiche toutes les versions des sous-objets sur la page on pourrait fournir la dernière version de chaque objet à la méthode pour éviter le recalcul.