### PR TITLE
Ajout limite de taille pour l'upload d'un document

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -10,6 +10,7 @@ from django.utils.safestring import mark_safe
 
 from core.fields import DSFRCheckboxSelectMultiple, DSFRRadioButton, ContactModelMultipleChoiceField
 from core.models import Document, Contact, Message, Structure, Visibilite
+from core.validators import MAX_UPLOAD_SIZE_BYTES, MAX_UPLOAD_SIZE_MEGABYTES
 from core.widgets import RestrictedFileWidget
 
 User = get_user_model()
@@ -66,7 +67,7 @@ class DocumentUploadForm(DSFRForm, WithNextUrlMixin, WithContentTypeMixin, forms
     description = forms.CharField(
         widget=forms.Textarea(attrs={"cols": 30, "rows": 4}), label="Commentaire - facultatif", required=False
     )
-    file = forms.FileField(label="Ajouter un Document", widget=RestrictedFileWidget)
+    file = forms.FileField(label="Ajouter un document", widget=RestrictedFileWidget)
 
     class Meta:
         model = Document
@@ -78,6 +79,12 @@ class DocumentUploadForm(DSFRForm, WithNextUrlMixin, WithContentTypeMixin, forms
         super().__init__(*args, **kwargs)
         self.add_content_type_fields(obj)
         self.add_next_field(next)
+
+    def clean_file(self):
+        file = self.cleaned_data.get("file")
+        if file and file.size > MAX_UPLOAD_SIZE_BYTES:
+            raise forms.ValidationError(f"La taille du fichier ne doit pas dépasser {MAX_UPLOAD_SIZE_MEGABYTES}Mo")
+        return file
 
 
 class DocumentEditForm(DSFRForm, forms.ModelForm):
@@ -261,7 +268,7 @@ class MessageDocumentForm(DSFRForm, forms.ModelForm):
         required=False,
     )
     file = forms.FileField(
-        label="Ajouter un Document", required=False, widget=RestrictedFileWidget(attrs={"disabled": True})
+        label="Ajouter un document", required=False, widget=RestrictedFileWidget(attrs={"disabled": True})
     )
 
     class Meta:

--- a/core/static/core/document.js
+++ b/core/static/core/document.js
@@ -1,0 +1,28 @@
+export function validateFileSize(fileInput) {
+    const maxSizeAttr = fileInput.getAttribute('data-max-size');
+
+    if (maxSizeAttr === null) {
+        console.error("Erreur de configuration: l'attribut 'data-max-size' est manquant");
+        fileInput.setCustomValidity("Erreur de configuration: limite de taille non définie");
+        fileInput.reportValidity();
+        return false;
+    }
+
+    const maxSizeBytes = parseInt(maxSizeAttr);
+    if (isNaN(maxSizeBytes)) {
+        console.error("Erreur de configuration: 'data-max-size' n'est pas un nombre valide");
+        fileInput.setCustomValidity("Erreur de configuration: limite de taille invalide");
+        fileInput.reportValidity();
+        return false;
+    }
+
+    if (fileInput.files[0] && fileInput.files[0].size > maxSizeBytes) {
+        const maxSizeMB = maxSizeBytes / (1024 * 1024);
+        fileInput.setCustomValidity(`Le fichier est trop volumineux (maximum ${maxSizeMB} Mo autorisés)`);
+        fileInput.reportValidity();
+        return false;
+    }
+
+    fileInput.setCustomValidity('');
+    return true;
+}

--- a/core/static/core/document_form.js
+++ b/core/static/core/document_form.js
@@ -1,0 +1,7 @@
+import { validateFileSize } from './document.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+    const uploadModal = document.getElementById('fr-modal-add-doc');
+    const fileInput = uploadModal.querySelector('input[type="file"]');
+    fileInput.addEventListener('change', () => validateFileSize(fileInput));
+});

