### PR TITLE
Retirer du JavaScript au sein du HTML

### DIFF
--- a/core/static/core/base.js
+++ b/core/static/core/base.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll(".btn--close-js").forEach(element => element.addEventListener("click", event =>{
+        event.preventDefault()
+        const alert = event.target.parentNode;
+        alert.parentNode.removeChild(alert)
+    }))})
+
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll(".btn--close-notice-js").forEach(element => element.addEventListener("click", event =>{
+        event.preventDefault()
+        const notice = event.target.parentNode.parentNode.parentNode;
+        notice.parentNode.removeChild(notice)
+    }))})

--- a/core/templates/core/_contact_add_form.html
+++ b/core/templates/core/_contact_add_form.html
@@ -7,20 +7,8 @@
 {% endblock %}
 
 {% block scripts %}
-    <script>
-        document.addEventListener('DOMContentLoaded', function() {
-            const element = document.getElementById('id_structure');
-            const choices = new Choices(element, {
-                itemSelectText: '',
-                classNames: {
-                    containerInner: 'fr-select fr-mt-1w',
-                },
-                searchResultLimit: 500,
-            });
-        });
-    </script>
+    <script type="text/javascript" src="{% static 'sv/contact_add_form.js' %}"></script>
 {% endblock %}
-
 
 {% block content %}
     <div class="fr-container">
@@ -62,14 +50,7 @@
                                     {% if selection_form.contacts.errors %}
                                         <div class="grid-row">
                                             <div class="fr-col-8">
-                                                <div class="fr-alert fr-alert--error fr-alert--sm fr-mb-4w">
-                                                    {% for error in selection_form.contacts.errors %}
-                                                        <p>{{ error }}</p>
-                                                    {% endfor %}
-                                                    <button class="fr-btn--close fr-btn" title="Masquer le message" onclick="const alert = this.parentNode; alert.parentNode.removeChild(alert)">
-                                                        Masquer le message
-                                                    </button>
-                                                </div>
+                                                {% include "core/_show_form_errors.html" with errors=selection_form.contacts.errors classes="fr-alert--sm" %}
                                             </div>
                                         </div>
                                     {% endif %}

--- a/core/templates/core/_messages.html
+++ b/core/templates/core/_messages.html
@@ -4,7 +4,7 @@
             {% if value in message.extra_tags %}
                 <div class="fr-alert fr-alert--{{ message.level_tag }}">
                     <h3 class="fr-alert__title">{{message}}</h3>
-                    <button class="fr-btn--close fr-btn" title="Masquer le message" onclick="const alert = this.parentNode; alert.parentNode.removeChild(alert)">
+                    <button class="fr-btn--close fr-btn btn--close-js" title="Masquer le message">
                         Masquer le message
                     </button>
                 </div>

--- a/core/templates/core/_show_form_errors.html
+++ b/core/templates/core/_show_form_errors.html
@@ -1,0 +1,8 @@
+<div class="fr-alert fr-alert--error fr-mb-4w {{ classes }}">
+    {% for error in errors %}
+        <p>{{ error }}</p>
+    {% endfor %}
+    <button class="fr-btn--close fr-btn btn--close-js" title="Masquer le message">
+        Masquer le message
+    </button>
+</div>

--- a/core/templates/core/_structure_add_form.html
+++ b/core/templates/core/_structure_add_form.html
@@ -29,14 +29,7 @@
                         {% if form.errors %}
                             <div class="grid-row">
                                 <div class="fr-col-8">
-                                    <div class="fr-alert fr-alert--error fr-alert--sm fr-mb-4w">
-                                        {% for error in form.errors %}
-                                            <p>{{ error }}</p>
-                                        {% endfor %}
-                                        <button class="fr-btn--close fr-btn" title="Masquer le message" onclick="const alert = this.parentNode; alert.parentNode.removeChild(alert)">
-                                            Masquer le message
-                                        </button>
-                                    </div>
+                                    {% include "core/_show_form_errors.html" with errors=form.errors classes="fr-alert--sm" %}
                                 </div>
                             </div>
                         {% endif %}
