### PR TITLE
Vérifier que des éléments existent avant utilisation

### DIFF
--- a/core/static/core/document_form.js
+++ b/core/static/core/document_form.js
@@ -2,6 +2,8 @@ import { validateFileSize } from './document.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     const uploadModal = document.getElementById('fr-modal-add-doc');
-    const fileInput = uploadModal.querySelector('input[type="file"]');
-    fileInput.addEventListener('change', () => validateFileSize(fileInput));
+    if (!!uploadModal){
+        const fileInput = uploadModal.querySelector('input[type="file"]');
+        fileInput.addEventListener('change', () => validateFileSize(fileInput));
+    }
 });

--- a/sv/static/sv/view_manager.js
+++ b/sv/static/sv/view_manager.js
@@ -66,6 +66,9 @@ export class ViewManager {
 
     initialize() {
         this.#getElements();
+        if(!this.#elements.detailBtn && !this.#elements.syntheseBtn){
+            return
+        }
         this.#initViewState();
         this.#initViewModeButtons();
     }


### PR DESCRIPTION
Dans le cas d'une fiche en brouillon certains éléments HTML ne sont pas existant. N'initialiser les composants uniquement quand cela est possible.