### PR TITLE
Visibilité: modification affichage

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -327,9 +327,9 @@ class VisibiliteUpdateBaseForm(DSFRForm):
         super().__init__(*args, **kwargs)
         object = obj or self.instance
 
-        local = (Visibilite.LOCALE, Visibilite.LOCALE.capitalize())
+        locale = (Visibilite.LOCALE, Visibilite.LOCALE.capitalize())
         limitee = (Visibilite.LIMITEE, Visibilite.LIMITEE.capitalize())
-        national = (Visibilite.NATIONALE, Visibilite.NATIONALE.capitalize())
+        nationale = (Visibilite.NATIONALE, Visibilite.NATIONALE.capitalize())
 
-        self.fields["visibilite"].choices = [local, limitee, national]
+        self.fields["visibilite"].choices = [locale, limitee, nationale]
         self.fields["visibilite"].initial = object.visibilite

--- a/core/mixins.py
+++ b/core/mixins.py
@@ -203,9 +203,9 @@ class WithVisibiliteMixin(models.Model):
     def get_visibilite_display_text(self) -> str:
         match self.visibilite:
             case Visibilite.LOCALE:
-                return f"{self.createur}, {MUS_STRUCTURE}, {BSV_STRUCTURE}"
+                return ", ".join({str(self.createur), MUS_STRUCTURE, BSV_STRUCTURE})
             case Visibilite.LIMITEE:
-                return ", ".join(str(s) for s in self.allowed_structures.all())
+                return ", ".join(str(s) for s in self.allowed_structures.all()) + f", {MUS_STRUCTURE}, {BSV_STRUCTURE}"
             case Visibilite.NATIONALE:
                 return "Toutes les structures"
 

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -518,7 +518,7 @@ def test_create_multiple_messages_adds_contacts_once(
     assert evenement.contacts.filter(structure=mocked_authentification_user.agent.structure).count() == 1
 
 
-def test_create_message_from_local_changes_to_limitee_and_add_structures_in_allowed_structures(
+def test_create_message_from_locale_changes_to_limitee_and_add_structures_in_allowed_structures(
     live_server, page: Page, mocked_authentification_user: User, choice_js_fill
 ):
     evenement = EvenementFactory(visibilite=Visibilite.LOCALE)

--- a/sv/tests/test_evenement_visibilite_access.py
+++ b/sv/tests/test_evenement_visibilite_access.py
@@ -40,7 +40,7 @@ def test_agent_in_structure_createur_can_view_evenement_limitee(
 
 
 @pytest.mark.django_db
-def test_agent_not_in_structure_createur_cannot_view_evenement_local(
+def test_agent_not_in_structure_createur_cannot_view_evenement_locale(
     live_server, page: Page, mocked_authentification_user
 ):
     evenement = EvenementFactory(visibilite=Visibilite.LOCALE)

--- a/sv/tests/test_fiches_bloc_suivi.py
+++ b/sv/tests/test_fiches_bloc_suivi.py
@@ -21,7 +21,7 @@ def test_evenement_does_not_have_bloc_suivi_display(live_server, page, mocked_au
         Visibilite.NATIONALE,
     ],
 )
-def test_fiche_local_or_national_have_bloc_suivi_display(
+def test_fiche_locale_or_nationale_have_bloc_suivi_display(
     live_server, page, visibilite: Visibilite, mocked_authentification_user
 ):
     evenement = EvenementFactory(visibilite=visibilite)


### PR DESCRIPTION
Modification de l'affichage de la visibilité : 
- Si l'évènement est LOCAL et que le créateur est AC, ne pas mettre deux fois la structure MUS ou BSV
- Si l'évènement est LIMITE, on voir MUS et BSV

Modification de la méthode `get_visibilite_display_text` et ajout du test `test_visibilite_display_text_when_evenement_locale_and_createur_ac`