### PR TITLE
Corriger la factory du prélévement

### DIFF
--- a/sv/factories.py
+++ b/sv/factories.py
@@ -135,7 +135,7 @@ class PrelevementFactory(DjangoModelFactory):
     @factory.lazy_attribute
     def numero_rapport_inspection(self):
         if self.is_officiel:
-            return "".join(random.choices(string.digits, k=5))
+            return "".join(random.choices(string.digits, k=2)) + "-" + "".join(random.choices(string.digits, k=6))
         return ""
 
 


### PR DESCRIPTION
Corrige la factory qui faisait que les tests de mise à jour de prélévement ne fonctionnait pas toujours.
Avant le commit : sur 10 tentatives, 6 échecs
Après le commit : 10 OK sur 10 tentatives

Le cas ne se produisait que quand le prélévement était officiel.