### PR TITLE
Ajouter un bouton annuler dans le formulaire d’une fiche détection

### DIFF
--- a/sv/static/sv/evenement_details.js
+++ b/sv/static/sv/evenement_details.js
@@ -29,6 +29,7 @@ document.addEventListener('DOMContentLoaded', function() {
         element.addEventListener('dsfr.disclose', event=>{
             const tabId = event.target.getAttribute("id").replace("tabpanel-", "").replace("-panel", "")
             showOnlyActionsForDetection(tabId)
+            window.history.pushState({}, '', `?detection=${tabId}`);
         })
     })
 

--- a/sv/static/sv/fichedetection_form.js
+++ b/sv/static/sv/fichedetection_form.js
@@ -30,7 +30,13 @@ function hasStatusToOrganismeNuisibleData() {
 }
 
 document.addEventListener('DOMContentLoaded', function() {
+    document.getElementById("cancel-link").addEventListener("click", (event) => {
+        event.preventDefault();
+        window.location = document.referrer;
+    });
+
     if (hasStatusToOrganismeNuisibleData()) {
         setUpOrganismeNuisible();
     }
+
 });

--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -125,7 +125,7 @@
                                     </li>
                                 {% endfor %}
                                 <li>
-                                    <a href="{% url 'fiche-detection-creation' %}?evenement={{ evenement.pk }}" class="fr-tag fr-tag--tertiary fr-mx-1w">
+                                    <a id="add-detection-link" href="{% url 'fiche-detection-creation' %}?evenement={{ evenement.pk }}" class="fr-tag fr-tag--tertiary fr-mx-1w">
                                         <span class="fr-icon-add-line" aria-hidden="true"></span> Ajouter une détection</a>
                                 </li>
                             </ul>

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -44,10 +44,10 @@
                         <input type="hidden" name="evenement" value="{{ form.instance.evenement.pk }}">
                     {% endif %}
 
+                    <a id="cancel-link" href="#" class="fr-link fr-mr-3w">Annuler</a>
                     {% if is_creation %}
                         <input type="submit" value="Enregistrer" class="fr-btn">
                     {% else %}
-                        <a href="{{ fichedetection.evenement.get_absolute_url }}" class="fr-link fr-mr-3w">Annuler</a>
                         <input type="submit" name="action" value="Enregistrer les modifications" data-action="enregistrer-modifications" class="fr-btn" data-testid="fiche-detection-save-btn">
                     {% endif %}
                 </p>

--- a/sv/tests/test_utils.py
+++ b/sv/tests/test_utils.py
@@ -179,7 +179,7 @@ class LieuFormDomElements:
 
     @property
     def cancel_btn(self) -> Locator:
-        return self.page.get_by_role("link", name="Annuler")
+        return self.page.locator('[id^="modal-add-lieu-"][open="true"]').get_by_role("link", name="Annuler")
 
     @property
     def title(self) -> Locator:
@@ -294,7 +294,7 @@ class PrelevementFormDomElements:
 
     @property
     def cancel_btn(self) -> Locator:
-        return self.page.get_by_role("link", name="Annuler")
+        return self.page.locator('[id^="modal-add-edit-prelevement-"][open="true"]').get_by_role("link", name="Annuler")
 
     @property
     def save_btn(self) -> Locator:


### PR DESCRIPTION
Lorsque j'ajoute une nouvelle détection (ou modifie) depuis la page de détail d'un évènement, je peux annuler et revenir à la page de détail de l’évènement dans le même état (avec la même détection sélectionnée).

Ce qui a été fait : 
- Ajout de la fonction `updateAddDetectionLink` pour gérer la mise à jour de l'URL du bouton d'ajout d'une nouvelle détection lorsqu'on change la détection à visualiser et ajout de la variable `back_link` dans le context de la view `FicheDetectionCreateView`,
- Pour la modification, ajout de la variable `back_link` dans le context de la view `FicheDetectionUpdateView`,
- Modification de quelques tests pour différencier le lien ajouté de ceux existant dans les modales pour les formulaires d'ajout/modification d'un lieu et prélèvement.