### PR TITLE
Améliorer l'affichage des labels pour les messages

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -150,17 +150,13 @@ class ContactSelectionForm(forms.Form):
 
 
 class MessageForm(DSFRForm, WithNextUrlMixin, WithContentTypeMixin, forms.ModelForm):
-    recipients = ContactModelMultipleChoiceField(
-        queryset=Contact.objects.none(), label_suffix="", label="Destinataires :"
-    )
+    recipients = ContactModelMultipleChoiceField(queryset=Contact.objects.none(), label="Destinataires*")
     recipients_structures_only = ContactModelMultipleChoiceField(
-        queryset=Contact.objects.none(), label_suffix="", label="Destinataires :"
+        queryset=Contact.objects.none(), label="Destinataires*"
     )
-    recipients_copy = ContactModelMultipleChoiceField(
-        queryset=Contact.objects.none(), required=False, label="Copie :", label_suffix=""
-    )
+    recipients_copy = ContactModelMultipleChoiceField(queryset=Contact.objects.none(), required=False, label="Copie")
     recipients_copy_structures_only = ContactModelMultipleChoiceField(
-        queryset=Contact.objects.none(), required=False, label="Copie :", label_suffix=""
+        queryset=Contact.objects.none(), required=False, label="Copie"
     )
     recipients_limited_recipients = forms.MultipleChoiceField(
         choices=[("mus", "MUS"), ("bsv", "BSV")],
@@ -214,13 +210,13 @@ class MessageForm(DSFRForm, WithNextUrlMixin, WithContentTypeMixin, forms.ModelF
     def _get_recipients_label(self, obj):
         structure_ids = ",".join([str(c.id) for c in self._get_structures(obj)])
         return mark_safe(
-            f"Destinataires :<a href='#' class='fr-link destinataires-shortcut' data-structures='{structure_ids}'>Ajouter toutes les structures de la fiche</a>"
+            f"Destinataires*<a href='#' class='fr-link destinataires-shortcut' data-structures='{structure_ids}'>Ajouter toutes les structures de la fiche</a>"
         )
 
     def _get_recipients_copy_label(self, obj):
         structure_ids = ",".join([str(c.id) for c in self._get_structures(obj)])
         return mark_safe(
-            f"Copie :<a href='#' class='fr-link copie-shortcut' data-structures='{structure_ids}'>Ajouter toutes les structures de la fiche</a>"
+            f"Copie <a href='#' class='fr-link copie-shortcut' data-structures='{structure_ids}'>Ajouter toutes les structures de la fiche</a>"
         )
 
     def __init__(self, *args, sender, **kwargs):

--- a/core/static/core/message.css
+++ b/core/static/core/message.css
@@ -6,7 +6,9 @@
     align-items: center;
     justify-content: space-between
 }
-
+label[for=id_recipients]::after, label[for=id_recipients_structures_only]::after{
+    content: none !important;
+}
 .btn-full{
     width: 100%;
     display: block;
@@ -30,7 +32,7 @@
     display: flex;
     justify-content: end;
 }
-label[for=id_recipients], label[for=id_recipients_copy]
+label[for=id_recipients], label[for=id_recipients_copy], label[for=id_recipients_structures_only], label[for=id_recipients_copy_structures_only]
 {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
- Corrige l'espacement du raccourci dans le cas des demandes d'intervention
- Replace l'astérisque au bon endroit en contournant la règle CSS et en l'ajoutant de la label
- Retirer les précisions sur les suffix label car déjà défini dans le DSFRForm