### PR TITLE
Corriger les migrations et les settings

### DIFF
--- a/core/migrations/0024_document_is_infected.py
+++ b/core/migrations/0024_document_is_infected.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("core", "0022_alter_document_document_type"),
+        ("core", "0023_alter_document_file"),
     ]
 
     operations = [

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -45,11 +45,12 @@ DEBUG = env("DEBUG")
 ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["127.0.0.1", "localhost"])
 
 # Django admin URL
-ADMIN_URL = os.environ.get("DJANGO_ADMIN_URL")
-if not ADMIN_URL:
-    raise ImproperlyConfigured("DJANGO_ADMIN_URL doit être défini dans les variables d'environnement")
-
 ADMIN_ENABLED = env("DJANGO_ADMIN_ENABLED")
+if ADMIN_ENABLED:
+    ADMIN_URL = os.environ.get("DJANGO_ADMIN_URL")
+    if not ADMIN_URL:
+        raise ImproperlyConfigured("DJANGO_ADMIN_URL doit être défini dans les variables d'environnement")
+
 
 # Application definition
 

--- a/sv/tests/test_evenement_documents.py
+++ b/sv/tests/test_evenement_documents.py
@@ -428,7 +428,7 @@ def test_add_document_is_scanned_by_antivirus(live_server, page: Page, mocked_au
     page.locator("#id_nom").fill("Name of the document")
     page.locator("#fr-modal-add-doc #id_document_type").select_option(Document.TypeDocument.COMPTE_RENDU_REUNION)
     page.locator("#id_description").fill("Description")
-    page.locator("#fr-modal-add-doc").locator("#id_file").set_input_files("README.md")
+    page.locator("#fr-modal-add-doc").locator("#id_file").set_input_files("static/images/marianne.png")
     page.get_by_test_id("documents-send").click()
 
     assert evenement.documents.count() == 1


### PR DESCRIPTION
Corriger deux migrations qui avaient le même numéro. N'oblige pas à la présence du settings `DJANGO_ADMIN_URL` si l'admin est désactivé.