### PR TITLE
Fix bug qui empêchait la création d'une nouvelle détection (sans évènement)

### DIFF
--- a/sv/static/sv/fichedetection_prelevement_form.js
+++ b/sv/static/sv/fichedetection_prelevement_form.js
@@ -100,7 +100,6 @@ function showAddPrelevementmodal(event) {
     const currentModal = getNextAvailablePrelevementModal()
     modalHTMLContent[currentModal.dataset.id] = currentModal.querySelector(".fr-modal__content").innerHTML
     populateLieuSelect(currentModal.querySelector((`[id^="id_prelevements-"][id$="-lieu"]`)))
-
     dataRequiredToRequired(currentModal)
     dsfr(currentModal).modal.disclose();
 }
@@ -142,15 +141,9 @@ function savePrelevement(event){
 function saveModalWhenOpening(event){
     const modalId = event.target.getAttribute("id").split("-").pop()
     populateLieuSelect(event.target.querySelector((`[id^="id_prelevements-"][id$="-lieu"]`)))
-    modalHTMLContent[modalId] = event.target.querySelector(".fr-modal__content").innerHTML
-}
-
-
-function resetModalWhenClosing(event){
-    const originalTarget = event.explicitOriginalTarget
-    if (! originalTarget.classList.contains("prelevement-save-btn")){
-        const modalId = event.originalTarget.getAttribute("id").split("-").pop()
-        event.originalTarget.querySelector(".fr-modal__content").innerHTML = modalHTMLContent[modalId]
+    // On ne sauvegarde que si ce n'est pas déjà fait (cas de la modification)
+    if (!modalHTMLContent[modalId]) {
+        modalHTMLContent[modalId] = event.target.querySelector(".fr-modal__content").innerHTML
     }
 }
 
@@ -181,6 +174,17 @@ function handleChangeTypeAnalyse(event){
     });
 }
 
+function handleModalClose(event) {
+    const modal = event.target.closest('dialog');
+    const modalId = modal.id.split('-').pop();
+    const modalContent = modal.querySelector('.fr-modal__content');
+    // Réinitialise le contenu
+    if (modalContent && modalHTMLContent[modalId]) {
+        modalContent.innerHTML = modalHTMLContent[modalId];
+    }
+    dsfr(modal).modal.conceal();
+}
+
 (function() {
     showOrHidePrelevementUI()
     document.getElementById("btn-add-prelevment").addEventListener("click", showAddPrelevementmodal)
@@ -189,10 +193,10 @@ function handleChangeTypeAnalyse(event){
     document.querySelectorAll("select[id$=espece-echantillon]").forEach(element => addChoicesEspeceEchantillon(element))
     document.querySelectorAll("select[id$=structure_preleveuse]").forEach(element => element.addEventListener("change", setIsOfficiel))
     document.querySelectorAll("input[name$=type_analyse]").forEach(element => element.addEventListener("change", handleChangeTypeAnalyse))
-    document.querySelectorAll("[id^=modal-add-edit-prelevement-]").forEach(modal => modal.addEventListener('dsfr.conceal', resetModalWhenClosing))
     document.querySelectorAll("[id^=modal-add-edit-prelevement-]").forEach(modal => modal.addEventListener('dsfr.disclose', saveModalWhenOpening))
-    document.querySelectorAll("[id^=modal-add-edit-prelevement-] .fr-btn--close").forEach(element => element.addEventListener("click", closeDSFRModal))
-    document.querySelectorAll("[id^=modal-add-edit-prelevement-] .prelevement-cancel-btn").forEach(element => element.addEventListener("click", closeDSFRModal))
+    document.querySelectorAll("[id^=modal-add-edit-prelevement-] .fr-btn--close, [id^=modal-add-edit-prelevement-] .prelevement-cancel-btn")
+        .forEach(button => button.addEventListener('click', handleModalClose));
+
     document.querySelectorAll("[id^=modal-add-edit-prelevement-]").forEach(element =>{
         if (element.dataset.alreadyExisting){
             const data = buildPrelevementCardFromModal(element)

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -533,3 +533,28 @@ def test_can_add_fiche_detection_from_existing_evenement(live_server, page: Page
 
     page.wait_for_timeout(600)
     assert FicheDetection.objects.count() == 1
+
+
+def test_can_add_fiche_detection_when_open_and_closed_prelevement_form_modal(
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    prelevement_form_elements: PrelevementFormDomElements,
+    choice_js_fill,
+):
+    organisme_nuisible, _ = OrganismeNuisible.objects.get_or_create(
+        libelle_court="Mon ON",
+        libelle_long="Mon ON",
+    )
+    page.goto(f"{live_server.url}{reverse('fiche-detection-creation')}")
+    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
+    form_elements.add_lieu_btn.click()
+    lieu_form_elements = LieuFormDomElements(page)
+    lieu_form_elements.nom_input.fill("test lieu")
+    lieu_form_elements.save_btn.click()
+    form_elements.add_prelevement_btn.click()
+    prelevement_form_elements.cancel_btn.click()
+    form_elements.publish_btn.click()
+    page.wait_for_timeout(600)
+    assert FicheDetection.objects.count() == 1

--- a/sv/tests/test_utils.py
+++ b/sv/tests/test_utils.py
@@ -294,7 +294,7 @@ class PrelevementFormDomElements:
 
     @property
     def cancel_btn(self) -> Locator:
-        return self.page.get_by_role("button", name="Annuler")
+        return self.page.get_by_role("link", name="Annuler")
 
     @property
     def save_btn(self) -> Locator:


### PR DESCRIPTION
Problème :
Les attributs required ne sont pas retirés lors de la fermeture de la modale. 
Lors de l'ajout d'un nouveau prélèvement, les champs avec data-required ajoutent un attribut required. Mais quand j'annule le formulaire (via bouton annuler), le champ required reste. 
Donc lors de l'enregistrement de la nouvelle fiche, cela génère des erreurs js car les champs required sont vides et cachés.

Solution :
Retirer les attributs required ajoutés par data-required lors de la fermeture de la modale. 
De cette façon, lorsque la modale est fermée, tous les attributs required seront retirés, et le formulaire principal ne tentera pas de valider ces champs cachés.