### PR TITLE
Mettre à jour choicesjs

### DIFF
--- a/core/static/core/contact_add_form.css
+++ b/core/static/core/contact_add_form.css
@@ -2,3 +2,6 @@
     background-color: var(--background-default-grey);
     min-height: 600px
 }
+.choices {
+    margin-top: 0.5rem;
+}

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -21,7 +21,7 @@
         <link rel="stylesheet" href="{% static 'core/bloc_commun.css' %}">
         <link rel="stylesheet" href="{% static 'core/message.css' %}">
         <link rel="stylesheet" href="{% static 'core/fil_de_suivi.css' %}">
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/styles/choices.min.css" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js@11.0.4/public/assets/styles/choices.min.css" />
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.3.0/fonts/remixicon.css"/>
         {% block extrahead %}{% endblock %}
     </head>
@@ -116,7 +116,7 @@
 
     <script type="module" src="{% static 'dsfr.module.min.js' %}"></script>
     <script type="text/javascript" nomodule src="{% static 'dsfr.nomodule.min.js' %}"></script>
-    <script src="https://cdn.jsdelivr.net/npm/choices.js@9.0.1/public/assets/scripts/choices.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/choices.js@11.0.4/public/assets/scripts/choices.min.js"></script>
     <script type="text/javascript" src="{% static 'core/base.js' %}"></script>
     {% block scripts %}{% endblock %}
 </body>

--- a/sv/static/sv/contact_add_form.js
+++ b/sv/static/sv/contact_add_form.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', function() {
     const choices = new Choices(element, {
         itemSelectText: '',
         classNames: {
-            containerInner: 'fr-select fr-mt-1w',
+            containerInner: 'fr-select',
         },
         searchResultLimit: 500,
     });

--- a/sv/static/sv/evenement_form.js
+++ b/sv/static/sv/evenement_form.js
@@ -12,7 +12,7 @@ function setUpOrganismeNuisible(){
         let found = false;
         const statutElement = document.getElementById('id_statut_reglementaire')
         statusToNuisibleId.forEach((status) =>{
-            if (status.nuisibleIds.includes(parseInt(event.detail.choice.value))) {
+            if (status.nuisibleIds.includes(parseInt(event.detail.value))) {
                 statutElement.value = status.statusID;
                 statutElement.dispatchEvent(new Event('change'));
                 found = true;

--- a/sv/static/sv/fichedetection_form.js
+++ b/sv/static/sv/fichedetection_form.js
@@ -12,7 +12,7 @@ function setUpOrganismeNuisible(){
         let found = false;
         const statutElement = document.getElementById('id_statut_reglementaire')
         statusToNuisibleId.forEach((status) =>{
-            if (status.nuisibleIds.includes(parseInt(event.detail.choice.value))) {
+            if (status.nuisibleIds.includes(parseInt(event.detail.value))) {
                 statutElement.value = status.statusID;
                 statutElement.dispatchEvent(new Event('change'));
                 found = true;

--- a/sv/static/sv/fichedetection_lieux_form.js
+++ b/sv/static/sv/fichedetection_lieux_form.js
@@ -147,9 +147,9 @@ function setUpCommune(element) {
     })
 
     choicesCommunes.passedElement.element.addEventListener("choice", (event)=> {
-        communeInput.value = event.detail.choice.value
-        inseeInput.value = event.detail.choice.customProperties.inseeCode
-        departementInput.value = event.detail.choice.customProperties.departementCode
+        communeInput.value = event.detail.value
+        inseeInput.value = event.detail.customProperties.inseeCode
+        departementInput.value = event.detail.customProperties.departementCode
     })
 }
 

--- a/sv/tests/test_evenement_update.py
+++ b/sv/tests/test_evenement_update.py
@@ -176,9 +176,9 @@ def test_update_evenement_free_links_filtered_by_user_visibility(
     page.goto(f"{live_server.url}{evenement.get_update_url()}")
     page.locator("#liens-libre .choices").click()
 
-    expect(page.get_by_text(str(visible_evenement.numero))).to_be_visible()
-    expect(page.get_by_text(str(limited_visible_evenement.numero))).to_be_visible()
-    expect(page.get_by_text(str(hidden_evenement.numero))).not_to_be_visible()
+    expect(page.get_by_role("option", name=str(visible_evenement.numero))).to_be_visible()
+    expect(page.get_by_role("option", name=str(limited_visible_evenement.numero))).to_be_visible()
+    expect(page.get_by_role("option", name=str(hidden_evenement.numero))).not_to_be_visible()
 
 
 def test_update_evenement_has_locking_protection(live_server, page: Page, choice_js_fill):


### PR DESCRIPTION
Mise à jour de la bibliothéque choicesjs pour avoir les dernières méthodes a disposition (nécessaire pour un ticket a venir).

- Les listes de classes ne sont plus autorisées
- Quelques changement dans la structure des événements