### PR TITLE
Affiche le tag clôturé si l'évènement est clôturé

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -259,6 +259,9 @@ class WithEtatMixin(models.Model):
     def is_draft(self):
         return self.etat == self.Etat.BROUILLON
 
+    def is_cloture(self):
+        return self.etat == self.Etat.CLOTURE
+
     def can_publish(self, user):
         return user.agent.is_in_structure(self.createur) if self.is_draft else False
 

--- a/sv/models/evenements.py
+++ b/sv/models/evenements.py
@@ -146,7 +146,7 @@ class Evenement(
         return self.get_etat_data_from_fin_de_suivi(is_fin_de_suivi)
 
     def get_etat_data_from_fin_de_suivi(self, is_fin_de_suivi):
-        if is_fin_de_suivi:
+        if not self.is_cloture() and is_fin_de_suivi:
             return {"etat": "fin de suivi", "readable_etat": "Fin de suivi"}
         return {"etat": self.etat, "readable_etat": self.get_etat_display()}
 

--- a/sv/tests/test_evenement_etats.py
+++ b/sv/tests/test_evenement_etats.py
@@ -205,3 +205,9 @@ def test_cannot_cloturer_evenement_if_user_is_not_ac(live_server, page: Page, mo
     expect(page.get_by_role("link", name="Clôturer l'événement")).not_to_be_visible()
     evenement.refresh_from_db()
     assert evenement.etat == Evenement.Etat.EN_COURS
+
+
+def test_show_cloture_tag(live_server, page: Page):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    expect(page.get_by_text("Clôturé")).to_be_visible()


### PR DESCRIPTION
Problème: lorsque l'évènement est clôturé, on ne le voit pas sur la fiche de l'évènement. Le tag affiché est Fin de suivi.