### PR TITLE
Corrige erreur indentation du service redis dans le fichier des GitHub Actions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -14,14 +14,16 @@ jobs:
           - 5432:5432
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-      services:
-        redis:
-          image: redis
-          options: >-
-            --health-cmd "redis-cli ping"
-            --health-interval 10s
-            --health-timeout 5s
-            --health-retries 5
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          # Maps port 6379 on service container to the host
+          - 6379:6379
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,5 +21,5 @@ env =
     EMAIL_PRIORITY=now
     ROOT_URL=http://testserver.com
     BYPASS_ANTIVIRUS=True
-    SCALINGO_REDIS_URL=redis://127.0.0.1:6379
+    SCALINGO_REDIS_URL=redis://localhost:6379
     DJANGO_ADMIN_ENABLED=


### PR DESCRIPTION
Les tests ne s’exécutaient pas à cause d'une erreur d'indentation du service Redis dans le fichier de configuration des GitHub Actions.