### PR TITLE
Corriger les modales sur l'événement

### DIFF
--- a/sv/templates/sv/_fichedetection_detail.html
+++ b/sv/templates/sv/_fichedetection_detail.html
@@ -72,7 +72,7 @@
 
                     <div class="fr-grid-row fr-grid-row--gutters">
                         {% for lieu_initial in fichedetection.lieux.all %}
-                            {% include "sv/fichedetection_detail_lieu.html" with lieu=lieu_initial lieu_index=forloop.counter %}
+                            {% include "sv/fichedetection_detail_lieu.html" with lieu=lieu_initial lieu_index=lieu_initial.pk %}
                             <div class="fr-col-6 fr-col-lg-12">
                                 <div class="lieu-initial fr-card fr-card--horizontal fr-card--sm fr-card--grey fr-card--no-border ">
                                     <div class="fr-card__body">
@@ -84,7 +84,7 @@
                                                 <div class="fr-col-1">
                                                     <button class="fr-btn fr-btn--sm fr-btn--tertiary fr-icon-eye-line"
                                                             data-fr-opened="false"
-                                                            aria-controls="fr-modal-lieu-{{forloop.counter}}"
+                                                            aria-controls="fr-modal-lieu-{{lieu_initial.pk}}"
                                                             title="Consulter le détail du lieu {{lieu_initial.nom}}"></button>
                                                 </div>
                                             </div>
@@ -110,7 +110,7 @@
                     <div class="fr-grid-row fr-grid-row--gutters">
                         {% for lieu in fichedetection.lieux.all %}
                             {% for prelevement in lieu.prelevements.all %}
-                                {% include "sv/fichedetection_detail_prelevement.html" with prelevement=prelevement prelevement_index=forloop.counter %}
+                                {% include "sv/fichedetection_detail_prelevement.html" with prelevement=prelevement prelevement_index=prelevement.pk %}
                                 <div class="fr-col-6 fr-col-lg-12">
                                     <div class="prelevement fr-card fr-card--horizontal fr-card--sm fr-card--grey fr-card--no-border" style="margin-bottom: 1rem;">
                                         <div class="fr-card__body">
@@ -122,7 +122,7 @@
                                                     <div class="fr-col-1">
                                                         <button class="fr-btn fr-btn--sm fr-btn--tertiary fr-icon-eye-line"
                                                                 data-fr-opened="false"
-                                                                aria-controls="fr-modal-prelevement-{{forloop.counter}}"
+                                                                aria-controls="fr-modal-prelevement-{{prelevement.pk}}"
                                                                 title="Consulter le détail du prélèvement {{prelevement.numero_echantillon}}">
                                                         </button>
                                                     </div>

--- a/sv/tests/test_fichedetection_detail.py
+++ b/sv/tests/test_fichedetection_detail.py
@@ -14,30 +14,36 @@ def test_lieu_details(live_server, page, fiche_detection):
     page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
     page.get_by_role("button", name=f"Consulter le détail du lieu {lieu.nom}").click()
     expect(page.get_by_role("heading", name=lieu.nom)).to_be_visible()
