### PR TITLE
Ajouter un cron en cas de problème avec le broker

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -1,0 +1,12 @@
+{
+	"jobs": [
+	  {
+		"command": "*/10 * * * * python manage.py scan_documents",
+	    "size": "2XL"
+	  },
+	  {
+		"command": "*/10 * * * * python manage.py send_queued_mail",
+	    "size": "2XL"
+	  }
+	]
+  }


### PR DESCRIPTION
Si Redis venais a avoir un problème, les documents serait tout de même scanés et les mails envoyés.