### PR TITLE
Arriver en haut de la page quand on revient sur l’évènement après création/modif fiche zone

### DIFF
--- a/sv/static/sv/evenement_details.js
+++ b/sv/static/sv/evenement_details.js
@@ -21,7 +21,25 @@ function initializeDetectionTags() {
     });
 }
 
+function selectZoneTab() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('tab') === 'zone') {
+        const tabzone = document.getElementById("tabpanel-zone-panel");
+        dsfr(tabzone).tabPanel.disclose();
+    }
+}
+
+function updateURLParameters(paramName, paramValue) {
+    const params = new URLSearchParams(window.location.search);
+    params.set(paramName, paramValue);
+    window.history.pushState({}, '', `?${params.toString()}`);
+}
+
 document.addEventListener('DOMContentLoaded', function() {
+    setTimeout(() => {
+        selectZoneTab();
+    }, 500);
+
     const viewManager = new ViewManager(evenementViewModeConfig);
     viewManager.initialize();
 
@@ -29,7 +47,7 @@ document.addEventListener('DOMContentLoaded', function() {
         element.addEventListener('dsfr.disclose', event=>{
             const tabId = event.target.getAttribute("id").replace("tabpanel-", "").replace("-panel", "")
             showOnlyActionsForDetection(tabId)
-            window.history.pushState({}, '', `?detection=${tabId}`);
+            updateURLParameters('detection', tabId);
         })
     })
 

--- a/sv/views.py
+++ b/sv/views.py
@@ -488,7 +488,7 @@ class FicheZoneDelimiteeCreateView(WithFormErrorsAsMessagesMixin, CreateView):
     context_object_name = "fiche"
 
     def get_success_url(self):
-        return reverse("evenement-details", args=[self.object.evenement.numero]) + "#tabpanel-zone-panel"
+        return reverse("evenement-details", args=[self.object.evenement.numero]) + "?tab=zone"
 
     def dispatch(self, request, *args, **kwargs):
         try:
@@ -595,7 +595,7 @@ class FicheZoneDelimiteeUpdateView(
     context_object_name = "fiche"
 
     def get_success_url(self):
-        return self.get_object().get_absolute_url() + "#tabpanel-zone-panel"
+        return self.get_object().get_absolute_url() + "?tab=zone"
 
     def test_func(self) -> bool | None:
         return self.get_object().evenement.can_user_access(self.request.user)


### PR DESCRIPTION
Cette PR permet d'arriver en haut de la page quand on revient sur l’évènement après création ou modification d'une fiche zone délimitée.

Initialement, le lien de redirection incluait un hash (#tabpanel-zone-panel) vers l'onglet zone et au chargement de la page la navigateur se positionné dessus. Par conséquent, le haut de la page de l'évènement n'était plus visible.

Ce qui a été fait : 
- suppression du hash pour supprimer l'effet de positionnement natif du navigateur sur l'onglet Zone,
- ajout du paramètre `tab` dans l'URL suite à une création ou modification d'une fiche zone délimitée,
- au chargement de la page, si le paramètre tab est a `zone`, alors sélection automatique de l'onglet (via API js DSFR)
- ~~ajout d'un écouteur dsfr.ready ou dsfr.start pour éviter que la fonction ne s’exécute avant le chargement du DSFR (si non présent, erreur js possible -> Uncaught TypeError: dsfr(...) is null)~~
- utilisation d'un settimeout pour s'assurer que le DSFR soit chargé (à remplacer par dsfr.ready ou dsfr.start lors du merge de #743)