### PR TITLE
Corrige 2 failles open-redirect

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -2,6 +2,7 @@ from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError, PermissionDenied
 from django.db import models, transaction
+from django.shortcuts import get_object_or_404
 from django.urls import reverse
 
 from core.forms import DocumentUploadForm, DocumentEditForm
@@ -285,3 +286,14 @@ class PreventActionIfVisibiliteBrouillonMixin:
             return safe_redirect(request.POST.get("next") or obj.get_absolute_url() or "/")
 
         return super().dispatch(request, *args, **kwargs)
+
+
+class WithObjectFromContentTypeMixin:
+    def _get_object_from_content_type(self, *, object_id, content_type_id):
+        if hasattr(self, "_object"):
+            return self._object
+
+        content_type = ContentType.objects.get(pk=content_type_id)
+        ModelClass = content_type.model_class()
+        self._object = get_object_or_404(ModelClass, pk=object_id)
+        return self._object

--- a/core/templates/core/_contact_add_form.html
+++ b/core/templates/core/_contact_add_form.html
@@ -28,7 +28,7 @@
             <div class="fr-col-9">
                 <div class="fr-grid-row">
                     <div class="fr-col-12">
-                        <p class="fr-my-2w"><a href="{{form.next.value}}" class="fr-link fr-icon-arrow-left-line fr-link--icon-left">Retour à l'évenement</a></p>
+                        <p class="fr-my-2w"><a href="{{ object.get_absolute_url }}" class="fr-link fr-icon-arrow-left-line fr-link--icon-left">Retour à l'évenement</a></p>
                     </div>
                 </div>
                 <div class="fr-grid-row">

--- a/core/templates/core/_structure_add_form.html
+++ b/core/templates/core/_structure_add_form.html
@@ -12,7 +12,7 @@
             <div class="fr-col-9">
                 <div class="fr-grid-row">
                     <div class="fr-col-12">
-                        <p class="fr-my-2w"><a href="{{form.next.value}}" class="fr-link fr-icon-arrow-left-line fr-link--icon-left">Retour à l'évenement</a></p>
+                        <p class="fr-my-2w"><a href="{{ object.get_absolute_url }}" class="fr-link fr-icon-arrow-left-line fr-link--icon-left">Retour à l'évenement</a></p>
                     </div>
                 </div>
 

--- a/core/views.py
+++ b/core/views.py
@@ -21,7 +21,7 @@ from .forms import (
     StructureAddForm,
     StructureSelectionForm,
 )
-from .mixins import PreventActionIfVisibiliteBrouillonMixin
+from .mixins import PreventActionIfVisibiliteBrouillonMixin, WithObjectFromContentTypeMixin
 from .models import Document, Message, Contact, FinSuiviContact, Visibilite
 from .notifications import notify_message
 from .redirect import safe_redirect
@@ -85,16 +85,19 @@ class DocumentUpdateView(PreventActionIfVisibiliteBrouillonMixin, UpdateView):
         return response
 
 
-class ContactAddFormView(PreventActionIfVisibiliteBrouillonMixin, FormView):
+class ContactAddFormView(PreventActionIfVisibiliteBrouillonMixin, WithObjectFromContentTypeMixin, FormView):
     template_name = "core/_contact_add_form.html"
     form_class = ContactAddForm
 
     def get_fiche_object(self):
         content_type_id = self.request.GET.get("content_type_id") or self.request.POST.get("content_type_id")
         fiche_id = self.request.GET.get("fiche_id") or self.request.POST.get("fiche_id")
-        content_type = ContentType.objects.get(pk=content_type_id)
-        ModelClass = content_type.model_class()
-        return get_object_or_404(ModelClass, pk=fiche_id)
+        return self._get_object_from_content_type(object_id=fiche_id, content_type_id=content_type_id)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["object"] = self.get_fiche_object()
+        return context
 
     def get_initial(self):
         initial = super().get_initial()
@@ -104,7 +107,7 @@ class ContactAddFormView(PreventActionIfVisibiliteBrouillonMixin, FormView):
         initial["structure"] = self.request.user.agent.structure
         return initial
 
-    def form_valid(self, form):
+    def form_valid(self, form, **kwargs):
         selection_form = ContactSelectionForm(
             structure=form.cleaned_data.get("structure"),
             fiche_id=form.cleaned_data.get("fiche_id"),
@@ -113,23 +116,23 @@ class ContactAddFormView(PreventActionIfVisibiliteBrouillonMixin, FormView):
                 "next": form.cleaned_data.get("next"),
             },
         )
