### PR TITLE
Empécher de changer la visibilité quand brouillon

### DIFF
--- a/sv/models/evenements.py
+++ b/sv/models/evenements.py
@@ -76,7 +76,7 @@ class Evenement(
         return reverse("evenement-visibilite-update", kwargs={"pk": self.pk})
 
     def can_update_visibilite(self, user):
-        return user.agent.structure.is_mus_or_bsv
+        return not self.is_draft and user.agent.structure.is_mus_or_bsv
 
     def __str__(self):
         return str(self.numero)


### PR DESCRIPTION
Empécher de changer la visibilité quand la l'événement est dans un état brouillon.