### PR TITLE
Corriger les boutons d'actions pour les détections

### DIFF
--- a/sv/static/sv/evenement_details.js
+++ b/sv/static/sv/evenement_details.js
@@ -1,17 +1,10 @@
 import {ViewManager, evenementViewModeConfig} from './view_manager.js';
 
 function showOnlyActionsForDetection(detectionId){
-    document.querySelectorAll('[id^="detection-actions-"]').forEach(actionElement =>{
-
-        if (actionElement.getAttribute("id") != "detection-actions-" + detectionId.toString()){
-
-            actionElement.classList.add("fr-hidden")
-        } else {
-            actionElement.classList.remove("fr-hidden")
-
-        }
-    }
-    )
+    document.querySelectorAll('[id^="detection-actions-"]').forEach(element =>{
+        element.classList.add("fr-hidden")
+    })
+    document.querySelector(`[id^="detection-actions-${detectionId}"]`).classList.remove("fr-hidden")
 }
 
 function initializeDetectionTags() {
@@ -33,11 +26,14 @@ document.addEventListener('DOMContentLoaded', function() {
     viewManager.initialize();
 
     document.querySelectorAll(".no-tab-look .fr-tabs__panel").forEach(element =>{
-        element.addEventListener('dsfr.conceal', event=>{
+        element.addEventListener('dsfr.disclose', event=>{
             const tabId = event.target.getAttribute("id").replace("tabpanel-", "").replace("-panel", "")
             showOnlyActionsForDetection(tabId)
         })
     })
+
+    const selectedTagDocument = document.querySelector(".no-tab-look .fr-tag.selected")
+    showOnlyActionsForDetection(selectedTagDocument.getAttribute("id").replace("tabpanel-", ""))
 
     initializeDetectionTags();
 });

--- a/sv/tests/test_evenement_details.py
+++ b/sv/tests/test_evenement_details.py
@@ -285,3 +285,19 @@ def test_visibilite_limitee_display_long_text(live_server, page: Page):
     tooltip = page.locator("#tooltip-visibilite")
     for i in range(10):
         expect(tooltip).to_contain_text(f"Structure Test {i}")
+
+
+def test_will_edit_correct_fiche_detection(live_server, page: Page):
+    evenement = EvenementFactory()
+    fiche_1 = FicheDetectionFactory(evenement=evenement)
+    fiche_2 = FicheDetectionFactory(evenement=evenement)
+
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    page.get_by_role("tab", name=fiche_1.numero_detection).click()
+    page.get_by_role("button", name="Modifier").click()
+    assert fiche_1.get_update_url() in page.url
+
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    page.get_by_role("tab", name=fiche_2.numero_detection).click()
+    page.get_by_role("button", name="Modifier").click()
+    assert fiche_2.get_update_url() in page.url


### PR DESCRIPTION
- Simplifier le code
- Gérer un tag qui aurait déjà été sélectionné au chargement de la page
- Fixer le problème qui pouvait amener vers la mauvaise fiche en édition