### PR TITLE
Amélioration affichage et mise à jour de la visibilité

### DIFF
--- a/core/fields.py
+++ b/core/fields.py
@@ -27,6 +27,19 @@ class MultiModelChoiceField(forms.MultipleChoiceField):
 class DSFRCheckboxSelectMultiple(forms.CheckboxSelectMultiple):
     option_template_name = "forms/dsfr_checkbox_option.html"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.disabled_choices = []
+        self.checked_choices = []
+
+    def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
+        option = super().create_option(name, value, label, selected, index, subindex, attrs)
+        if value in self.disabled_choices:
+            option["attrs"]["disabled"] = "disabled"
+        if value in self.checked_choices:
+            option["attrs"]["checked"] = "checked"
+        return option
+
 
 class DSFRToogle(forms.CheckboxInput):
     template_name = "forms/dsfr_toogle.html"

--- a/core/mixins.py
+++ b/core/mixins.py
@@ -200,6 +200,15 @@ class WithVisibiliteMixin(models.Model):
             return True
         return False
 
+    def get_visibilite_display_text(self) -> str:
+        match self.visibilite:
+            case Visibilite.LOCALE:
+                return f"{self.createur}, {MUS_STRUCTURE}, {BSV_STRUCTURE}"
+            case Visibilite.LIMITEE:
+                return ", ".join(str(s) for s in self.allowed_structures.all())
+            case Visibilite.NATIONALE:
+                return "Toutes les structures"
+
     def save(self, *args, **kwargs):
         if self.pk:
             if self.is_visibilite_limitee and self.allowed_structures.count() == 0:

--- a/core/static/core/structure_add_form.js
+++ b/core/static/core/structure_add_form.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', function() {
     const form = document.querySelector('#structures-form');
-    const checkboxes = form.querySelectorAll('input[type=checkbox]');
+    const checkboxes = form.querySelectorAll('input[type=checkbox]:not([disabled])');
+
 
     function init() {
         form.addEventListener('submit', validateForm);

--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -102,21 +102,17 @@
                 </div>
                 <div class="fr-col-6 fr-col-lg-5">
                     <span class="bold fr-mr-2v">Visibilité</span>
-                    {% if evenement.is_visibilite_locale %}
-                        Locale
-                    {% elif evenement.is_visibilite_nationale %}
-                        Toutes les structures
-                    {% else %}
-                        {% with  evenement.allowed_structures.all|join:', ' as structures_str %}
-                            {% if structures_str|length > 150 %}
+                    <span data-testid="evenement-visibilite">
+                        {% with structures_str=evenement.get_visibilite_display_text %}
+                            {% if evenement.is_visibilite_limitee and structures_str|length > 150 %}
                                 {{ structures_str|truncatechars:150 }}
-                                <button class="fr-btn--tooltip fr-btn" aria-describedby="tooltip-2989" type="button" id="button-2995"></button>
-                                <span class="fr-tooltip fr-placement" id="tooltip-2989" role="tooltip" aria-hidden="true">{{ evenement.allowed_structures.all|join:', ' }}</span>
+                                <button class="fr-btn--tooltip fr-btn" aria-describedby="tooltip-visibilite" type="button"></button>
+                                <span class="fr-tooltip fr-placement" id="tooltip-visibilite" role="tooltip" aria-hidden="true">{{ structures_str }}</span>
                             {% else %}
                                 {{ structures_str }}
                             {% endif %}
                         {% endwith %}
-                    {% endif %}
+                    </span>
                 </div>
 
             </div>

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -211,8 +211,8 @@ def test_can_add_and_see_compte_rendu(live_server, page: Page):
     page.get_by_test_id("element-actions").click()
     page.get_by_test_id("fildesuivi-actions-compte-rendu").click()
 
-    page.get_by_text("MUS").click()
-    page.get_by_text("BSV").click()
+    page.get_by_text("MUS", exact=True).click()
+    page.get_by_text("BSV", exact=True).click()
     page.locator("#id_title").fill("Title of the message")
     page.locator("#id_content").fill("My content \n with a line return")
     page.get_by_test_id("fildesuivi-add-submit").click()


### PR DESCRIPTION
Cette PR est découpée en deux parties : 

- Amélioration de l'affichage de la visibilité 
Lorsque la visibilité est locale, on affiche la structure créatrice et les structures de l'AC (MUS et BSV).
J'ai ajouté une fonction `get_visibilite_display_text` dans le mixin `WithVisibiliteMixin` pour alléger la logique d'affichage dans le template.
Ajout des tests.

- Mise à jour visibilité : cases AC et créateur pré-cochées et désactivées 
Sur le formulaire d'ajout de structure lorsque la visibilité est limitée, les cases correspondantes à la structure créatrice et les structures de l'AC (MUS et BSV) sont cochées et désactivées.
Ajout d'un test.

J'ai volontairement laissé les deux commits pour bien séparer les modifs.