### PR TITLE
Corriger la suppresion de détection dans la zone

### DIFF
--- a/sv/static/sv/fichezone_form.js
+++ b/sv/static/sv/fichezone_form.js
@@ -33,7 +33,7 @@ function initializeChoices(elementId) {
     }
     let choices = new Choices(document.getElementById(elementId), options)
     choices.passedElement.element.addEventListener('change', event=> {
-        pickedDetections.push(event.detail.value)
+        initializepickedDetections()
         rebuildChoicesOptions()
     })
     allChoices.push(choices)
@@ -48,6 +48,7 @@ function initializeAllChoices() {
 }
 
 function initializepickedDetections() {
+    pickedDetections = []
     allChoices.forEach((detectionChoice) =>{
         detectionChoice.getValue().forEach((item) =>{
             pickedDetections.push(item.value)


### PR DESCRIPTION
Corrige les pickers en cas de suppression d'une détection d'un picker sur le formulaire de zone.
En cas de suppression la valeur était ajoutée au tableau alors qu'elle aurait du être retirée.

- On est obligé d'utiliser "change" (et non pas addItem et removeItem) car c'est la seule méthode qui filtre uniquement sur les événements de l'utilisateur (les autres méthodes provoquerait une boucle infinie).
- Dans cette méthode on ne peut pas faire la distinction dans l'événement entre un ajout et une suppression.

Nous sommes donc obligé de reconstruire la liste à chaque fois, heuresement la fonction existait déjà (utilisé pour la première initialisation de la page).