-    expect(page.locator("#fr-modal-lieu-1").get_by_text("Adresse ou lieu-dit")).to_be_visible()
-    expect(page.locator("#fr-modal-lieu-1").get_by_text("Commune")).to_be_visible()
-    expect(page.locator("#fr-modal-lieu-1").get_by_text("Code INSEE")).to_be_visible()
-    expect(page.locator("#fr-modal-lieu-1").get_by_text("Département")).to_be_visible()
-    expect(page.locator("#fr-modal-lieu-1").get_by_text("Région")).to_be_visible()
-    expect(page.locator("#fr-modal-lieu-1").get_by_text("Coord. WGS84")).to_be_visible()
-    expect(page.get_by_test_id("lieu-1-adresse")).to_contain_text(lieu.adresse_lieu_dit)
-    expect(page.get_by_test_id("lieu-1-commune")).to_contain_text(lieu.commune)
-    expect(page.get_by_test_id("lieu-1-code-insee")).to_contain_text(lieu.code_insee)
-    expect(page.get_by_test_id("lieu-1-departement")).to_contain_text(lieu.departement.nom)
-    expect(page.get_by_test_id("lieu-1-region")).to_contain_text(lieu.departement.region.nom)
-    expect(page.get_by_test_id("lieu-1-wgs84-latitude")).to_contain_text(str(lieu.wgs84_latitude).replace(".", ","))
-    expect(page.get_by_test_id("lieu-1-wgs84-longitude")).to_contain_text(str(lieu.wgs84_longitude).replace(".", ","))
+    expect(page.locator(f"#fr-modal-lieu-{lieu.pk}").get_by_text("Adresse ou lieu-dit")).to_be_visible()
+    expect(page.locator(f"#fr-modal-lieu-{lieu.pk}").get_by_text("Commune")).to_be_visible()
+    expect(page.locator(f"#fr-modal-lieu-{lieu.pk}").get_by_text("Code INSEE")).to_be_visible()
+    expect(page.locator(f"#fr-modal-lieu-{lieu.pk}").get_by_text("Département")).to_be_visible()
+    expect(page.locator(f"#fr-modal-lieu-{lieu.pk}").get_by_text("Région")).to_be_visible()
+    expect(page.locator(f"#fr-modal-lieu-{lieu.pk}").get_by_text("Coord. WGS84")).to_be_visible()
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-adresse")).to_contain_text(lieu.adresse_lieu_dit)
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-commune")).to_contain_text(lieu.commune)
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-code-insee")).to_contain_text(lieu.code_insee)
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-departement")).to_contain_text(lieu.departement.nom)
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-region")).to_contain_text(lieu.departement.region.nom)
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-wgs84-latitude")).to_contain_text(
+        str(lieu.wgs84_latitude).replace(".", ",")
+    )
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-wgs84-longitude")).to_contain_text(
+        str(lieu.wgs84_longitude).replace(".", ",")
+    )
     expect(page.get_by_text("Il s'agit d'un établissement", exact=True)).to_be_visible()
-    expect(page.get_by_test_id("lieu-1-nom-etablissement")).to_contain_text(lieu.nom_etablissement)
-    expect(page.get_by_test_id("lieu-1-activite-etablissement")).to_contain_text(lieu.activite_etablissement)
-    expect(page.get_by_test_id("lieu-1-pays-etablissement")).to_contain_text(lieu.pays_etablissement)
-    expect(page.get_by_test_id("lieu-1-raison-sociale-etablissement")).to_contain_text(
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-nom-etablissement")).to_contain_text(lieu.nom_etablissement)
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-activite-etablissement")).to_contain_text(lieu.activite_etablissement)
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-pays-etablissement")).to_contain_text(lieu.pays_etablissement)
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-raison-sociale-etablissement")).to_contain_text(
         lieu.raison_sociale_etablissement
     )
-    expect(page.get_by_test_id("lieu-1-adresse-etablissement")).to_contain_text(lieu.adresse_etablissement)
-    expect(page.get_by_test_id("lieu-1-siret-etablissement")).to_contain_text(lieu.siret_etablissement)
-    expect(page.get_by_test_id("lieu-1-code-inupp-etablissement")).to_contain_text(lieu.code_inupp_etablissement)
-    expect(page.get_by_test_id("lieu-1-position-etablissement")).to_contain_text(
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-adresse-etablissement")).to_contain_text(lieu.adresse_etablissement)
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-siret-etablissement")).to_contain_text(lieu.siret_etablissement)
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-code-inupp-etablissement")).to_contain_text(
+        lieu.code_inupp_etablissement
+    )
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-position-etablissement")).to_contain_text(
         lieu.position_chaine_distribution_etablissement.libelle
     )
 
@@ -49,16 +55,44 @@ def test_lieu_details_second_lieu(live_server, page, fiche_detection):
     evenement.createur = fiche_detection.createur
     evenement.save()
     lieu2 = baker.make(Lieu, fiche_detection=fiche_detection, _fill_optional=True)
+    lieu2.refresh_from_db()
     page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
     page.get_by_role("button", name=f"Consulter le détail du lieu {lieu2.nom}").click()
     expect(page.get_by_role("heading", name=lieu2.nom)).to_be_visible()
