### PR TITLE
Empêcher les utilisateurs d'envoyer un message si pas accès

### DIFF
--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -1,5 +1,7 @@
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
 from model_bakery import baker
 from playwright.sync_api import Page, expect
 
@@ -573,3 +575,32 @@ def test_create_message_from_visibilite_limitee_add_structures_in_allowed_struct
     assert len(evenement.allowed_structures.all()) == 2
     assert contact.agent.structure in evenement.allowed_structures.all()
     assert mocked_authentification_user.agent.structure in evenement.allowed_structures.all()
+
+
+@pytest.mark.django_db
+def test_cant_forge_post_of_message_in_evenement_we_cant_see(client, mocked_authentification_user):
+    evenement = EvenementFactory(createur=Structure.objects.create(libelle="A new structure"))
+    response = client.get(evenement.get_absolute_url())
+    contact = ContactAgentFactory()
+    contact.agent.user.is_active = True
+    contact.agent.user.save()
+
+    assert response.status_code == 403
+    content_type = ContentType.objects.get_for_model(evenement).id
+
+    payload = {
+        "content_type": content_type,
+        "object_id": evenement.pk,
+        "recipients": contact.pk,
+        "title": "Test",
+        "content": "Test",
+        "message_type": "message",
+        "next": "/",
+    }
+    response = client.post(
+        reverse("message-add", kwargs={"obj_type_pk": content_type, "obj_pk": evenement.pk}), data=payload
+    )
+
+    assert response.status_code == 403
+    evenement.refresh_from_db()
+    assert evenement.messages.count() == 0

--- a/sv/tests/test_evenement_performance_details.py
+++ b/sv/tests/test_evenement_performance_details.py
@@ -5,7 +5,7 @@ from core.models import Message, Document, Structure, Contact
 from sv.factories import EvenementFactory, FicheDetectionFactory, PrelevementFactory, FicheZoneFactory
 from sv.models import Lieu, ZoneInfestee
 
-BASE_NUM_QUERIES = 20  # Please note a first call is made without assertion to warm up any possible cache
+BASE_NUM_QUERIES = 19  # Please note a first call is made without assertion to warm up any possible cache
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Empêche les utilisateurs de forger l'URL / le formulaire pour envoyer un message sur un événement auquel ils n'auraient pas accès. Retrait du champ sender dans le form pour éviter d'augmenter les problème potentiel, l'expéditeur doit toujours être l'utilisateur à l'origine de la requête.