### PR TITLE
Améliore la sécurité de l'interface d'administration Django

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -7,6 +7,9 @@ SECRET_KEY=secret
 # DB
 DATABASE_URL=psql://user:password@127.0.0.1:8458/database_name
 
+# Django admin
+DJANGO_ADMIN_URL=mon_url_secrete_admin
+
 # Storage
 STORAGE_ENGINE="django.core.files.storage.FileSystemStorage"
 STORAGE_BUCKET_NAME="dev"

--- a/.env.dist
+++ b/.env.dist
@@ -10,6 +10,9 @@ DATABASE_URL=psql://user:password@127.0.0.1:8458/database_name
 # Django admin
 DJANGO_ADMIN_URL=mon_url_secrete_admin
 
+# SECURITY WARNING: don't run with the DJANGO_ADMIN_ENABLED turned on in production!
+DJANGO_ADMIN_ENABLED=True
+
 # Storage
 STORAGE_ENGINE="django.core.files.storage.FileSystemStorage"
 STORAGE_BUCKET_NAME="dev"

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -34,6 +34,7 @@ jobs:
           OIDC_RP_USER_ENDPOINT: null
           OIDC_RP_JWKS_ENDPOINT: null
           OIDC_RP_LOGOUT_ENDPOINT: null
+          DJANGO_ADMIN_URL: mon_url_secrete_admin
       - name: Run ruff
         run: ruff check .
       - name: Run ruff format
@@ -45,3 +46,4 @@ jobs:
         env:
           SECRET_KEY: NOT_A_REAL_SECRET
           DATABASE_URL: postgres://postgres:postgres@localhost/github_actions
+          DJANGO_ADMIN_URL: mon_url_secrete_admin

--- a/core/tests/test_settings.py
+++ b/core/tests/test_settings.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.mark.django_db
+def test_default_admin_url_not_accessible(admin_client):
+    """Vérifie que l'URL par défaut 'admin/' n'est pas accessible"""
+    response = admin_client.get("/admin/")
+    assert response.status_code == 404

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -26,7 +26,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # Environment variables (django-environ)
 env = environ.Env(
     # set casting and default value
-    DEBUG=(bool, False)
+    DEBUG=(bool, False),
+    DJANGO_ADMIN_ENABLED=(bool, False),
 )
 # Take environment variables from .env file
 env.read_env(os.path.join(BASE_DIR, ".env"))
@@ -48,11 +49,11 @@ ADMIN_URL = os.environ.get("DJANGO_ADMIN_URL")
 if not ADMIN_URL:
     raise ImproperlyConfigured("DJANGO_ADMIN_URL doit être défini dans les variables d'environnement")
 
+ADMIN_ENABLED = env("DJANGO_ADMIN_ENABLED")
 
 # Application definition
 
 INSTALLED_APPS = [
-    "django.contrib.admin",
     "django.contrib.auth",
     "mozilla_django_oidc",
     "django.contrib.contenttypes",
@@ -66,6 +67,8 @@ INSTALLED_APPS = [
     "post_office",
     "reversion",
 ]
+if ADMIN_ENABLED:
+    INSTALLED_APPS.append("django.contrib.admin")
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import environ
 import tempfile
 import sentry_sdk
+from django.core.exceptions import ImproperlyConfigured
 from sentry_sdk.integrations.django import DjangoIntegration
 from django.urls import reverse_lazy
 
@@ -41,6 +42,11 @@ SECRET_KEY = env("SECRET_KEY")
 DEBUG = env("DEBUG")
 
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["127.0.0.1", "localhost"])
+
+# Django admin URL
+ADMIN_URL = os.environ.get("DJANGO_ADMIN_URL")
+if not ADMIN_URL:
+    raise ImproperlyConfigured("DJANGO_ADMIN_URL doit être défini dans les variables d'environnement")
 
 
 # Application definition

--- a/seves/urls.py
+++ b/seves/urls.py
@@ -29,7 +29,7 @@ admin.site.index_title = "Bienvenue sur l'administration de Sèves"
 urlpatterns = [
     path("", RedirectView.as_view(pattern_name="fiche-liste"), name="index"),
     path("login-eap-callback", OIDCCallbackClass.as_view(), name="custom_oidc_authentication_callback"),
-    path("admin/", admin.site.urls),
+    path(f"{settings.ADMIN_URL}/", admin.site.urls),
     path("sv/", include("sv.urls"), name="sv-index"),
     path("core/", include("core.urls"), name="core"),
     path("account/", include("account.urls"), name="account"),

--- a/seves/urls.py
+++ b/seves/urls.py
@@ -16,26 +16,29 @@ Including another URLconf
 """
 
 from mozilla_django_oidc.urls import OIDCCallbackClass
-from django.contrib import admin
 from django.urls import path, include
 from django.views.generic.base import RedirectView
 from django.conf import settings
 
-# Personnalisation du titre et de l'en-tête de l'interface d'administration
-admin.site.site_header = "Administration de Sèves"
-admin.site.site_title = "Sèves"
-admin.site.index_title = "Bienvenue sur l'administration de Sèves"
 
 urlpatterns = [
     path("", RedirectView.as_view(pattern_name="fiche-liste"), name="index"),
     path("login-eap-callback", OIDCCallbackClass.as_view(), name="custom_oidc_authentication_callback"),
-    path(f"{settings.ADMIN_URL}/", admin.site.urls),
     path("sv/", include("sv.urls"), name="sv-index"),
     path("core/", include("core.urls"), name="core"),
     path("account/", include("account.urls"), name="account"),
     path("oidc/", include("mozilla_django_oidc.urls")),
 ]
 
+if settings.ADMIN_ENABLED:
+    from django.contrib import admin
+
+    admin.site.site_header = "Administration de Sèves"
+    admin.site.site_title = "Sèves"
+    admin.site.index_title = "Bienvenue sur l'administration de Sèves"
+    urlpatterns += [
+        path(f"{settings.ADMIN_URL}/", admin.site.urls),
+    ]
 
 if settings.DEBUG:
     urlpatterns.append(path("__debug__/", include("debug_toolbar.urls")))


### PR DESCRIPTION
Cette PR améliore la sécurité de l'interface d'administration Django en 

- personnalisant son URL d'accès via une variable d'environnement. Cette modification empêche l'exposition de l'URL dans le code source et retire la valeur par défaut "admin",
- désactivant l'accès à l'administration par défaut.

## Configuration de l'URL de Django Admin via une variable d'environnement
- Ajout de la variable d'environnement DJANGO_ADMIN_URL
- Configuration du settings.py pour vérifier la présence de l'URL personnalisée
- Mise à jour des URLs pour utiliser la nouvelle configuration
- Validation de la présence de la variable au démarrage du serveur
- Ajout d'un test pour vérifier que l'ancienne URL "admin/" est non accessible

## Désactivation de Django admin par défaut
- Ajoute de la variable d'environnement DJANGO_ADMIN_ENABLED (activation explicite de l'interface - False par défaut)
- Retrait de django.contrib.admin des INSTALLED_APPS quand désactivé
- Déplacement de la configuration admin dans le bloc conditionnel