### PR TITLE
Améliorer les performances de la page événement

### DIFF
--- a/sv/models/fiches_detection.py
+++ b/sv/models/fiches_detection.py
@@ -274,8 +274,7 @@ class FicheDetection(
 
     @cached_property
     def latest_version(self):
-        lieux_ids = list(self.lieux.all().values_list("id", flat=True))
-        lieu_versions = get_versions_from_ids(lieux_ids, Lieu)
+        lieu_versions = get_versions_from_ids([lieu.id for lieu in self.lieux.all()], Lieu)
 
         prelevements = Prelevement.objects.filter(lieu__fiche_detection__pk=self.pk).values_list("id", flat=True)
         prelevement_versions = get_versions_from_ids(prelevements, Prelevement)

--- a/sv/tests/test_evenement_performance_details.py
+++ b/sv/tests/test_evenement_performance_details.py
@@ -47,11 +47,11 @@ def test_evenement_performances_with_lieux(client, django_assert_num_queries):
     fiche_detection = FicheDetectionFactory(evenement=evenement)
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 7):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 6):
         client.get(evenement.get_absolute_url())
 
     baker.make(Lieu, fiche_detection=fiche_detection, _quantity=3, _fill_optional=True)
-    with django_assert_num_queries(BASE_NUM_QUERIES + 13):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 12):
         client.get(evenement.get_absolute_url())
 
 
@@ -75,12 +75,12 @@ def test_evenement_performances_with_prelevement(client, django_assert_num_queri
     fiche_detection = FicheDetectionFactory(evenement=evenement)
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 7):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 6):
         client.get(evenement.get_absolute_url())
 
     PrelevementFactory.create_batch(3, lieu__fiche_detection=fiche_detection)
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 13):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 12):
         client.get(evenement.get_absolute_url())
 
 
@@ -123,5 +123,5 @@ def test_fiche_zone_delimitee_with_multiple_zone_infestee(
 
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 28):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 25):
         client.get(evenement.get_absolute_url())


### PR DESCRIPTION
L'utilisation de values_list pouvait sembler une bonne idée, mais les lieux sont déjà pré-chargés par ailleurs. Construire la liste en python retire une requete SQL et sera aussi performant car le nombre de Lieux par fiche est faible (<100).
Comme on utilise plusieurs fois cette méthode sur la fiche événement (une fois par détection), plusieurs requêtes sont retirées dans un cas "réaliste".