### PR TITLE
Renforcer la sécurité de nombreuses vues

### DIFF
--- a/sv/tests/test_evenement_contacts_remove.py
+++ b/sv/tests/test_evenement_contacts_remove.py
@@ -1,7 +1,10 @@
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
 from model_bakery import baker
 from playwright.sync_api import expect
 
-from core.models import Contact, Agent
+from core.factories import ContactAgentFactory
+from core.models import Contact, Agent, Structure
 from sv.factories import EvenementFactory
 
 
@@ -42,3 +45,25 @@ def test_can_remove_another_contact_from_a_fiche(live_server, page):
     assert page.url == f"{live_server.url}{evenement.get_absolute_url()}#tabpanel-contacts-panel"
     assert evenement.contacts.count() == 0
     expect(page.get_by_text(str(agent), exact=True)).not_to_be_visible()
+
+
+def test_cant_forge_contact_deletion_of_evenement_i_cant_see(client):
+    evenement = EvenementFactory(createur=Structure.objects.create(libelle="A new structure"))
+    contact = ContactAgentFactory()
+    evenement.contacts.set([contact])
+    assert evenement.contacts.count() == 1
+    content_type = ContentType.objects.get_for_model(evenement).pk
+
+    response = client.get(evenement.get_absolute_url())
+    assert response.status_code == 403
+
+    payload = {
+        "fiche_pk": evenement.pk,
+        "content_type_pk": content_type,
+        "pk": contact.pk,
+        "next": evenement.get_absolute_url(),
+    }
+    response = client.post(reverse("contact-delete"), data=payload)
+
+    assert response.status_code == 403
+    assert evenement.contacts.count() == 1

--- a/sv/tests/test_evenement_performance_details.py
+++ b/sv/tests/test_evenement_performance_details.py
@@ -47,11 +47,11 @@ def test_evenement_performances_with_lieux(client, django_assert_num_queries):
     fiche_detection = FicheDetectionFactory(evenement=evenement)
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 9):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 11):
         client.get(evenement.get_absolute_url())
 
     baker.make(Lieu, fiche_detection=fiche_detection, _quantity=3, _fill_optional=True)
-    with django_assert_num_queries(BASE_NUM_QUERIES + 16):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 18):
         client.get(evenement.get_absolute_url())
 
 
@@ -75,12 +75,12 @@ def test_evenement_performances_with_prelevement(client, django_assert_num_queri
     fiche_detection = FicheDetectionFactory(evenement=evenement)
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 9):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 11):
         client.get(evenement.get_absolute_url())
 
     PrelevementFactory.create_batch(3, lieu__fiche_detection=fiche_detection)
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 16):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 18):
         client.get(evenement.get_absolute_url())
 
 
@@ -123,5 +123,5 @@ def test_fiche_zone_delimitee_with_multiple_zone_infestee(
 
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 38):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 44):
         client.get(evenement.get_absolute_url())

--- a/sv/tests/test_fichezonedelimitee_update_performance.py
+++ b/sv/tests/test_fichezonedelimitee_update_performance.py
@@ -3,7 +3,7 @@ from model_bakery import baker
 from sv.factories import FicheZoneFactory, EvenementFactory
 from sv.models import FicheDetection
 
-BASE_NUM_QUERIES = 17
+BASE_NUM_QUERIES = 20
 
 
 def test_update_fiche_zone_delimitee_form_with_multiple_existing_fiche_detection(

--- a/sv/views.py
+++ b/sv/views.py
@@ -280,7 +280,11 @@ class FicheDetectionCreateView(WithStatusToOrganismeNuisibleMixin, WithPreleveme
 
 
 class FicheDetectionUpdateView(
-    WithStatusToOrganismeNuisibleMixin, WithPrelevementHandlingMixin, WithAddUserContactsMixin, UpdateView
+    WithStatusToOrganismeNuisibleMixin,
+    WithPrelevementHandlingMixin,
+    WithAddUserContactsMixin,
+    UserPassesTestMixin,
+    UpdateView,
 ):
     model = FicheDetection
     form_class = FicheDetectionForm
@@ -288,6 +292,9 @@ class FicheDetectionUpdateView(
 
     def get_success_url(self):
         return f"{self.object.evenement.get_absolute_url()}?detection={self.object.pk}"
+
+    def test_func(self):
+        return self.get_object().evenement.can_user_access(self.request.user)
 
     def get_object(self, queryset=None):
         if hasattr(self, "object"):
@@ -551,13 +558,16 @@ class FicheZoneDelimiteeCreateView(CreateView):
         return self.render_to_response(self.get_context_data())
 
 
-class FicheZoneDelimiteeUpdateView(WithAddUserContactsMixin, UpdateView):
+class FicheZoneDelimiteeUpdateView(WithAddUserContactsMixin, UserPassesTestMixin, UpdateView):
     model = FicheZoneDelimitee
     form_class = FicheZoneDelimiteeForm
     context_object_name = "fiche"
 
     def get_success_url(self):
         return self.get_object().get_absolute_url() + "#tabpanel-zone-panel"
+
+    def test_func(self) -> bool | None:
+        return self.get_object().evenement.can_user_access(self.request.user)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)


### PR DESCRIPTION
Repasse sur plusieurs vues afin de s'assurer que l'utilisateur à l'origine de la requête a bien le droit de réaliser une action liée a l'objet qu'il consulte / modifie.