### PR TITLE
Autoriser l'enregistrement pour les anciennes valeurs

### DIFF
--- a/sv/views.py
+++ b/sv/views.py
@@ -400,7 +400,9 @@ class FicheDetectionUpdateView(
             lieu_formset.save()
             allowed_lieux = self.object.lieux.all()
             try:
-                self._save_prelevement_if_not_empty(request.POST.copy(), allowed_lieux)
+                self._save_prelevement_if_not_empty(
+                    request.POST.copy(), allowed_lieux, check_for_inactive_values=True, detection=self.object
+                )
             except ValidationError as e:
                 for message in e.messages:
                     messages.error(self.request, message)


### PR DESCRIPTION
Vérifier que la sauvegarde fonctionne bien pour les anciennes fiches contenant des valeurs inactives (labo, structures préleveuses). Le test ne faisait que vérifier que la page chargait bien et que l'option était dans la liste déroulante, mais lors de la sauvegarde l'utilisateur avait un message d'erreur car l'option choisie n'était pas dans la liste des options possibles.

Amélioration du message d'erreur pour affiche le nom du champ en erreur le cas échéant.