### PR TITLE
Ajout organisme_nuisible et statut sur formulaire de la fiche zone

### DIFF
--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -92,7 +92,7 @@
             <div class="fr-grid-row fr-my-1w white-container--lite">
                 <div class="fr-col-6 fr-col-lg-4">
                     <div class="fr-mb-2v"><span class="bold fr-mr-2v">Organisme nuisible</span> {{ evenement.organisme_nuisible }}</div>
-                    <div class="fr-mb-2v"><span class="bold fr-mr-2v">Status réglementaire</span> {{ evenement.statut_reglementaire }}</div>
+                    <div class="fr-mb-2v"><span class="bold fr-mr-2v">Statut réglementaire</span> {{ evenement.statut_reglementaire }}</div>
                     <div class="fr-mb-2v"><span class="bold fr-mr-2v">Code OEPP</span> {{ evenement.organisme_nuisible.code_oepp }}</div>
                 </div>
                 <div class="fr-col-6 fr-col-lg-3">

--- a/sv/templates/sv/fichezonedelimitee_form.html
+++ b/sv/templates/sv/fichezonedelimitee_form.html
@@ -43,11 +43,11 @@
                     <p class="fr-h6">Risques</p>
                     <div class="fr-grid-row fr-mb-2w">
                         <div id="organisme-nuisible-label" class="fr-col-5">Organisme nuisible</div>
-                        <div class="fr-col">{{ fiche.evenement.organisme_nuisible }}</div>
+                        <div class="fr-col">{{ evenement.organisme_nuisible }}</div>
                     </div>
                     <div class="fr-grid-row">
                         <div id="statut-reglementaire-label" class="fr-col-5">Statut réglementaire</div>
-                        <div class="fr-col">{{ fiche.evenement.statut_reglementaire }}</div>
+                        <div class="fr-col">{{ evenement.statut_reglementaire }}</div>
                     </div>
                 </div>
             </div>

--- a/sv/tests/test_fichezonedelimitee_create.py
+++ b/sv/tests/test_fichezonedelimitee_create.py
@@ -211,3 +211,13 @@ def test_has_same_rayon_units_order_for_zone_tampon_and_zone_infestee(live_serve
     form_page = FicheZoneDelimiteeFormPage(page, choice_js_fill)
     form_page.goto_create_form_page(live_server, evenement)
     assert form_page.has_same_rayon_units_order_for_zone_tampon_and_zone_infestee() is True
+
+
+def test_shows_correct_organisme_and_statut(live_server, page: Page, choice_js_fill):
+    evenement = EvenementFactory()
+    form_page = FicheZoneDelimiteeFormPage(page, choice_js_fill)
+
+    form_page.goto_create_form_page(live_server, evenement)
+
+    expect(page.get_by_text(str(evenement.organisme_nuisible))).to_be_visible()
+    expect(page.get_by_text(str(evenement.statut_reglementaire))).to_be_visible()

--- a/sv/tests/test_fichezonedelimitee_update.py
+++ b/sv/tests/test_fichezonedelimitee_update.py
@@ -290,3 +290,12 @@ def test_cant_forge_update_of_zone_delimitee_i_cant_see(client):
     assert response.status_code == 403
     fiche_zone.refresh_from_db()
     assert fiche_zone.commentaire != "AAAA"
+
+
+def test_shows_correct_organisme_and_statut(live_server, page: Page):
+    evenement = EvenementFactory(fiche_zone_delimitee=FicheZoneFactory())
+
+    page.goto(f"{live_server.url}{evenement.fiche_zone_delimitee.get_update_url()}")
+
+    expect(page.get_by_text(str(evenement.organisme_nuisible))).to_be_visible()
+    expect(page.get_by_text(str(evenement.statut_reglementaire))).to_be_visible()

--- a/sv/tests/test_fichezonedelimitee_update_performance.py
+++ b/sv/tests/test_fichezonedelimitee_update_performance.py
@@ -3,7 +3,7 @@ from model_bakery import baker
 from sv.factories import FicheZoneFactory, EvenementFactory
 from sv.models import FicheDetection
 
-BASE_NUM_QUERIES = 20
+BASE_NUM_QUERIES = 16
 
 
 def test_update_fiche_zone_delimitee_form_with_multiple_existing_fiche_detection(


### PR DESCRIPTION
- Ajout de l'affichage des informations de l'événement sur le formulaire de création et MAJ
- Suppression des champs initialisés inutiles (dans la vue FicheZoneDelimiteeUpdateView/méthode get_initial)
- Ajout des tests correspondants
- Fix typo label statut réglementaire sur le détail de la fiche évènement