--- a/core/static/core/message_form.js
+++ b/core/static/core/message_form.js
@@ -1,3 +1,5 @@
+import { validateFileSize } from "./document.js";
+
 
 function cloneDocumentInput(input, currentID, destination){
     let newFileInput = input.cloneNode()
@@ -39,9 +41,9 @@ function allowToUploadWhenTypeIsSelected(typeInput, fileInput,messageAddDocument
     })
 }
 
-function allowToValidateWhenDocumentIsSelected(typeInput, fileInput,messageAddDocumentButton){
+function allowToValidateWhenDocumentIsSelectedAndValidSize(typeInput, fileInput,messageAddDocumentButton){
     fileInput.addEventListener("change", ()=>{
-        if (typeInput.value !== ""){
+        if (typeInput.value !== "" && validateFileSize(fileInput)){
             messageAddDocumentButton.removeAttribute("disabled")
         }
     })
@@ -72,7 +74,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const inputDestination = document.getElementById("inputs-for-upload")
 
     allowToUploadWhenTypeIsSelected(typeInput, fileInput, messageAddDocumentButton)
-    allowToValidateWhenDocumentIsSelected(typeInput, fileInput, messageAddDocumentButton)
+    allowToValidateWhenDocumentIsSelectedAndValidSize(typeInput, fileInput, messageAddDocumentButton)
 
     addDocumentFormButton.addEventListener("click", event =>{
         event.preventDefault();

--- a/core/templates/core/_modale_ajout_document.html
+++ b/core/templates/core/_modale_ajout_document.html
@@ -14,6 +14,7 @@
 
                             {{ document_form.as_dsfr_div }}
                             <span class="fr-hint-text">Formats supportés : {{ allowed_extensions|join:", " }}</span>
+                            <span class="fr-hint-text">Taille maximale autorisée : {{ max_upload_size_mb }} Mo</span>
 
                         </div>
                         <div class="fr-modal__footer">

--- a/core/validators.py
+++ b/core/validators.py
@@ -2,6 +2,8 @@ import magic
 from django.core.exceptions import ValidationError
 from django.utils.deconstruct import deconstructible
 
+MAX_UPLOAD_SIZE_MEGABYTES = 15
+MAX_UPLOAD_SIZE_BYTES = MAX_UPLOAD_SIZE_MEGABYTES * 1024 * 1024
 
 AUTHORIZED_EXTENSIONS = [
     "png",

--- a/core/widgets.py
+++ b/core/widgets.py
@@ -1,10 +1,11 @@
 from django.forms.widgets import FileInput
 
-from core.validators import AUTHORIZED_EXTENSIONS
+from core.validators import AUTHORIZED_EXTENSIONS, MAX_UPLOAD_SIZE_BYTES
 
 
 class RestrictedFileWidget(FileInput):
     def __init__(self, attrs=None):
         attrs = attrs or {}
         attrs["accept"] = ",".join(f".{ext}" for ext in AUTHORIZED_EXTENSIONS)
+        attrs["data-max-size"] = MAX_UPLOAD_SIZE_BYTES
         super().__init__(attrs)

--- a/sv/templates/sv/_sidebar_message_form.html
+++ b/sv/templates/sv/_sidebar_message_form.html
@@ -17,6 +17,7 @@
             <div class="fr-hidden document-form">
                 {{ add_document_form.as_dsfr_div }}
                 <span class="fr-hint-text">Formats supportés : {{ allowed_extensions|join:", " }}</span>
+                <span class="fr-hint-text">Taille maximale autorisée : {{ max_upload_size_mb }} Mo</span>
                 <div class="message-documents-actions">
                     <button class="fr-btn fr-btn--tertiary btn-full" id="message-add-document" disabled>Valider l'ajout du document</button>
                 </div>

--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -14,7 +14,8 @@
 {% block scripts %}
     <script type="module" src="{% static 'sv/evenement_details.js' %}"></script>
     <script type="module" src="{% static 'sv/sidebar.js' %}"></script>
-    <script type="text/javascript" src="{% static 'core/message_form.js' %}"></script>
+    <script type="module" src="{% static 'core/message_form.js' %}"></script>
+    <script type="module" src="{% static 'core/document_form.js' %}"></script>
 {% endblock %}
 
 {% block aside %}

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -1,3 +1,6 @@
+import os
+import tempfile
+
 import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
@@ -636,3 +639,45 @@ def test_can_delete_document_attached_to_message(live_server, page: Page, mocked
     document = Document.objects.get()
     assert document.is_deleted is True
     assert document.deleted_by == mocked_authentification_user.agent
+
+
+def test_message_with_document_exceeding_max_size_shows_validation_error(
+    live_server, page: Page, with_active_contact, choice_js_fill
+):
+    # Créer un fichier temporaire CSV de 16Mo
+    file_size = 16 * 1024 * 1024
+    fd, temp_path = tempfile.mkstemp(suffix=".csv")
+    os.truncate(fd, file_size)
+    os.close(fd)
+
+    evenement = EvenementFactory()
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    page.get_by_test_id("element-actions").click()
+    page.get_by_role("link", name="Message").click()
+    choice_js_fill(
+        page,
+        ".choices__input--cloned:first-of-type",
+        with_active_contact.nom,
+        with_active_contact.contact_set.get().display_with_agent_unit,
+    )
+    page.locator("#id_title").fill("Message avec fichier trop volumineux")
+    page.locator("#id_content").fill("Test de validation de taille de fichier")
+    page.get_by_role("button", name="Ajouter un document").click()
+
+    file_input = page.locator(".sidebar #id_file")
+    max_size_attr = file_input.get_attribute("data-max-size")
+    assert int(max_size_attr) == 15 * 1024 * 1024
+
+    page.locator(".sidebar #id_document_type").select_option("Autre document")
+    page.locator(".sidebar #id_file").set_input_files(temp_path)
+
+    validation_message = file_input.evaluate("el => el.validationMessage")
+    assert "Le fichier est trop volumineux (maximum 15 Mo autorisés)" in validation_message
+
+    page.get_by_test_id("fildesuivi-add-submit").click()
+
+    evenement.refresh_from_db()
+    assert evenement.documents.count() == 0
+    assert evenement.messages.count() == 0
+
+    os.unlink(temp_path)

--- a/sv/views.py
+++ b/sv/views.py
@@ -29,7 +29,7 @@ from core.mixins import (
 )
 from core.models import Visibilite
 from core.redirect import safe_redirect
-from core.validators import AUTHORIZED_EXTENSIONS
+from core.validators import AUTHORIZED_EXTENSIONS, MAX_UPLOAD_SIZE_MEGABYTES
 from sv.forms import (
     FicheZoneDelimiteeForm,
     ZoneInfesteeFormSet,
@@ -183,6 +183,7 @@ class EvenementDetailView(
             if self.request.GET.get("detection")
             else self.object.first_detection_id  # first_detection_id sera None s'il n'y a pas de détection
         )
+        context["max_upload_size_mb"] = MAX_UPLOAD_SIZE_MEGABYTES
         return context
 
 


### PR DESCRIPTION
- Ajoute une limite de taille lors de l'upoad d'un fichier via le formulaire d'ajout de document et via l'ajout d'un élément de suivi (message, note...),
- Vérification effectuée côté backend et frontend,
- Affiche un message d'erreur dès la sélection du fichier si celui-ci dépasse la limite autorisée,
- Ajout d'une indication sur la taille limite à respecter
- la constante `MAX_UPLOAD_SIZE_BYTES` est dans le fichier `validator.py` pour garder une cohérence avec le reste (extensions autorisées)

![image](https://github.com/user-attachments/assets/eb4c113f-c421-4c9a-a0e5-44d36c0fc58d)
![image](https://github.com/user-attachments/assets/4ed443a0-a0b3-47c6-af81-81582b321b9d)
![image](https://github.com/user-attachments/assets/ed5b62bc-8727-4d78-9e66-394388606758)