-        return render(self.request, self.template_name, {"form": form, "selection_form": selection_form})
+        context = self.get_context_data(**kwargs)
+        context.update({"form": form, "selection_form": selection_form})
+        return render(self.request, self.template_name, context)
 
 
-class ContactSelectionView(PreventActionIfVisibiliteBrouillonMixin, FormView):
+class ContactSelectionView(PreventActionIfVisibiliteBrouillonMixin, WithObjectFromContentTypeMixin, FormView):
     template_name = "core/_contact_add_form.html"
     form_class = ContactSelectionForm
 
     def get_fiche_object(self):
-        content_type_id = self.request.POST.get("content_type_id")
-        fiche_id = self.request.POST.get("fiche_id")
-        content_type = ContentType.objects.get(pk=content_type_id)
-        ModelClass = content_type.model_class()
-        return get_object_or_404(ModelClass, pk=fiche_id)
+        return self._get_object_from_content_type(
+            object_id=self.request.POST.get("fiche_id"), content_type_id=self.request.POST.get("content_type_id")
+        )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["next"] = self.request.GET.get("next")
+        context["object"] = self.get_fiche_object()
         return context
 
     def get_form_kwargs(self):
@@ -159,7 +162,7 @@ class ContactSelectionView(PreventActionIfVisibiliteBrouillonMixin, FormView):
 
         return safe_redirect(self.request.POST.get("next") + "#tabpanel-contacts-panel")
 
-    def form_invalid(self, form):
+    def form_invalid(self, form, **kwargs):
         add_form = ContactAddForm(
             initial={
                 "structure": form.data.get("structure"),
@@ -168,13 +171,17 @@ class ContactSelectionView(PreventActionIfVisibiliteBrouillonMixin, FormView):
                 "next": form.data.get("next"),
             }
         )
-        return render(
-            self.request,
-            self.template_name,
+        context = self.get_context_data(**kwargs)
+        context.update(
             {
                 "form": add_form,
                 "selection_form": form,
-            },
+            }
+        )
+        return render(
+            self.request,
+            self.template_name,
+            context,
         )
 
 
@@ -313,16 +320,14 @@ class MessageDetailsView(PreventActionIfVisibiliteBrouillonMixin, DetailView):
         return fiche
 
 
-class StructureAddFormView(PreventActionIfVisibiliteBrouillonMixin, FormView):
+class StructureAddFormView(PreventActionIfVisibiliteBrouillonMixin, WithObjectFromContentTypeMixin, FormView):
     template_name = "core/_structure_add_form.html"
     form_class = StructureAddForm
 
     def get_fiche_object(self):
         content_type_id = self.request.GET.get("content_type_id") or self.request.POST.get("content_type_id")
         fiche_id = self.request.GET.get("fiche_id") or self.request.POST.get("fiche_id")
-        content_type = ContentType.objects.get(pk=content_type_id)
-        ModelClass = content_type.model_class()
-        return get_object_or_404(ModelClass, pk=fiche_id)
+        return self._get_object_from_content_type(object_id=fiche_id, content_type_id=content_type_id)
 
     def get_initial(self):
         initial = super().get_initial()
@@ -331,7 +336,12 @@ class StructureAddFormView(PreventActionIfVisibiliteBrouillonMixin, FormView):
         initial["content_type_id"] = self.request.GET.get("content_type_id")
         return initial
 
-    def form_valid(self, form):
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["object"] = self.get_fiche_object()
+        return context
+
+    def form_valid(self, form, **kwargs):
         selection_form = StructureSelectionForm(
             fiche_id=form.cleaned_data.get("fiche_id"),
             content_type_id=form.cleaned_data.get("content_type_id"),
@@ -340,23 +350,23 @@ class StructureAddFormView(PreventActionIfVisibiliteBrouillonMixin, FormView):
                 "next": form.cleaned_data.get("next"),
             },
         )
