### PR TITLE
Mettre à jour les dépendances indirectes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ botocore==1.34.134
     # via
     #   boto3
     #   s3transfer
-certifi==2024.2.2
+certifi==2025.1.31
     # via
     #   requests
     #   sentry-sdk
@@ -137,7 +137,7 @@ python-slugify==8.0.4
     # via pytest-playwright
 pyyaml==6.0.1
     # via pre-commit
-requests==2.31.0
+requests==2.32.3
     # via
     #   mozilla-django-oidc
     #   pytest-base-url
@@ -151,7 +151,7 @@ six==1.16.0
     # via
     #   bleach
     #   python-dateutil
-sqlparse==0.4.4
+sqlparse==0.5.3
     # via
     #   django
     #   django-debug-toolbar
@@ -165,12 +165,12 @@ typing-extensions==4.11.0
     # via
     #   faker
     #   pyee
-urllib3==2.2.1
+urllib3==2.3.0
     # via
     #   botocore
     #   requests
     #   sentry-sdk
-virtualenv==20.25.3
+virtualenv==20.29.1
     # via pre-commit
 webencodings==0.5.1
     # via


### PR DESCRIPTION
Mise à jour des dépendances indirectes pour passer sur des versions sans failles de sécurités connues (analyse Dependabot).