@@ -75,14 +68,7 @@
                                     {% if selection_form.contacts.errors %}
                                         <div class="grid-row">
                                             <div class="fr-col-8">
-                                                <div class="fr-alert fr-alert--error fr-alert--sm fr-mb-4w">
-                                                    {% for error in selection_form.contacts.errors %}
-                                                        <p>{{ error }}</p>
-                                                    {% endfor %}
-                                                    <button class="fr-btn--close fr-btn" title="Masquer le message" onclick="const alert = this.parentNode; alert.parentNode.removeChild(alert)">
-                                                        Masquer le message
-                                                    </button>
-                                                </div>
+                                                {% include "core/_show_form_errors.html" with errors=selection_form.contacts.errors classes="fr-alert--sm" %}
                                             </div>
                                         </div>
                                     {% endif %}

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -103,7 +103,7 @@
                 {% if "core" not in message.extra_tags %}
                     <div class="fr-alert fr-alert--{{ message.level_tag }}">
                         <h3 class="fr-alert__title">{{message}}</h3>
-                        <button class="fr-btn--close fr-btn" title="Masquer le message" onclick="const alert = this.parentNode; alert.parentNode.removeChild(alert)">
+                        <button class="fr-btn--close fr-btn btn--close-js" title="Masquer le message">
                             Masquer le message
                         </button>
                     </div>
@@ -117,6 +117,7 @@
     <script type="module" src="{% static 'dsfr.module.min.js' %}"></script>
     <script type="text/javascript" nomodule src="{% static 'dsfr.nomodule.min.js' %}"></script>
     <script src="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/scripts/choices.min.js"></script>
+    <script type="text/javascript" src="{% static 'core/base.js' %}"></script>
     {% block scripts %}{% endblock %}
 </body>
 

--- a/sv/static/sv/contact_add_form.js
+++ b/sv/static/sv/contact_add_form.js
@@ -1,0 +1,10 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const element = document.getElementById('id_structure');
+    const choices = new Choices(element, {
+        itemSelectText: '',
+        classNames: {
+            containerInner: 'fr-select fr-mt-1w',
+        },
+        searchResultLimit: 500,
+    });
+});

--- a/sv/templates/sv/_fichezonedelimitee_form_zones_infestees.html
+++ b/sv/templates/sv/_fichezonedelimitee_form_zones_infestees.html
@@ -11,14 +11,8 @@
         </div>
     </div>
     {% if zone_infestee_formset.non_form_errors %}
-        <div class="fr-alert fr-alert--error fr-mb-4w">
-            {% for error in zone_infestee_formset.non_form_errors %}
-                <p>{{ error }}</p>
-            {% endfor %}
-            <button class="fr-btn--close fr-btn" title="Masquer le message" onclick="const alert = this.parentNode; alert.parentNode.removeChild(alert)">
-                Masquer le message
-            </button>
-        </div>
+        {% include "core/_show_form_errors.html" with errors=zone_infestee_formset.non_form_errors %}
+
     {% endif %}
     <div class="fr-grid-row fr-grid-row--gutters" id="zones-infestees">
         {{ zone_infestee_formset.management_form }}
@@ -37,7 +31,7 @@
                                     {% endfor %}
                                 {% endfor %}
                             </ul>
-                            <button class="fr-btn--close fr-btn" title="Masquer le message" onclick="const alert = this.parentNode; alert.parentNode.removeChild(alert)">
+                            <button class="fr-btn--close fr-btn btn--close-js" title="Masquer le message">
                                 Masquer le message
                             </button>
                         </div>

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -149,7 +149,7 @@
                                     <p>
                                         <span class="fr-notice__title">Pour ajouter une prélèvement vous devez avoir renseigné au moins un lieu.</span>
                                     </p>
-                                    <button title="Masquer le message" onclick="const notice = this.parentNode.parentNode.parentNode; notice.parentNode.removeChild(notice)" id="button-1290" class="fr-btn--close fr-btn">Masquer le message</button>
+                                    <button title="Masquer le message" id="button-1290" class="fr-btn--close fr-btn btn--close-notice-js" >Masquer le message</button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Afin de préparer le travail pour les CSP, faciliter la maintenance et mieux séparer les intéractions du templating.