### PR TITLE
Corriger la recherche pour la zone

### DIFF
--- a/sv/filters.py
+++ b/sv/filters.py
@@ -113,6 +113,8 @@ class FicheFilter(django_filters.FilterSet):
             return queryset.filter(numero_detection__startswith=value)
         if self._is_zone:
             parts = list(map(int, value.split(".")))
+            if len(parts) == 1:
+                return queryset.filter(evenement__numero_annee=parts[0])
             return queryset.filter(evenement__numero_annee=parts[0], evenement__numero_evenement=parts[1])
 
     def filter_organisme_nuisible(self, queryset, name, value):

--- a/sv/tests/test_fiches_search.py
+++ b/sv/tests/test_fiches_search.py
@@ -119,6 +119,21 @@ def test_search_with_fiche_number_allows_year_only(live_server, page: Page, mock
 
 
 @pytest.mark.django_db
+def test_search_zone_with_fiche_number_allows_year_only(live_server, page: Page, mocked_authentification_user):
+    EvenementFactory(fiche_zone_delimitee=FicheZoneFactory(), numero_annee=2024, numero_evenement=1)
+    EvenementFactory(fiche_zone_delimitee=FicheZoneFactory(), numero_annee=2024, numero_evenement=2)
+    EvenementFactory(fiche_zone_delimitee=FicheZoneFactory(), numero_annee=2023, numero_evenement=1)
+
+    page.goto(f"{live_server.url}{get_fiche_detection_search_form_url()}?type_fiche=zone")
+    page.get_by_label("Numéro").fill("2024")
+    page.get_by_role("button", name="Rechercher").click()
+
+    expect(page.locator('role=cell[name="2024.1"]')).to_have_count(2)
+    expect(page.locator('role=cell[name="2024.2"]')).to_have_count(2)
+    expect(page.get_by_role("cell", name="2023.1")).not_to_be_visible()
+
+
+@pytest.mark.django_db
 def test_search_with_fiche_number_allows_year_and_first_char(live_server, page: Page, mocked_authentification_user):
     FicheDetectionFactory(numero_detection="2024.1.1")
     FicheDetectionFactory(numero_detection="2024.1.2")


### PR DESCRIPTION
Corrige le cas où l'on veut rechercher uniquement avec une année.