### PR TITLE
Corriger l'affichage des destinataires

### DIFF
--- a/core/static/core/message_form.js
+++ b/core/static/core/message_form.js
@@ -72,6 +72,7 @@ function changeFormBasedOnMessageType(messageType){
     const destinatairesElement = document.querySelector('label[for="id_recipients"]').parentNode
     const destinatairesInput = document.getElementById("id_recipients")
     const copieElement = document.querySelector('label[for="id_recipients_copy"]').parentNode
+    document.getElementById("id_recipients_limited_recipients").parentNode.classList.add("fr-hidden")
 
     if (messageType === "note" || messageType === "point de situation" || messageType === "fin de suivi") {
         destinatairesElement.classList.add("fr-hidden")


### PR DESCRIPTION
Dans le scénario suivant:
- Je fais un nouvel élément de suivi de type compte rendu sur DI
- Je ferme la sidebar
- Je fais un nouvel élément de suivi d'un autre type (message par exemple)

Les cases a cocher (choix de destinataire limité) ne devraient pas être affichées car elle ne servent que pour le compte rendu sur DI.