### PR TITLE
Ajouter un mécanisme pour empécher l'écrasement

### DIFF
--- a/sv/forms.py
+++ b/sv/forms.py
@@ -11,7 +11,7 @@ from django.utils.translation import ngettext
 from core.fields import DSFRRadioButton, DSFRCheckboxSelectMultiple
 from core.forms import DSFRForm, VisibiliteUpdateBaseForm
 from core.models import Structure
-from sv.form_mixins import WithDataRequiredConversionMixin, WithFreeLinksMixin
+from sv.form_mixins import WithDataRequiredConversionMixin, WithFreeLinksMixin, WithLatestVersionLocking
 from sv.models import (
     FicheZoneDelimitee,
     ZoneInfestee,
@@ -210,7 +210,7 @@ class PrelevementForm(DSFRForm, WithDataRequiredConversionMixin, forms.ModelForm
                 self.cleaned_data.pop(field)
 
 
-class FicheDetectionForm(DSFRForm, forms.ModelForm):
+class FicheDetectionForm(DSFRForm, WithLatestVersionLocking, forms.ModelForm):
     vegetaux_infestes = forms.CharField(
         label="Quantité de végétaux infestés", max_length=500, required=False, widget=forms.Textarea(attrs={"rows": ""})
     )
@@ -261,6 +261,7 @@ class FicheDetectionForm(DSFRForm, forms.ModelForm):
             "mesures_consignation",
             "mesures_phytosanitaires",
             "mesures_surveillance_specifique",
+            "latest_version",
         ]
         labels = {"statut_evenement": "Statut évènement"}
 
@@ -290,7 +291,7 @@ class FicheDetectionForm(DSFRForm, forms.ModelForm):
         return instance
 
 
-class FicheZoneDelimiteeForm(DSFRForm, forms.ModelForm):
+class FicheZoneDelimiteeForm(DSFRForm, WithLatestVersionLocking, forms.ModelForm):
     date_creation = forms.DateTimeField(
         widget=forms.DateTimeInput(attrs={"disabled": "", "value": now().strftime("%d/%m/%Y")}),
         required=False,
@@ -497,10 +498,10 @@ class EvenementForm(DSFRForm, forms.ModelForm):
         return instance
 
 
-class EvenementUpdateForm(DSFRForm, WithFreeLinksMixin, forms.ModelForm):
+class EvenementUpdateForm(DSFRForm, WithFreeLinksMixin, WithLatestVersionLocking, forms.ModelForm):
     class Meta:
         model = Evenement
-        fields = ["organisme_nuisible", "statut_reglementaire"]
+        fields = ["organisme_nuisible", "statut_reglementaire", "latest_version"]
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user")

--- a/sv/templates/sv/evenement_form.html
+++ b/sv/templates/sv/evenement_form.html
@@ -17,6 +17,9 @@
         {{ status_to_organisme_nuisible|json_script:"status-to-organisme-nuisible-id" }}
         <form action="{% url 'evenement-update' evenement.id  %}" method="post">
             {% csrf_token %}
+            {{ form.latest_version }}
+
+            {{ form.errors }}
 
             <div class="evenement-form-header">
                 <div>

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -1,3 +1,4 @@
+
 {% extends 'sv/base.html' %}
 
 {% load static %}
@@ -21,6 +22,7 @@
 
         <form action="{% if is_creation %}{% url 'fiche-detection-creation' %}{% else %}{% url 'fiche-detection-modification' form.instance.id  %}{% endif %}" method="post">
             {% csrf_token %}
+            {{ form.latest_version }}
 
             <div id="fiche-detection-form-header">
                 <div>

--- a/sv/templates/sv/fichezonedelimitee_form.html
+++ b/sv/templates/sv/fichezonedelimitee_form.html
@@ -35,6 +35,7 @@
         </div>
 
         {% csrf_token %}
+        {{ form.latest_version }}
         <div id="risques-infos-commentaire-row" class="fr-grid-row fr-grid-row--gutters">
 
             <div id="risques" class="fr-col-12 fr-col-lg">

--- a/sv/tests/test_fichezonedelimitee_update_performance.py
+++ b/sv/tests/test_fichezonedelimitee_update_performance.py
@@ -3,7 +3,7 @@ from model_bakery import baker
 from sv.factories import FicheZoneFactory, EvenementFactory
 from sv.models import FicheDetection
 
-BASE_NUM_QUERIES = 15
+BASE_NUM_QUERIES = 17
 
 
 def test_update_fiche_zone_delimitee_form_with_multiple_existing_fiche_detection(


### PR DESCRIPTION
Dans le cas où quelqu'un a modifié un objet entre temps rendre impossible les modifications d'un objet pour éviter les conflits.