### PR TITLE
Corrige un test qui pouvait générer une incohérence

### DIFF
--- a/sv/tests/test_models.py
+++ b/sv/tests/test_models.py
@@ -123,7 +123,7 @@ def test_invalid_wgs84_latitude(fiche_detection):
 def test_numero_rapport_inspection_format_valide():
     rapport = Prelevement(
         lieu=LieuFactory(),
-        structure_preleveuse=StructurePreleveuseFactory(),
+        structure_preleveuse=StructurePreleveuseFactory(not_exploitant=True),
         is_officiel=True,
         resultat=Prelevement.Resultat.DETECTE,
         numero_rapport_inspection="24-123456",


### PR DESCRIPTION
Le test pouvait générer une structure préleveuse "Exploitant" sachant que le prélèvement est officiel (impossible d'après règle métier - cf. méthode clean du model Prelevement)