-        return render(self.request, self.template_name, {"form": form, "selection_form": selection_form})
+        context = self.get_context_data(**kwargs)
+        context.update({"form": form, "selection_form": selection_form})
+        return render(self.request, self.template_name, context)
 
 
-class StructureSelectionView(PreventActionIfVisibiliteBrouillonMixin, FormView):
+class StructureSelectionView(PreventActionIfVisibiliteBrouillonMixin, WithObjectFromContentTypeMixin, FormView):
     template_name = "core/_structure_add_form.html"
     form_class = StructureSelectionForm
 
     def get_fiche_object(self):
         content_type_id = self.request.POST.get("content_type_id")
         fiche_id = self.request.POST.get("fiche_id")
-        content_type = ContentType.objects.get(pk=content_type_id)
-        ModelClass = content_type.model_class()
-        return get_object_or_404(ModelClass, pk=fiche_id)
+        return self._get_object_from_content_type(object_id=fiche_id, content_type_id=content_type_id)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["next"] = self.request.GET.get("next")
+        context["object"] = self.get_fiche_object()
         return context
 
     def get_form_kwargs(self):
@@ -370,7 +380,8 @@ class StructureSelectionView(PreventActionIfVisibiliteBrouillonMixin, FormView):
         )
         return kwargs
 
-    def form_invalid(self, form):
+    def form_invalid(self, form, **kwargs):
+        context = self.get_context_data(**kwargs)
         add_form = StructureAddForm(
             initial={
                 "fiche_id": form.data.get("fiche_id"),
@@ -379,14 +390,13 @@ class StructureSelectionView(PreventActionIfVisibiliteBrouillonMixin, FormView):
                 "structure_niveau1": form.data.get("structure_selected"),
             }
         )
-        return render(
-            self.request,
-            self.template_name,
+        context.update(
             {
                 "form": add_form,
                 "selection_form": form,
-            },
+            }
         )
+        return render(self.request, self.template_name, context)
 
     def form_valid(self, form):
         content_type = ContentType.objects.get(pk=form.cleaned_data["content_type_id"]).model_class()

--- a/sv/tests/test_evenement_contact_add.py
+++ b/sv/tests/test_evenement_contact_add.py
@@ -52,6 +52,21 @@ def test_add_contact_form(live_server, page, mocked_authentification_user):
     expect(page.get_by_role("button", name="Rechercher")).to_be_visible()
 
 
+@pytest.mark.django_db
+def test_cant_forge_url_to_create_open_redirect_add_contact_form(live_server, page):
+    evenement = EvenementFactory()
+    content_type = ContentType.objects.get_for_model(evenement)
+    url = (
+        reverse("structure-selection-add-form")
+        + f"?fiche_id={evenement.pk}&content_type_id={content_type.pk}&next=https://google.fr"
+    )
+    page.goto(f"{live_server.url}/{url}")
+
+    expect(page.get_by_role("link", name="Retour à l'évenement")).to_have_attribute(
+        "href", evenement.get_absolute_url()
+    )
+
+
 def test_cant_access_add_contact_form_if_evenement_brouillon(live_server, page):
     evenement = EvenementFactory(etat=Evenement.Etat.BROUILLON)
     content_type = ContentType.objects.get_for_model(evenement)

--- a/sv/tests/test_evenement_structure_add.py
+++ b/sv/tests/test_evenement_structure_add.py
@@ -39,6 +39,21 @@ def test_add_structure_form(live_server, page, contacts_structure):
 
 
 @pytest.mark.django_db
+def test_cant_forge_url_to_create_open_redirect_add_structure_form(live_server, page, contacts_structure):
+    evenement = EvenementFactory()
+    content_type = ContentType.objects.get_for_model(evenement)
+    url = (
+        reverse("contact-add-form")
+        + f"?fiche_id={evenement.pk}&content_type_id={content_type.pk}&next=https://google.fr"
+    )
+    page.goto(f"{live_server.url}/{url}")
+
+    expect(page.get_by_role("link", name="Retour à l'évenement")).to_have_attribute(
+        "href", evenement.get_absolute_url()
+    )
+
+
+@pytest.mark.django_db
 def test_add_structure_form_hides_empty_emails(live_server, page, contacts_structure):
     structure_1 = StructureFactory(niveau1="Level 1")
     structure_2 = StructureFactory(niveau1="Level 2")


### PR DESCRIPTION
Corrige deux failles de sécurité où un attaquant pouvait forger une URL pour controler l'URL de redirection lors du clic sur le lien de retour vers l'événement.
Correction de plusieurs vues pour que la fonction de mise à jour du contexte soit bien prise en compte.