-    expect(page.get_by_test_id("lieu-2-adresse")).to_contain_text(lieu2.adresse_lieu_dit)
-    expect(page.get_by_test_id("lieu-2-commune")).to_contain_text(lieu2.commune)
-    expect(page.get_by_test_id("lieu-2-code-insee")).to_contain_text(lieu2.code_insee)
-    expect(page.get_by_test_id("lieu-2-departement")).to_contain_text(lieu2.departement.nom)
-    expect(page.get_by_test_id("lieu-2-region")).to_contain_text(lieu2.departement.region.nom)
-    expect(page.get_by_test_id("lieu-2-wgs84-latitude")).to_contain_text(str(lieu2.wgs84_latitude).replace(".", ","))
-    expect(page.get_by_test_id("lieu-2-wgs84-longitude")).to_contain_text(str(lieu2.wgs84_longitude).replace(".", ","))
+    expect(page.get_by_test_id(f"lieu-{lieu2.pk}-adresse")).to_contain_text(lieu2.adresse_lieu_dit)
+    expect(page.get_by_test_id(f"lieu-{lieu2.pk}-commune")).to_contain_text(lieu2.commune)
+    expect(page.get_by_test_id(f"lieu-{lieu2.pk}-code-insee")).to_contain_text(lieu2.code_insee)
+    expect(page.get_by_test_id(f"lieu-{lieu2.pk}-departement")).to_contain_text(lieu2.departement.nom)
+    expect(page.get_by_test_id(f"lieu-{lieu2.pk}-region")).to_contain_text(lieu2.departement.region.nom)
+    expect(page.get_by_test_id(f"lieu-{lieu2.pk}-wgs84-latitude")).to_contain_text(
+        str(lieu2.wgs84_latitude).replace(".", ",")
+    )
+    expect(page.get_by_test_id(f"lieu-{lieu2.pk}-wgs84-longitude")).to_contain_text(
+        str(lieu2.wgs84_longitude).replace(".", ",")
+    )
+
+
+def test_lieu_details_of_second_detection_when_first_detection_has_lieu(live_server, page):
+    evenement = EvenementFactory()
+    fiche_detection_1 = FicheDetectionFactory(evenement=evenement)
+    LieuFactory(fiche_detection=fiche_detection_1)
+    fiche_detection_2 = FicheDetectionFactory(evenement=evenement)
+    lieu = LieuFactory(fiche_detection=fiche_detection_2)
+    lieu.refresh_from_db()
+
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    page.wait_for_timeout(4000)
+    page.get_by_role("tab", name=fiche_detection_2.numero_detection).click()
+    page.wait_for_timeout(4000)
+    page.get_by_role("button", name=f"Consulter le détail du lieu {lieu.nom}").click()
+    expect(page.get_by_role("heading", name=lieu.nom)).to_be_visible()
+    expect(page.locator(".fr-modal--opened")).to_contain_text(lieu.adresse_lieu_dit)
+    expect(page.locator(".fr-modal--opened")).to_contain_text(lieu.commune)
+    expect(page.locator(".fr-modal--opened")).to_contain_text(lieu.code_insee)
+    expect(page.locator(".fr-modal--opened")).to_contain_text(lieu.departement.nom)
+    expect(page.locator(".fr-modal--opened")).to_contain_text(lieu.departement.region.nom)
+    expect(page.locator(".fr-modal--opened")).to_contain_text(str(lieu.wgs84_latitude).replace(".", ","))
+    expect(page.locator(".fr-modal--opened")).to_contain_text(str(lieu.wgs84_longitude).replace(".", ","))
 
 
 def test_lieu_details_with_no_data(live_server, page, fiche_detection):
@@ -69,13 +103,13 @@ def test_lieu_details_with_no_data(live_server, page, fiche_detection):
     evenement.save()
     page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
     page.get_by_role("button", name=f"Consulter le détail du lieu {lieu.nom}").click()
-    expect(page.get_by_test_id("lieu-1-adresse")).to_contain_text("nc.")
-    expect(page.get_by_test_id("lieu-1-commune")).to_contain_text(lieu.commune)
-    expect(page.get_by_test_id("lieu-1-code-insee")).to_contain_text("nc.")
-    expect(page.get_by_test_id("lieu-1-departement")).to_contain_text("nc.")
-    expect(page.get_by_test_id("lieu-1-region")).to_contain_text("nc.")
-    expect(page.get_by_test_id("lieu-1-wgs84")).to_contain_text("nc.")
-    expect(page.get_by_test_id("lieu-1-wgs84")).to_contain_text("nc.")
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-adresse")).to_contain_text("nc.")
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-commune")).to_contain_text(lieu.commune)
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-code-insee")).to_contain_text("nc.")
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-departement")).to_contain_text("nc.")
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-region")).to_contain_text("nc.")
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-wgs84")).to_contain_text("nc.")
+    expect(page.get_by_test_id(f"lieu-{lieu.pk}-wgs84")).to_contain_text("nc.")
 
 
 def test_prelevement_card(live_server, page):
