### PR TITLE
Bloquer la sélection de détections déjà sélectionnées

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -74,3 +74,14 @@ def choice_js_cant_pick(db, page):
         expect(page.get_by_role("option", name=exact_name, exact=True)).not_to_be_visible()
 
     return _choice_js_cant_pick
+
+
+@pytest.fixture
+def choice_js_option_disabled(db, page):
+    def _choice_js_cant_pick(page, locator, exact_name):
+        page.query_selector(locator).click()
+        page.wait_for_selector("input:focus", state="visible", timeout=2_000)
+        element = page.locator(locator).locator("xpath=..").locator(".choices__item--choice")
+        expect(element.get_by_role("option", name=exact_name, exact=True))
+
+    return _choice_js_cant_pick

--- a/sv/tests/test_fichezonedelimitee_create.py
+++ b/sv/tests/test_fichezonedelimitee_create.py
@@ -189,6 +189,7 @@ def test_cant_have_same_detection_in_hors_zone_infestee_and_zone_infestee(live_s
     form_page = FicheZoneDelimiteeFormPage(page, choice_js_fill)
 
     form_page.goto_create_form_page(live_server, evenement)
+    page.evaluate("window.rebuildDetectionOptions = function() {};")  # Bypass front-end protection
     form_page.fill_form(fiche_zone_delimitee, zone_infestee, (fiche_detection,), (fiche_detection,))
     form_page.save()
 
@@ -209,6 +210,7 @@ def test_cant_have_same_detection_in_zone_infestee_forms(live_server, page: Page
     form_page = FicheZoneDelimiteeFormPage(page, choice_js_fill)
 
     form_page.goto_create_form_page(live_server, evenement)
+    page.evaluate("window.rebuildDetectionOptions = function() {};")  # Bypass front-end protection
     form_page.fill_form(fiche_zone_delimitee, zone_infestee1, (), (fiche_detection,))
     form_page.add_new_zone_infestee(zone_infestee2, (fiche_detection,))
     form_page.save()

--- a/sv/tests/test_fichezonedelimitee_update.py
+++ b/sv/tests/test_fichezonedelimitee_update.py
@@ -141,6 +141,10 @@ def test_update_form_cant_have_same_detection_in_hors_zone_infestee_and_zone_inf
 
     form_page = FicheZoneDelimiteeFormPage(page, choice_js_fill)
     page.goto(f"{live_server.url}{fiche_zone_delimitee.get_update_url()}")
+    page.wait_for_function("pickedDetections !== undefined")
+    page.evaluate("pickedDetections.push = function() {};")
+    page.evaluate("pickedDetections = [];")  # Bypass front-end protection
+    page.evaluate("window.rebuildChoicesOptions();")
     form_page.select_detections_in_zone_infestee(0, (fiche_detection,))
     form_page.save()
     expect(
@@ -159,6 +163,7 @@ def test_update_form_cant_have_same_detection_in_two_zone_infestee(live_server, 
     fiche_detection.save()
     form_page = FicheZoneDelimiteeFormPage(page, choice_js_fill)
     page.goto(f"{live_server.url}{fiche_zone_delimitee.get_update_url()}")
+    page.evaluate("window.rebuildDetectionOptions = function() {};")  # Bypass front-end protection
     form_page.add_new_zone_infestee(ZoneInfesteeFactory(), (fiche_detection,))
     form_page.save()
     expect(
@@ -336,3 +341,67 @@ def test_shows_correct_organisme_and_statut(live_server, page: Page):
 
     expect(page.get_by_text(str(evenement.organisme_nuisible))).to_be_visible()
     expect(page.get_by_text(str(evenement.statut_reglementaire))).to_be_visible()
+
+
+def test_update_form_cant_have_same_detection_in_hors_zone_infestee_and_zone_infestee_check_ui(
+    live_server,
+    page: Page,
+    choice_js_fill,
+    choice_js_option_disabled,
+):
+    fiche_detection = FicheDetectionFactory()
+    fiche_zone_delimitee = FicheZoneFactory()
+    evenement = fiche_detection.evenement
+    evenement.fiche_zone_delimitee = fiche_zone_delimitee
+    evenement.save()
+    ZoneInfesteeFactory(fiche_zone_delimitee=fiche_zone_delimitee)
+    fiche_detection.hors_zone_infestee = fiche_zone_delimitee
+    fiche_detection.save()
+
+    FicheZoneDelimiteeFormPage(page, choice_js_fill)
+    page.goto(f"{live_server.url}{fiche_zone_delimitee.get_update_url()}")
+    choice_js_option_disabled(
+        page,
+        "#zones-infestees .fr-col-4:nth-of-type(1) .choices__input--cloned:first-of-type",
+        str(fiche_detection.numero),
+    )
+
+
+def test_update_form_cant_have_same_detection_in_hors_zone_infestee_and_in_new_zone_infestee_check_ui(
+    live_server,
+    page: Page,
+    choice_js_fill,
+    choice_js_option_disabled,
+):
+    fiche_detection = FicheDetectionFactory()
+    fiche_zone_delimitee = FicheZoneFactory()
+    evenement = fiche_detection.evenement
+    evenement.fiche_zone_delimitee = fiche_zone_delimitee
+    evenement.save()
+    ZoneInfesteeFactory(fiche_zone_delimitee=fiche_zone_delimitee)
+    fiche_detection.hors_zone_infestee = fiche_zone_delimitee
+    fiche_detection.save()
+    other_detection = FicheDetectionFactory(evenement=evenement)
+
+    FicheZoneDelimiteeFormPage(page, choice_js_fill)
+    page.goto(f"{live_server.url}{fiche_zone_delimitee.get_update_url()}")
+
+    form_page = FicheZoneDelimiteeFormPage(page, choice_js_fill)
+    form_page.add_new_zone_infestee(ZoneInfesteeFactory.build(), ())
+    choice_js_option_disabled(
+        page,
+        "#zones-infestees .fr-col-4:nth-of-type(2) .choices__input--cloned:first-of-type",
+        str(fiche_detection.numero),
+    )
+
+    choice_js_fill(
+        page,
+        "#zones-infestees .fr-col-4:nth-of-type(2) .choices__input--cloned:first-of-type",
+        str(other_detection.numero),
+        str(other_detection.numero),
+    )
+    choice_js_option_disabled(
+        page,
+        ".fichezoneform__detections-hors-zone-infestee .choices__list--multiple",
+        str(other_detection.numero),
+    )


### PR DESCRIPTION
Dans l'interface d'édition de la zone bloquer dans l'interface les détections qui auraient déjà été sélectionnées dans un autre picker. Ainsi un utilisateur ne peut plus avoir l'erreur back disant qu'une détection donnée a été sélectionnée à la fois dans une ZI et en hors zone infestée, ou alors dans deux ZI différentes.

J'ai essayé plusieurs approches, les contraintes a prendre en compte étant:
- Que la recherche fonctionne toujours
- Gérer l'ajout et la supression de détection dans un picker
- Le nombre de picker est variable dans le temps (il est possible d'ajouter ou de supprimer des ZI)

Une autre approche était d'ajouter l'attribut disabled directement au niveau de l'élément HTML, mais cela me forçait a demander a choiceJS le rafraichissement des dropdowns. En utilisant setChoices, cette partie est directement gérée par la bibliothéque.