### PR TITLE
Exclusion des événements en brouillon des liens libres

### DIFF
--- a/sv/form_mixins.py
+++ b/sv/form_mixins.py
@@ -2,6 +2,7 @@ from django.core.exceptions import ValidationError
 
 from core.fields import MultiModelChoiceField
 from core.models import LienLibre
+from sv.models import Evenement
 
 
 class WithDataRequiredConversionMixin:
@@ -35,6 +36,7 @@ class WithFreeLinksMixin:
             .get_user_can_view(self.user)
             .select_related("numero")
             .exclude(id=self.instance.id)
+            .exclude(etat=Evenement.Etat.BROUILLON)
         )
         self.fields["free_link"] = MultiModelChoiceField(
             required=False,

--- a/sv/tests/test_evenement_update.py
+++ b/sv/tests/test_evenement_update.py
@@ -1,6 +1,6 @@
 from playwright.sync_api import Page, expect
 
-from core.models import LienLibre, Structure
+from core.models import LienLibre, Structure, Visibilite
 from ..factories import EvenementFactory, OrganismeNuisibleFactory
 from ..factories import StatutReglementaireFactory
 from ..models import StatutReglementaire, Evenement
@@ -138,3 +138,43 @@ def test_update_evenement_multiple_times_adds_contacts_once(
             str(mocked_authentification_user.agent.structure), exact=True
         )
     ).to_be_visible()
+
+
+def test_update_evenement_cant_select_draft_evenement_in_free_links(
+    live_server,
+    page: Page,
+    choice_js_cant_pick,
+):
+    evenement = EvenementFactory()
+    draft_evenement = EvenementFactory(etat=Evenement.Etat.BROUILLON)
+
+    page.goto(f"{live_server.url}{evenement.get_update_url()}")
+
+    fiche_input = "Événement : " + str(draft_evenement.numero)
+    choice_js_cant_pick(page, "#liens-libre .choices", str(draft_evenement.numero), fiche_input)
+
+
+def test_update_evenement_free_links_filtered_by_user_visibility(
+    live_server,
+    page: Page,
+    mocked_authentification_user,
+):
+    # Événement visible en national
+    visible_evenement = EvenementFactory(visibilite=Visibilite.NATIONALE)
+
+    # Événement en visibilité limitée avec structure autorisée
+    limited_visible_evenement = EvenementFactory()
+    limited_visible_evenement.visibilite = Visibilite.LIMITEE
+    limited_visible_evenement.allowed_structures.add(mocked_authentification_user.agent.structure)
+    limited_visible_evenement.save()
+
+    # Événement en visibilité limitée sans accès
+    hidden_evenement = EvenementFactory(createur=Structure.objects.create(niveau1="test"))
+
+    evenement = EvenementFactory()
+    page.goto(f"{live_server.url}{evenement.get_update_url()}")
+    page.locator("#liens-libre .choices").click()
+
+    expect(page.get_by_text(str(visible_evenement.numero))).to_be_visible()
+    expect(page.get_by_text(str(limited_visible_evenement.numero))).to_be_visible()
+    expect(page.get_by_text(str(hidden_evenement.numero))).not_to_be_visible()


### PR DESCRIPTION
- Filtre les événements en brouillon des choix de liens libres dans le formulaire de modification d'un évènement
- Ajout d'un test pour vérifier qu'un événement en brouillon n'est pas sélectionnable dans la liste des liens libres
- Ajout d'un test pour vérifier que seuls les événements accessibles par l'utilisateur sont visibles dans la liste des liens libres selon leur visibilité