### PR TITLE
Améliorer les performances de l'événement

### DIFF
--- a/sv/models/fiches_detection.py
+++ b/sv/models/fiches_detection.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 import reversion
 from django.core.validators import MinValueValidator
 from django.db import models
@@ -261,7 +263,7 @@ class FicheDetection(
         if self.zone_infestee and self.zone_infestee.fiche_zone_delimitee:
             return self.zone_infestee.fiche_zone_delimitee
 
-    @property
+    @cached_property
     def latest_version(self):
         lieux_ids = list(self.lieux.all().values_list("id", flat=True))
         lieu_versions = get_versions_from_ids(lieux_ids, Lieu)

--- a/sv/models/fiches_zone_delimitee.py
+++ b/sv/models/fiches_zone_delimitee.py
@@ -1,3 +1,5 @@
+from functools import cached_property
+
 import reversion
 from django.core.validators import MinValueValidator
 from django.db import models
@@ -70,7 +72,7 @@ class FicheZoneDelimitee(models.Model):
         with reversion.create_revision():
             super().save(*args, **kwargs)
 
-    @property
+    @cached_property
     def latest_version(self):
         zone_infestees = ZoneInfestee.objects.filter(fiche_zone_delimitee_id=self.pk).values_list("id", flat=True)
         zone_infestees_versions = get_versions_from_ids(zone_infestees, ZoneInfestee)

--- a/sv/tests/test_evenement_performance_details.py
+++ b/sv/tests/test_evenement_performance_details.py
@@ -47,11 +47,11 @@ def test_evenement_performances_with_lieux(client, django_assert_num_queries):
     fiche_detection = FicheDetectionFactory(evenement=evenement)
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 11):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 8):
         client.get(evenement.get_absolute_url())
 
     baker.make(Lieu, fiche_detection=fiche_detection, _quantity=3, _fill_optional=True)
-    with django_assert_num_queries(BASE_NUM_QUERIES + 18):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 14):
         client.get(evenement.get_absolute_url())
 
 
@@ -75,12 +75,12 @@ def test_evenement_performances_with_prelevement(client, django_assert_num_queri
     fiche_detection = FicheDetectionFactory(evenement=evenement)
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 11):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 8):
         client.get(evenement.get_absolute_url())
 
     PrelevementFactory.create_batch(3, lieu__fiche_detection=fiche_detection)
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 19):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 14):
         client.get(evenement.get_absolute_url())
 
 
@@ -123,5 +123,5 @@ def test_fiche_zone_delimitee_with_multiple_zone_infestee(
 
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 44):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 32):
         client.get(evenement.get_absolute_url())

