### PR TITLE
Ajouter un message de confirmation pour les documents

### DIFF
--- a/sv/templates/sv/_document_warning_modal.html
+++ b/sv/templates/sv/_document_warning_modal.html
@@ -1,0 +1,22 @@
+<!-- bouton relié à la modal en display non -> https://github.com/GouvernementFR/dsfr/issues/728 -->
+<button type="button" class="fr-hidden" data-fr-opened="false" aria-controls="fr-modal-document-confirmation"></button>
+<dialog aria-labelledby="fr-modal-title-document-confirmation" role="dialog" id="fr-modal-document-confirmation" class="fr-modal">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-document-confirmation">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 id="fr-modal-title-document-confirmation" class="fr-modal__title"><span class="fr-icon-arrow-right-line fr-icon--lg"></span>Document non ajouté</h1>
+                        <p>Vous n'avez pas validé l'ajout du document, que souhaitez vous faire&nbsp;?</p>
+
+                        <button type="button" class="fr-btn fr-btn--secondary" id="send-without-adding-document">Envoyer le message sans document</button>
+                        <button type="button" class="fr-btn" id="send-with-adding-document">Valider et envoyer</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/sv/templates/sv/_sidebar_message_form.html
+++ b/sv/templates/sv/_sidebar_message_form.html
@@ -3,7 +3,7 @@
         <a href="#" class="fr-link close-sidebar fr-mb-2v">Annuler et fermer</a>
     </div>
     <h5 id="message-type-title" class="fr-h5 fr-mb-0-5v"></h5>
-    <form method="post" enctype="multipart/form-data" action="{{ evenement.add_message_url }}">
+    <form method="post" id="message-form" enctype="multipart/form-data" action="{{ evenement.add_message_url }}">
         {% csrf_token %}
         <div class=" fr-fieldset__element fr-hidden">
             <label>Destinataires</label>
@@ -25,7 +25,7 @@
 
         </div>
         <div class="message-send-btn fr-pr-1w fr-mb-8w">
-            <button type="submit" class="fr-btn " data-testid="fildesuivi-add-submit">Envoyer</button>
+            <button type="submit" class="fr-btn " id="message-send-btn" data-testid="fildesuivi-add-submit">Envoyer</button>
         </div>
 
     </form>

--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -20,6 +20,7 @@
 
 {% block aside %}
     {% include "sv/_sidebar_message_form.html" %}
+    {% include "sv/_document_warning_modal.html" %}
 
     {% for message in message_list %}
         {% include "sv/_sidebar_message_details.html" %}

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -665,3 +665,62 @@ def test_message_with_document_exceeding_max_size_shows_validation_error(
     assert evenement.messages.count() == 0
 
     os.unlink(temp_path)
+
+
+def test_can_add_message_with_document_confirmation_modal_reject(live_server, page: Page, choice_js_fill):
+    active_contact = ContactAgentFactory(with_active_agent=True).agent
+    evenement = EvenementFactory()
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    page.get_by_test_id("element-actions").click()
+    page.get_by_role("link", name="Message").click()
+
+    choice_js_fill(
+        page,
+        ".choices__input--cloned:first-of-type",
+        active_contact.nom,
+        active_contact.contact_set.get().display_with_agent_unit,
+    )
+    page.locator("#id_title").fill("Title of the message")
+    page.locator("#id_content").fill("My content \n with a line return")
+
+    page.get_by_role("button", name="Ajouter un document").click()
+    page.locator(".sidebar #id_document_type").select_option("Autre document")
+    page.locator(".sidebar #id_file").set_input_files("README.md")
+
+    page.get_by_test_id("fildesuivi-add-submit").click()
+    expect(page.locator("#fr-modal-document-confirmation")).to_be_visible()
+    page.locator("#send-without-adding-document").click()
+
+    page.wait_for_url(f"**{evenement.get_absolute_url()}#tabpanel-messages-panel")
+    message = Message.objects.get()
+    assert message.documents.count() == 0
+
+
+def test_can_add_message_with_document_confirmation_modal_confirm(live_server, page: Page, choice_js_fill):
+    active_contact = ContactAgentFactory(with_active_agent=True).agent
+    evenement = EvenementFactory()
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    page.get_by_test_id("element-actions").click()
+    page.get_by_role("link", name="Message").click()
+
+    choice_js_fill(
+        page,
+        ".choices__input--cloned:first-of-type",
+        active_contact.nom,
+        active_contact.contact_set.get().display_with_agent_unit,
+    )
+    page.locator("#id_title").fill("Title of the message")
+    page.locator("#id_content").fill("My content \n with a line return")
+
+    page.get_by_role("button", name="Ajouter un document").click()
+    page.locator(".sidebar #id_document_type").select_option("Autre document")
+    page.locator(".sidebar #id_file").set_input_files("README.md")
+
+    page.get_by_test_id("fildesuivi-add-submit").click()
+    expect(page.locator("#fr-modal-document-confirmation")).to_be_visible()
+    page.locator("#send-with-adding-document").click()
+
+    page.wait_for_url(f"**{evenement.get_absolute_url()}#tabpanel-messages-panel")
+    message = Message.objects.get()
+    assert message.documents.count() == 1
+    expect(page.get_by_role("link", name="README.md", exact=True)).to_be_visible()


### PR DESCRIPTION
Ajoute un message de confirmation quand l'utilisateur va envoyer son message avec un document non validé (formulaire rempli mais non confirmé). L'utilisateur a deux choix: envoyer en validant ou non le denier document.

- Refactoring du JS pour éclaircir un peu le code
- Ajout de tests sur les 2 nouveaux cas