@@ -98,17 +132,17 @@ def test_prelevement_non_officiel_details_with_no_data(live_server, page, fiche_
     prelevement = baker.make(Prelevement, lieu=lieu)
     page.goto(f"{live_server.url}{fiche_detection.get_absolute_url()}")
     page.get_by_role("button", name=f"Consulter le détail du prélèvement {prelevement.numero_echantillon}").click()
-    expect(page.get_by_test_id("prelevement-1-is-officiel")).to_contain_text(
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-is-officiel")).to_contain_text(
         "oui" if prelevement.is_officiel else "non"
     )
-    expect(page.get_by_test_id("prelevement-1-structure-preleveuse")).to_contain_text(
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-structure-preleveuse")).to_contain_text(
         prelevement.structure_preleveuse.nom
     )
-    expect(page.get_by_test_id("prelevement-1-numero-echantillon")).to_contain_text("nc.")
-    expect(page.get_by_test_id("prelevement-1-date-prelevement")).to_contain_text("nc.")
-    expect(page.get_by_test_id("prelevement-1-matrice-prelevee")).to_contain_text("nc.")
-    expect(page.get_by_test_id("prelevement-1-espece-echantillon")).to_contain_text("nc.")
-    expect(page.get_by_test_id("prelevement-1-code-oepp")).to_contain_text("nc.")
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-numero-echantillon")).to_contain_text("nc.")
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-date-prelevement")).to_contain_text("nc.")
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-matrice-prelevee")).to_contain_text("nc.")
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-espece-echantillon")).to_contain_text("nc.")
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-code-oepp")).to_contain_text("nc.")
 
 
 def test_prelevement_non_officiel_details_second_prelevement(live_server, page):
@@ -125,26 +159,38 @@ def test_prelevement_non_officiel_details_second_prelevement(live_server, page):
     page.get_by_role("button", name=f"Consulter le détail du prélèvement {prelevement2.numero_echantillon}").click()
 
     expect(page.get_by_role("heading", name=f"Échantillon {prelevement2.numero_echantillon}")).to_be_visible()
-    expect(page.get_by_test_id("prelevement-2-type-analyse")).to_contain_text(prelevement2.get_type_analyse_display())
-    expect(page.get_by_test_id("prelevement-2-is-officiel")).to_contain_text("non")
-    expect(page.get_by_test_id("prelevement-2-numero-rapport-inspection")).to_contain_text(
+    expect(page.get_by_test_id(f"prelevement-{prelevement2.pk}-type-analyse")).to_contain_text(
+        prelevement2.get_type_analyse_display()
+    )
+    expect(page.get_by_test_id(f"prelevement-{prelevement2.pk}-is-officiel")).to_contain_text("non")
+    expect(page.get_by_test_id(f"prelevement-{prelevement2.pk}-numero-rapport-inspection")).to_contain_text(
         prelevement2.numero_rapport_inspection
     )
-    expect(page.get_by_test_id("prelevement-2-laboratoire")).to_contain_text(prelevement2.laboratoire.nom)
-    expect(page.get_by_test_id("prelevement-2-numero-echantillon")).to_contain_text(prelevement2.numero_echantillon)
-    expect(page.get_by_test_id("prelevement-2-lieu")).to_contain_text(prelevement2.lieu.nom)
-    expect(page.get_by_test_id("prelevement-2-structure-preleveuse")).to_contain_text(
+    expect(page.get_by_test_id(f"prelevement-{prelevement2.pk}-laboratoire")).to_contain_text(
+        prelevement2.laboratoire.nom
+    )
+    expect(page.get_by_test_id(f"prelevement-{prelevement2.pk}-numero-echantillon")).to_contain_text(
+        prelevement2.numero_echantillon
+    )
+    expect(page.get_by_test_id(f"prelevement-{prelevement2.pk}-lieu")).to_contain_text(prelevement2.lieu.nom)
+    expect(page.get_by_test_id(f"prelevement-{prelevement2.pk}-structure-preleveuse")).to_contain_text(
         prelevement2.structure_preleveuse.nom
     )
-    expect(page.get_by_test_id("prelevement-2-date-prelevement")).to_contain_text(
+    expect(page.get_by_test_id(f"prelevement-{prelevement2.pk}-date-prelevement")).to_contain_text(
         prelevement2.date_prelevement.strftime("%d/%m/%Y")
     )
-    expect(page.get_by_test_id("prelevement-2-matrice-prelevee")).to_contain_text(prelevement2.matrice_prelevee.libelle)
-    expect(page.get_by_test_id("prelevement-2-espece-echantillon")).to_contain_text(
+    expect(page.get_by_test_id(f"prelevement-{prelevement2.pk}-matrice-prelevee")).to_contain_text(
+        prelevement2.matrice_prelevee.libelle
+    )
+    expect(page.get_by_test_id(f"prelevement-{prelevement2.pk}-espece-echantillon")).to_contain_text(
         prelevement2.espece_echantillon.libelle
     )
-    expect(page.get_by_test_id("prelevement-2-code-oepp")).to_contain_text(prelevement2.espece_echantillon.code_oepp)
-    expect(page.get_by_test_id("prelevement-2-resultat")).to_contain_text(prelevement2.get_resultat_display())
+    expect(page.get_by_test_id(f"prelevement-{prelevement2.pk}-code-oepp")).to_contain_text(
+        prelevement2.espece_echantillon.code_oepp
+    )
+    expect(page.get_by_test_id(f"prelevement-{prelevement2.pk}-resultat")).to_contain_text(
+        prelevement2.get_resultat_display()
+    )
 
 
 def test_prelevement_details(live_server, page):
@@ -156,25 +202,37 @@ def test_prelevement_details(live_server, page):
 
     page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
     page.get_by_role("button", name=f"Consulter le détail du prélèvement {prelevement.numero_echantillon}").click()
-    expect(page.get_by_test_id("prelevement-1-type-analyse")).to_contain_text(prelevement.get_type_analyse_display())
-    expect(page.get_by_test_id("prelevement-1-is-officiel")).to_contain_text(
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-type-analyse")).to_contain_text(
+        prelevement.get_type_analyse_display()
+    )
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-is-officiel")).to_contain_text(
         "oui" if prelevement.is_officiel else "non"
     )
-    expect(page.get_by_test_id("prelevement-1-numero-rapport-inspection")).to_contain_text(
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-numero-rapport-inspection")).to_contain_text(
         prelevement.numero_rapport_inspection
     )
-    expect(page.get_by_test_id("prelevement-1-laboratoire")).to_contain_text(prelevement.laboratoire.nom)
-    expect(page.get_by_test_id("prelevement-1-numero-echantillon")).to_contain_text(prelevement.numero_echantillon)
-    expect(page.get_by_test_id("prelevement-1-lieu")).to_contain_text(prelevement.lieu.nom)
-    expect(page.get_by_test_id("prelevement-1-structure-preleveuse")).to_contain_text(
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-laboratoire")).to_contain_text(
+        prelevement.laboratoire.nom
+    )
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-numero-echantillon")).to_contain_text(
+        prelevement.numero_echantillon
+    )
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-lieu")).to_contain_text(prelevement.lieu.nom)
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-structure-preleveuse")).to_contain_text(
         prelevement.structure_preleveuse.nom
     )
-    expect(page.get_by_test_id("prelevement-1-date-prelevement")).to_contain_text(
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-date-prelevement")).to_contain_text(
         prelevement.date_prelevement.strftime("%d/%m/%Y")
     )
-    expect(page.get_by_test_id("prelevement-1-matrice-prelevee")).to_contain_text(prelevement.matrice_prelevee.libelle)
-    expect(page.get_by_test_id("prelevement-1-espece-echantillon")).to_contain_text(
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-matrice-prelevee")).to_contain_text(
+        prelevement.matrice_prelevee.libelle
+    )
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-espece-echantillon")).to_contain_text(
         prelevement.espece_echantillon.libelle
     )
-    expect(page.get_by_test_id("prelevement-1-code-oepp")).to_contain_text(prelevement.espece_echantillon.code_oepp)
-    expect(page.get_by_test_id("prelevement-1-resultat")).to_contain_text(prelevement.get_resultat_display())
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-code-oepp")).to_contain_text(
+        prelevement.espece_echantillon.code_oepp
+    )
+    expect(page.get_by_test_id(f"prelevement-{prelevement.pk}-resultat")).to_contain_text(
+        prelevement.get_resultat_display()
+    )


### PR DESCRIPTION
Corrige le problème d'ouverture du modale quand un événement contient plusieurs détections qui ont au moins un lieu. Comme le compteur utilisé est celui de la boucle on se retrouve avec plusieurs modales ayant le même ID. En utilisant le pk, nous avons la garanti que les modales auront bien des identifiants différents.