### PR TITLE
Masque le bouton clôturer lorsque l'évènement l'est déjà

### DIFF
--- a/sv/templates/sv/_evenement_action_navigation.html
+++ b/sv/templates/sv/_evenement_action_navigation.html
@@ -25,7 +25,7 @@
                     <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-edit-visibilite"><span class="fr-icon-eye-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Modifier la visibilité</a></li>
                 {% endif %}
                 <li><a class="fr-translate__language fr-nav__link" href="{{ evenement.get_update_url}}" ><span class="fr-icon-edit-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Modifier l'événement</a></li>
-                {%  if is_evenement_can_be_cloturer_by_user %}
+                {%  if is_evenement_can_be_cloturer_by_user and not is_cloture %}
                     <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-cloturer-evenement"><span class="fr-icon-close-circle-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Clôturer l'événement</a></li>
                 {% endif %}
                 <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-delete-evenement"><span class="fr-icon-close-circle-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Supprimer l'événement</a></li>

--- a/sv/tests/test_evenement_etats.py
+++ b/sv/tests/test_evenement_etats.py
@@ -93,10 +93,6 @@ def test_can_cloturer_evenement_if_creator_structure_in_fin_suivi(
     mocked_authentification_user.agent.structure = contact_ac.structure
 
     page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
-    page.get_by_test_id("element-actions").click()
-    page.get_by_role("link", name="Signaler la fin de suivi").click()
-    page.get_by_label("Message").fill("a")
-    page.get_by_test_id("fildesuivi-add-submit").click()
     page.get_by_role("button", name="Actions").click()
     page.get_by_role("link", name="Clôturer l'événement").click()
     page.get_by_role("button", name="Confirmer la clôture").click()

--- a/sv/view_mixins.py
+++ b/sv/view_mixins.py
@@ -104,4 +104,5 @@ class WithClotureContextMixin:
         context["is_evenement_can_be_cloturer"] = evenement.can_be_cloturer(
             self.request.user, contacts_not_in_fin_suivi
         )
+        context["is_cloture"] = evenement.is_cloture()
         return context


### PR DESCRIPTION
Cette PR permet de masquer le bouton clôturer lorsque l'évènement l'est déjà.
Suppression de la partie Fin de suivi dans le test `test_can_cloturer_evenement_if_creator_structure_in_fin_suivi` car non nécessaire.