### PR TITLE
Trier les fiches de détection par numéro séquentiel et non par ID

### DIFF
--- a/sv/factories.py
+++ b/sv/factories.py
@@ -17,6 +17,7 @@ from .constants import (
     SITES_INSPECTION,
     DEPARTEMENTS,
     REGIONS,
+    POSITION_CHAINE_DISTRIBUTION,
 )
 from .models import (
     Prelevement,
@@ -36,6 +37,7 @@ from .models import (
     Contexte,
     SiteInspection,
     Region,
+    PositionChaineDistribution,
 )
 
 fake = Faker()
@@ -187,6 +189,26 @@ class PrelevementFactory(DjangoModelFactory):
         espece = EspeceEchantillonFactory()
         return cls.build(matrice_prelevee=matrice_prelevee, espece_echantillon=espece, *args, **kwargs)
 
+    @classmethod
+    def create_minimal(cls, **kwargs):
+        return cls.create(
+            numero_echantillon="",
+            date_prelevement=None,
+            matrice_prelevee=None,
+            espece_echantillon=None,
+            laboratoire=None,
+            numero_rapport_inspection="",
+            **kwargs,
+        )
+
+
+class PositionChaineDistributionFactory(DjangoModelFactory):
+    class Meta:
+        model = PositionChaineDistribution
+        django_get_or_create = ("libelle",)
+
+    libelle = factory.lazy_attribute(lambda _: random.choice(POSITION_CHAINE_DISTRIBUTION))
+
 
 class LieuFactory(DjangoModelFactory):
     class Meta:
@@ -210,6 +232,29 @@ class LieuFactory(DjangoModelFactory):
     siret_etablissement = factory.Faker("numerify", text="##############")
     code_inupp_etablissement = factory.Faker("numerify", text="#######")
     site_inspection = factory.SubFactory("sv.factories.SiteInspectionFactory")
+    position_chaine_distribution_etablissement = factory.SubFactory("sv.factories.PositionChaineDistributionFactory")
+
+    @classmethod
+    def create_minimal(cls, **kwargs):
+        return cls.create(
+            wgs84_longitude=None,
+            wgs84_latitude=None,
+            adresse_lieu_dit="",
+            commune="",
+            code_insee="",
+            departement=None,
+            is_etablissement=False,
+            nom_etablissement="",
+            activite_etablissement="",
+            pays_etablissement="",
+            raison_sociale_etablissement="",
+            adresse_etablissement="",
+            siret_etablissement="",
+            code_inupp_etablissement="",
+            site_inspection=None,
+            position_chaine_distribution_etablissement=None,
+            **kwargs,
+        )
 
 
 class FicheDetectionFactory(DjangoModelFactory):

--- a/sv/tests/test_evenement_details.py
+++ b/sv/tests/test_evenement_details.py
@@ -335,3 +335,33 @@ def test_show_details_synthese_switch(live_server, page: Page, etat: Etat):
     page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
     expect(page.get_by_text("Détail")).to_be_visible()
     expect(page.get_by_text("Synthèse")).to_be_visible()
+
+
+def test_first_detection_by_number_is_selected_by_default(live_server, page: Page):
+    """Test que la première fiche de détection (par numéro et non par id) est sélectionnée par défaut."""
+    evenement = EvenementFactory()
+
+    FicheDetectionFactory(evenement=evenement, numero_detection=f"{evenement.numero}.3")
+    FicheDetectionFactory(evenement=evenement, numero_detection=f"{evenement.numero}.2")
+    detection_3 = FicheDetectionFactory(evenement=evenement, numero_detection=f"{evenement.numero}.1")
+
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+
+    expect(page.get_by_role("tab", name=detection_3.numero_detection)).to_have_class(
+        re.compile(r"(^|\s)selected($|\s)")
+    )
+
+
+def test_detections_are_order_by_detection_number_not_by_id(live_server, page: Page):
+    """Test que les fiches détections sont triées par numéro et non par id."""
+    evenement = EvenementFactory()
+    detection_10 = FicheDetectionFactory(evenement=evenement, numero_detection=f"{evenement.numero}.10")
+    detection_3 = FicheDetectionFactory(evenement=evenement, numero_detection=f"{evenement.numero}.3")
+    detection_2 = FicheDetectionFactory(evenement=evenement, numero_detection=f"{evenement.numero}.2")
+    detection_1 = FicheDetectionFactory(evenement=evenement, numero_detection=f"{evenement.numero}.1")
+
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+
+    expect(page.locator("#tabpanel-detection-panel ul > li")).to_contain_text(
+        [detection_1.numero, detection_2.numero, detection_3.numero, detection_10.numero]
+    )

--- a/sv/tests/test_evenement_performance_details.py
+++ b/sv/tests/test_evenement_performance_details.py
@@ -110,7 +110,7 @@ def test_evenement_performances_with_prelevement(client, django_assert_num_queri
 
     PrelevementFactory.create_batch(3, lieu__fiche_detection=fiche_detection)
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 12):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 13):
         client.get(evenement.get_absolute_url())
 
 


### PR DESCRIPTION
- Sélectionner la première fiche de détection par numéro et non par ID dans la vue détail événement
- MAJ des tests avec factories
  * Remplacement de baker par des factories dans quelques tests
  * Ajout d'une méthode create_miniaml pour créer une factory Lieu ou Prelevement avec uniquement les champs obligatoires
  * Ajout de la factory PosistionChaineDistribution