### PR TITLE
Champs obligatoires sur les formulaires de modification d'un lieu, prelevement et evenement

### DIFF
--- a/core/static/core/base.css
+++ b/core/static/core/base.css
@@ -76,14 +76,20 @@ header{
 
 /* -- Champs obligatoires -- */
 label:has(+ input:required),
+label:has(+ input[data-required="true"]),
 label:has(+ select:required),
-label:has(+ .choices select:required), /* pour Choices.js */
+label:has(+ select[data-required="true"]),
+label:has(+ .choices select:required),
+label:has(+ .choices select[data-required="true"]),
 .required-field {
     font-weight: bold;
 }
 label:has(+ input:required)::after,
+label:has(+ input[data-required="true"])::after,
 label:has(+ select:required)::after,
-label:has(+ .choices select:required)::after,  /*pour Choices.js */
+label:has(+ select[data-required="true"])::after,
+label:has(+ .choices select:required)::after,
+label:has(+ .choices select[data-required="true"])::after,
 .required-field::after {
     content: "*";
 }

--- a/sv/templates/sv/evenement_form.html
+++ b/sv/templates/sv/evenement_form.html
@@ -39,7 +39,7 @@
                     <div class="fr-col-6">
                         <div class="white-container--lite">
                             <div class="fr-grid-row fr-grid-row--gutters">
-                                <div class="fr-col-3 evenement-form--label"><label class="fr-label" for="id_organisme_nuisible">Organisme Nuisible</label></div>
+                                <div class="fr-col-3 evenement-form--label"><label class="fr-label required-field" for="id_organisme_nuisible">Organisme Nuisible</label></div>
                                 <div class="fr-col-9">{{ form.organisme_nuisible}}</div>
                             </div>
                         </div>
@@ -47,7 +47,7 @@
                     <div class="fr-col-6">
                         <div class="white-container--lite">
                             <div class="fr-grid-row fr-grid-row--gutters">
-                                <div class="fr-col-3 evenement-form--label"><label class="fr-label" for="id_statut_reglementaire">Statut réglementaire</label></div>
+                                <div class="fr-col-3 evenement-form--label"><label class="fr-label required-field" for="id_statut_reglementaire">Statut réglementaire</label></div>
                                 <div class="fr-col-9">{{ form.statut_reglementaire}}</div>
                             </div>
                         </div>


### PR DESCRIPTION
- harmonise style des champs obligatoires
Problème : Les champs obligatoires n'avaient pas un style cohérent entre la création et la modification, car l'attribut HTML diffère (required vs data-required).
Solution : Ajout de sélecteurs CSS pour cibler les deux types d'attributs

- ajout organisme nuisible et statut réglementaire sur la fiche de modification d'un évènement