### PR TITLE
Forcer le téléchargement des documents

### DIFF
--- a/seves/settings.py
+++ b/seves/settings.py
@@ -181,6 +181,10 @@ STORAGES = {
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
     },
 }
+AWS_S3_OBJECT_PARAMETERS = {
+    "ContentDisposition": "attachment",
+}
+
 
 if all(
     [


### PR DESCRIPTION
Forcer le téléchargement des documents au clic sur le lien de téléchargement plutôt que la consultation dans le navigateur pour le format supportés (images, PDF, etc.)

https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#settings
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/put_object.html#
https://www.rfc-editor.org/rfc/rfc6266#section-4