### PR TITLE
Élargir la recherche par organisme nuisible

### DIFF
--- a/sv/factories.py
+++ b/sv/factories.py
@@ -37,6 +37,7 @@ from datetime import datetime
 class OrganismeNuisibleFactory(DjangoModelFactory):
     class Meta:
         model = OrganismeNuisible
+        django_get_or_create = ("libelle_court",)
 
     code_oepp = factory.Faker("lexify", text="??????")
     libelle_court = factory.Faker("lexify", text="??????")

--- a/sv/filters.py
+++ b/sv/filters.py
@@ -36,7 +36,10 @@ class FicheFilter(django_filters.FilterSet):
         label="Région", queryset=Region.objects.all(), empty_label=settings.SELECT_EMPTY_CHOICE, method="filter_region"
     )
     evenement__organisme_nuisible = django_filters.ModelChoiceFilter(
-        label="Organisme", queryset=OrganismeNuisible.objects.all(), empty_label=settings.SELECT_EMPTY_CHOICE
+        label="Organisme",
+        queryset=OrganismeNuisible.objects.all(),
+        empty_label=settings.SELECT_EMPTY_CHOICE,
+        method="filter_organisme_nuisible",
     )
     start_date = django_filters.DateFilter(
         field_name="date_creation__date",
@@ -111,6 +114,9 @@ class FicheFilter(django_filters.FilterSet):
         if self._is_zone:
             parts = list(map(int, value.split(".")))
             return queryset.filter(evenement__numero_annee=parts[0], evenement__numero_evenement=parts[1])
+
+    def filter_organisme_nuisible(self, queryset, name, value):
+        return queryset.filter(evenement__organisme_nuisible__libelle_court__startswith=value).distinct()
 
     def filter_region(self, queryset, name, value):
         return queryset.filter(lieux__departement__region=value).distinct()


### PR DESCRIPTION
Permettre de rechercher par "sous-espèce" en cherchant toute les fiches dont l'ON commence par le terme recherché à la place d'une recherche exacte.