### PR TITLE
Corriger l'ordre des détections dans vue de liste

### DIFF
--- a/sv/tests/test_fichedetection_export.py
+++ b/sv/tests/test_fichedetection_export.py
@@ -1,8 +1,11 @@
 from django.urls import reverse
 from playwright.sync_api import expect
 
+from sv.factories import FicheDetectionFactory
 
-def test_can_download_export_fiche_detection(live_server, page, fiche_detection):
+
+def test_can_download_export_fiche_detection(live_server, page):
+    FicheDetectionFactory()
     page.goto(f"{live_server.url}{reverse('fiche-liste')}")
 
     page.get_by_test_id("extract-open").click()

--- a/sv/tests/test_fiches_search.py
+++ b/sv/tests/test_fiches_search.py
@@ -306,19 +306,44 @@ def test_search_without_filters(live_server, page: Page, mocked_authentification
 
 def test_list_is_ordered(live_server, page):
     FicheDetectionFactory(evenement__numero_annee=2023, evenement__numero_evenement=1, numero_detection="2023.1.7")
+    FicheDetectionFactory(evenement__numero_annee=2024, evenement__numero_evenement=11, numero_detection="2024.11.1")
     FicheDetectionFactory(evenement__numero_annee=2024, evenement__numero_evenement=1, numero_detection="2024.1.30")
     FicheDetectionFactory(evenement__numero_annee=2024, evenement__numero_evenement=2, numero_detection="2024.2.31")
 
     page.goto(f"{live_server.url}{get_fiche_detection_search_form_url()}")
 
     cell_selector = ".fiches__list-row:nth-child(1) td:nth-child(2)"
-    assert page.text_content(cell_selector).strip() == "2024.2.31"
+    assert page.text_content(cell_selector).strip() == "2024.11.1"
 
     cell_selector = ".fiches__list-row:nth-child(2) td:nth-child(2)"
-    assert page.text_content(cell_selector).strip() == "2024.1.30"
+    assert page.text_content(cell_selector).strip() == "2024.2.31"
 
     cell_selector = ".fiches__list-row:nth-child(3) td:nth-child(2)"
+    assert page.text_content(cell_selector).strip() == "2024.1.30"
+
+    cell_selector = ".fiches__list-row:nth-child(4) td:nth-child(2)"
     assert page.text_content(cell_selector).strip() == "2023.1.7"
+
+
+def test_list_of_zone_is_ordered(live_server, page):
+    EvenementFactory(numero_annee=2023, numero_evenement=1, fiche_zone_delimitee=FicheZoneFactory())
+    EvenementFactory(numero_annee=2024, numero_evenement=11, fiche_zone_delimitee=FicheZoneFactory())
+    EvenementFactory(numero_annee=2024, numero_evenement=1, fiche_zone_delimitee=FicheZoneFactory())
+    EvenementFactory(numero_annee=2024, numero_evenement=2, fiche_zone_delimitee=FicheZoneFactory())
+
+    page.goto(f"{live_server.url}{reverse('fiche-liste')}?type_fiche=zone")
+
+    cell_selector = ".fiches__list-row:nth-child(1) td:nth-child(2)"
+    assert page.text_content(cell_selector).strip() == "2024.11"
+
+    cell_selector = ".fiches__list-row:nth-child(2) td:nth-child(2)"
+    assert page.text_content(cell_selector).strip() == "2024.2"
+
+    cell_selector = ".fiches__list-row:nth-child(3) td:nth-child(2)"
+    assert page.text_content(cell_selector).strip() == "2024.1"
+
+    cell_selector = ".fiches__list-row:nth-child(4) td:nth-child(2)"
+    assert page.text_content(cell_selector).strip() == "2023.1"
 
 
 def test_search_fiche_zone(live_server, page: Page):

--- a/sv/tests/test_fichezonedelimitee_create.py
+++ b/sv/tests/test_fichezonedelimitee_create.py
@@ -76,6 +76,19 @@ def test_can_create_fiche_zone_delimitee_with_2_zones_infestees(
         )
         for _ in range(3)
     )
+    for i, detection in enumerate(FicheDetection.objects.all()):
+        detection.numero_detection = f"2024.01.{i}"
+        detection.save()
+    detections_hors_zone_infestee = list(
+        FicheDetection.objects.filter(id__in=[obj.id for obj in detections_hors_zone_infestee])
+    )
+    detections_zone_infestee1 = list(
+        FicheDetection.objects.filter(id__in=[obj.id for obj in detections_zone_infestee1])
+    )
+    detections_zone_infestee2 = list(
+        FicheDetection.objects.filter(id__in=[obj.id for obj in detections_zone_infestee2])
+    )
+
     fiche = baker.prepare(
         FicheZoneDelimitee,
         _fill_optional=True,

--- a/sv/tests/test_fichezonedelimitee_update_performance.py
+++ b/sv/tests/test_fichezonedelimitee_update_performance.py
@@ -1,7 +1,4 @@
-from model_bakery import baker
-
-from sv.factories import FicheZoneFactory, EvenementFactory
-from sv.models import FicheDetection
+from sv.factories import FicheZoneFactory, EvenementFactory, FicheDetectionFactory
 
 BASE_NUM_QUERIES = 13
 
@@ -13,28 +10,12 @@ def test_update_fiche_zone_delimitee_form_with_multiple_existing_fiche_detection
     quel que soit le nombre de fiches de détection affichées dans les champs hors zone infestée et zone infestée"""
     fiche_zone_delimitee = FicheZoneFactory()
     evenement = EvenementFactory(fiche_zone_delimitee=fiche_zone_delimitee)
-    baker.make(
-        FicheDetection,
-        _fill_optional=True,
-        createur=mocked_authentification_user.agent.structure,
-        hors_zone_infestee=None,
-        zone_infestee=None,
-        evenement=evenement,
-        _quantity=3,
-    )
+    FicheDetectionFactory.create_batch(3, evenement=evenement)
     client.get(fiche_zone_delimitee.get_update_url())
 
     with django_assert_num_queries(BASE_NUM_QUERIES):
         client.get(fiche_zone_delimitee.get_update_url())
 
-    baker.make(
-        FicheDetection,
-        _fill_optional=True,
-        createur=mocked_authentification_user.agent.structure,
-        hors_zone_infestee=None,
-        zone_infestee=None,
-        evenement=evenement,
-        _quantity=3,
-    )
+    FicheDetectionFactory.create_batch(3, evenement=evenement)
     with django_assert_num_queries(BASE_NUM_QUERIES):
         client.get(fiche_zone_delimitee.get_update_url())


### PR DESCRIPTION
En triant sur la chaine de caractères on se retrouve dans une situation où la détection 2025.1.1 est affichée avant (plus haut) que la détection 2025.1.10 qui est pourant "plus récente".

Ce commit adapte le tri pour que ce problème ne survienne plus. L'utilisation d'un objet extérieur (événement) dans le tri sera probablement plus lent.

- Ajout d'un test sur le tri des zones pour vérifier que cela était bien ok
- Correction d'un test qui utilisait des numéros non valides