--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -179,6 +179,7 @@ def test_saving_without_changes_does_create_revision(
     page.wait_for_timeout(600)
 
     fiche.refresh_from_db()
+    del fiche.latest_version
     assert latest_version.pk != fiche.latest_version.pk
     assert latest_version.revision.date_created <= fiche.latest_version.revision.date_created
 

--- a/sv/tests/test_models.py
+++ b/sv/tests/test_models.py
@@ -414,11 +414,13 @@ def test_fiche_detection_latest_revision():
 
     fiche_detection.commentaire = "Lorem"
     fiche_detection.save()
+    del fiche_detection.latest_version
     assert latest_version.pk != fiche_detection.latest_version.pk
     assert latest_version.revision.date_created < fiche_detection.latest_version.revision.date_created
 
     latest_version = fiche_detection.latest_version
     lieu = LieuFactory(fiche_detection=fiche_detection, nom="Maison")
+    del fiche_detection.latest_version
     assert latest_version.pk != fiche_detection.latest_version.pk
     assert latest_version.revision.date_created < fiche_detection.latest_version.revision.date_created
     assert fiche_detection.latest_version.revision.comment == "Le lieu 'Maison' a été ajouté à la fiche"
@@ -426,12 +428,14 @@ def test_fiche_detection_latest_revision():
     latest_version = fiche_detection.latest_version
     lieu.nom = "Nouvelle maison"
     lieu.save()
+    del fiche_detection.latest_version
     assert latest_version.pk != fiche_detection.latest_version.pk
     assert latest_version.revision.date_created < fiche_detection.latest_version.revision.date_created
 
     latest_version = fiche_detection.latest_version
     structure_sivep, _ = StructurePreleveuse.objects.get_or_create(nom="SIVEP")
     prelevement = PrelevementFactory(lieu=lieu, structure_preleveuse=structure_sivep)
+    del fiche_detection.latest_version
     assert latest_version.pk != fiche_detection.latest_version.pk
     assert latest_version.revision.date_created < fiche_detection.latest_version.revision.date_created
     assert (
@@ -443,11 +447,13 @@ def test_fiche_detection_latest_revision():
     new_structure, _ = StructurePreleveuse.objects.get_or_create(nom="SEMAE")
     prelevement.structure_preleveuse = new_structure
     prelevement.save()
+    del fiche_detection.latest_version
     assert latest_version.pk != fiche_detection.latest_version.pk
     assert latest_version.revision.date_created < fiche_detection.latest_version.revision.date_created
 
     latest_version = fiche_detection.latest_version
     prelevement.delete()
+    del fiche_detection.latest_version
     assert latest_version.pk != fiche_detection.latest_version.pk
     assert latest_version.revision.date_created < fiche_detection.latest_version.revision.date_created
     assert (
@@ -457,6 +463,7 @@ def test_fiche_detection_latest_revision():
 
     latest_version = fiche_detection.latest_version
     lieu.delete()
+    del fiche_detection.latest_version
     assert latest_version.pk != fiche_detection.latest_version.pk
     assert latest_version.revision.date_created < fiche_detection.latest_version.revision.date_created
     assert fiche_detection.latest_version.revision.comment == "Le lieu 'Nouvelle maison' a été supprimé de la fiche"
@@ -478,6 +485,7 @@ def test_fiche_detection_latest_revision_performances(django_assert_num_queries)
     LieuFactory(fiche_detection=fiche_detection)
     PrelevementFactory(lieu__fiche_detection=fiche_detection)
 
+    del fiche_detection.latest_version
     with django_assert_num_queries(5):
         assert fiche_detection.latest_version is not None
 
@@ -490,11 +498,13 @@ def test_fiche_zone_delimitee_latest_revision():
 
     fiche_zone_delimitee.commentaire = "Lorem"
     fiche_zone_delimitee.save()
+    del fiche_zone_delimitee.latest_version
     assert latest_version.pk != fiche_zone_delimitee.latest_version.pk
     assert latest_version.revision.date_created < fiche_zone_delimitee.latest_version.revision.date_created
 
     latest_version = fiche_zone_delimitee.latest_version
     zone_infestee = ZoneInfesteeFactory(fiche_zone_delimitee=fiche_zone_delimitee, nom="Zone 3")
+    del fiche_zone_delimitee.latest_version
     assert latest_version.pk != fiche_zone_delimitee.latest_version.pk
     assert latest_version.revision.date_created < fiche_zone_delimitee.latest_version.revision.date_created
     assert fiche_zone_delimitee.latest_version.revision.comment == "La zone infestée 'Zone 3' a été ajoutée à la fiche"
@@ -502,11 +512,13 @@ def test_fiche_zone_delimitee_latest_revision():
     latest_version = fiche_zone_delimitee.latest_version
     zone_infestee.nom = "Zone 4"
     zone_infestee.save()
+    del fiche_zone_delimitee.latest_version
     assert latest_version.pk != fiche_zone_delimitee.latest_version.pk
     assert latest_version.revision.date_created < fiche_zone_delimitee.latest_version.revision.date_created
 
     latest_version = fiche_zone_delimitee.latest_version
     zone_infestee.delete()
+    del fiche_zone_delimitee.latest_version
     assert latest_version.pk != fiche_zone_delimitee.latest_version.pk
     assert latest_version.revision.date_created < fiche_zone_delimitee.latest_version.revision.date_created
     assert (


### PR DESCRIPTION
En utilisant une cached_property pour les dernières version des détections et de la zone, on économise des requêtes SQL. En effet nous avons besoin de cette information à 2 endroits, une première fois pour la date de dernière modification d'une détection et une deuxième fois pour trouver la date de dernière modification d'un événément.