### PR TITLE
Amélioration de l'affichage du menu déroulant espece échantillon

### DIFF
--- a/sv/static/sv/fichedetection_prelevement_form.js
+++ b/sv/static/sv/fichedetection_prelevement_form.js
@@ -27,6 +27,7 @@ function addChoicesEspeceEchantillon(element){
         searchResultLimit: 50,
         classNames: {containerInner: 'fr-select'},
         itemSelectText: '',
+        position: 'top',
     });
     choicesEspece.input.element.addEventListener('input', function (event) {
         const query = choicesEspece.input.element.value


### PR DESCRIPTION
Problème:
Quand on fait une recherche dans Espèce de l’échantillon, on ne peut pas scroller donc on voit uniquement la première espèce.

Solution:
Modification du select pour que la liste s'ouvre vers le haut plutôt que vers le bas (ajout de l'option position "up" sur choicejs).