### PR TITLE
Supprime la référence à l'organisme nuisible sur le form de modification d'une fiche détection

### DIFF
--- a/sv/static/sv/fichedetection_form.js
+++ b/sv/static/sv/fichedetection_form.js
@@ -25,7 +25,12 @@ function setUpOrganismeNuisible(){
     })
 }
 
+function hasStatusToOrganismeNuisibleData() {
+    return document.getElementById('status-to-organisme-nuisible-id') !== null;
+}
 
 document.addEventListener('DOMContentLoaded', function() {
-    setUpOrganismeNuisible()
+    if (hasStatusToOrganismeNuisibleData()) {
+        setUpOrganismeNuisible();
+    }
 });

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -17,7 +17,9 @@
 
 {% block content %}
     <main>
-        {{ status_to_organisme_nuisible|json_script:"status-to-organisme-nuisible-id" }}
+        {% if is_creation %}
+            {{ status_to_organisme_nuisible|json_script:"status-to-organisme-nuisible-id" }}
+        {% endif %}
         {{ prelevement_resultats|json_script:"prelevement-resultats" }}
 
         <form action="{% if is_creation %}{% url 'fiche-detection-creation' %}{% else %}{% url 'fiche-detection-modification' form.instance.id  %}{% endif %}" method="post">


### PR DESCRIPTION
Supprime l'initialisation et la configuration de ChoiceJs pour le champ organisme nuisible sur le formulaire de modification d'un fiche détection (erreur js lors du chargement de la page).