### PR TITLE
Permettre à l'AC de clôturer quand il est le dernier sans fin de suivi

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -266,7 +266,24 @@ class WithEtatMixin(models.Model):
         return user.agent.is_in_structure(self.createur) if self.is_draft else False
 
     def can_be_cloturer_by(self, user):
-        return not self.is_draft and not self.is_already_cloturer() and user.agent.structure.is_ac
+        return user.agent.structure.is_ac
+
+    def is_the_only_remaining_structure(self, user, contacts_not_in_fin_suivi) -> bool:
+        """Un seul contact sans fin de suivi qui appartient à la structure de l'utilisateur"""
+        return len(contacts_not_in_fin_suivi) == 1 and contacts_not_in_fin_suivi[0].structure == user.agent.structure
+
+    def can_be_cloturer(self, user, contacts_not_in_fin_suivi) -> bool:
+        if self.is_draft or self.is_already_cloturer() or not self.can_be_cloturer_by(user):
+            return False
+
+        if not contacts_not_in_fin_suivi:
+            return True
+
+        if self.is_the_only_remaining_structure(user, contacts_not_in_fin_suivi):
+            return True
+
+        # Plusieurs contacts sans fin de suivi
+        return False
 
     def is_already_cloturer(self):
         return self.etat == self.Etat.CLOTURE

--- a/sv/models/evenements.py
+++ b/sv/models/evenements.py
@@ -164,3 +164,20 @@ class Evenement(
 
     def get_soft_delete_attribute_error_message(self):
         return f"L'évènement {self.numero} ne peut pas être supprimé"
+
+    def add_fin_suivi(self, user):
+        with transaction.atomic():
+            fin_suivi_contact = FinSuiviContact(
+                content_object=self,
+                contact=Contact.objects.get(structure=user.agent.structure),
+            )
+            fin_suivi_contact.full_clean()
+            fin_suivi_contact.save()
+
+            Message.objects.create(
+                title="Fin de suivi",
+                content="Fin de suivi ajoutée automatiquement suite à la clôture de l'événement.",
+                sender=user.agent.contact_set.get(),
+                message_type=Message.FIN_SUIVI,
+                content_object=self,
+            )

--- a/sv/templates/sv/_cloturer_modal.html
+++ b/sv/templates/sv/_cloturer_modal.html
@@ -11,18 +11,18 @@
                             <span class="fr-icon-arrow-right-line fr-icon--lg"></span>
                             Clôturer un événement
                         </h1>
-                        {% if can_cloturer_evenement %}
+                        {% if is_evenement_can_be_cloturer %}
                             <p>Étes-vous sûr.e de vouloir clôturer l'événement {{ evenement.numero }} ?</p>
                         {% else %}
-                            <p>Vous ne pouvez pas clôturer l'événement n°{{ evenement.numero }} car les structures suivantes n'ont pas signalées la fin de suivi : </p>
-                            <ul>
+                            <p>Vous ne pouvez pas clôturer l'événement n°{{ evenement.numero }} car les structures suivantes n'ont pas signalé la fin de suivi : </p>
+                            <ul data-testid="structures-not-in-fin-suivi">
                                 {% for contact in contacts_not_in_fin_suivi %}
                                     <li>{{ contact.structure }}</li>
                                 {% endfor %}
                             </ul>
                         {% endif %}
                     </div>
-                    {% if can_cloturer_evenement %}
+                    {% if is_evenement_can_be_cloturer %}
                         <div class="fr-modal__footer">
                             <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
                                 <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-cloturer-evenement">

--- a/sv/templates/sv/_evenement_action_navigation.html
+++ b/sv/templates/sv/_evenement_action_navigation.html
@@ -25,7 +25,7 @@
                     <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-edit-visibilite"><span class="fr-icon-eye-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Modifier la visibilité</a></li>
                 {% endif %}
                 <li><a class="fr-translate__language fr-nav__link" href="{{ evenement.get_update_url}}" ><span class="fr-icon-edit-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Modifier l'événement</a></li>
-                {%  if can_be_cloturer %}
+                {%  if is_evenement_can_be_cloturer_by_user %}
                     <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-cloturer-evenement"><span class="fr-icon-close-circle-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Clôturer l'événement</a></li>
                 {% endif %}
                 <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-delete-evenement"><span class="fr-icon-close-circle-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Supprimer l'événement</a></li>

--- a/sv/view_mixins.py
+++ b/sv/view_mixins.py
@@ -87,3 +87,21 @@ class WithPrelevementResultatsMixin:
         context = super().get_context_data(**kwargs)
         context["prelevement_resultats"] = dict(Prelevement.Resultat.choices)
         return context
+
+
+class WithClotureContextMixin:
+    """
+    Mixin qui ajoute au contexte les informations relatives à la clôture d'un événement.
+    """
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        evenement = self.get_object()
+        context["contacts_not_in_fin_suivi"] = contacts_not_in_fin_suivi = (
+            evenement.get_contacts_structures_not_in_fin_suivi()
+        )
+        context["is_evenement_can_be_cloturer_by_user"] = evenement.can_be_cloturer_by(self.request.user)
+        context["is_evenement_can_be_cloturer"] = evenement.can_be_cloturer(
+            self.request.user, contacts_not_in_fin_suivi
+        )
+        return context


### PR DESCRIPTION
Cette PR permet a un agent de l'AC de clôturer un évènement même si sa structure est la dernière à ne pas avoir mis fin au suivi.
Ce qui a été fait : 
- centralisation de la logique de clôture dans la méthode `can_be_cloturer`,
- la méthode `can_be_cloturer_by` à été modifiée pour seulement vérifier si un user a le droit de clôturer un évènement,
- renommage des variables dans les templates pour une meilleurs compréhension : 
  - `is_evenement_can_be_cloturer_by_user` : est-ce que le user a le droit de clôturer l'évènement
  - `is_evenement_can_be_cloturer` : est-ce que l'évènement peut être clôturer
- création d'un mixin `WithClotureContextMixin` pour regrouper les différentes variables nécessaires dans les templates pour la clôture,
- modification de la view `EvenementCloturerView` pour ajouter automatiquement la fin de suivi (avec message) lorsque l'agent connecté est de l'AC et que sa structure est la dernière à ne pas avoir mis fin au suivi.
- ajout d'un test