### PR TITLE
Corriger la configuration des tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -22,3 +22,4 @@ env =
     ROOT_URL=http://testserver.com
     BYPASS_ANTIVIRUS=True
     SCALINGO_REDIS_URL=redis://127.0.0.1:6379
+    DJANGO_ADMIN_ENABLED=


### PR DESCRIPTION
Comme la valeur n'est pas précisée dans pytest.ini, la valeur de l'env courant est prise, ce qui empêche d'activer l'admin en local.