### PR TITLE
Stocker et afficher les destinataires points de situation

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -221,6 +221,7 @@ class MessageForm(DSFRForm, WithNextUrlMixin, WithContentTypeMixin, forms.ModelF
 
     def __init__(self, *args, sender, **kwargs):
         obj = kwargs.pop("obj", None)
+        self.obj = obj
         self.sender = sender
         next_url = kwargs.pop("next", None)
         super().__init__(*args, **kwargs)
@@ -280,6 +281,8 @@ class MessageForm(DSFRForm, WithNextUrlMixin, WithContentTypeMixin, forms.ModelF
         if self.cleaned_data["message_type"] in Message.TYPES_WITH_STRUCTURES_ONLY:
             self.cleaned_data["recipients"] = self.cleaned_data["recipients_structures_only"]
             self.cleaned_data["recipients_copy"] = self.cleaned_data["recipients_copy_structures_only"]
+        if self.cleaned_data["message_type"] == Message.POINT_DE_SITUATION:
+            self.cleaned_data["recipients"] = self.obj.contacts.all()
         self.instance.sender = self.sender
 
 

--- a/core/notifications.py
+++ b/core/notifications.py
@@ -47,13 +47,11 @@ def notify_message(message_obj: Message):
         case Message.MESSAGE:
             recipients = [r.email for r in message_obj.recipients.all()]
             copy = [r.email for r in message_obj.recipients_copy.all()]
-        case Message.COMPTE_RENDU:
+        case Message.COMPTE_RENDU | Message.POINT_DE_SITUATION:
             recipients = [r.email for r in message_obj.recipients.all()]
         case Message.DEMANDE_INTERVENTION:
             recipients = [r.email for r in message_obj.recipients.structures_only()]
             copy = [r.email for r in message_obj.recipients_copy.structures_only()]
-        case Message.POINT_DE_SITUATION:
-            recipients = [c.email for c in message_obj.content_object.contacts.all()]
         case Message.FIN_SUIVI:
             recipients = message_obj.content_object.contacts.agents_only().filter(
                 agent__structure__niveau2=MUS_STRUCTURE

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -814,3 +814,32 @@ def test_can_add_message_with_document_confirmation_modal_confirm(live_server, p
     message = Message.objects.get()
     assert message.documents.count() == 1
     expect(page.get_by_role("link", name="README.md", exact=True)).to_be_visible()
+
+
+def test_can_add_and_see_point_de_situation(live_server, page: Page):
+    active_contact = ContactAgentFactory(with_active_agent=True)
+    evenement = EvenementFactory()
+    evenement.contacts.add(active_contact)
+
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    page.get_by_test_id("element-actions").click()
+    page.get_by_role("link", name="Point de situation").click()
+
+    expect(page.locator("#message-type-title")).to_have_text("point de situation")
+    page.locator("#id_title").fill("Title of the message")
+    page.locator("#id_content").fill("My content")
+    page.get_by_test_id("fildesuivi-add-submit").click()
+
+    page.wait_for_url(f"**{evenement.get_absolute_url()}#tabpanel-messages-panel")
+
+    cell_selector = f"#table-sm-row-key-1 td:nth-child({2}) a"
+    assert page.text_content(cell_selector) == "Structure Test"
+
+    cell_selector = f"#table-sm-row-key-1 td:nth-child({3}) a"
+    assert page.text_content(cell_selector).strip() == str(active_contact)
+
+    cell_selector = f"#table-sm-row-key-1 td:nth-child({4}) a"
+    assert page.text_content(cell_selector) == "Title of the message"
+
+    cell_selector = f"#table-sm-row-key-1 td:nth-child({6}) a"
+    assert page.text_content(cell_selector) == "Point de situation"

--- a/sv/tests/test_notifications.py
+++ b/sv/tests/test_notifications.py
@@ -89,11 +89,9 @@ def test_notification_point_de_situation(mailoutbox):
     evenement = EvenementFactory()
     agent_1, _agent_2 = ContactAgentFactory.create_batch(2)
     structure_1, _structure_2 = ContactStructureFactory.create_batch(2)
-    evenement.contacts.set([agent_1, structure_1])
 
     message = create_message_and_notify(
-        message_type=Message.POINT_DE_SITUATION,
-        object=evenement,
+        message_type=Message.POINT_DE_SITUATION, object=evenement, recipients=[agent_1, structure_1]
     )
 
     mail = assert_mail_common(mailoutbox, message, evenement)


### PR DESCRIPTION
Pour les points de situation les destinataires étaient ajouté à la voléee au moment de l'envoi du message. Cela empêche de savoir dans l'interface qui a reçu le message.
En déplaçant la logique de l'envoi de la notification au nettoyage des données dans le formulaire, les données sont correctement enregistrées en base et on retombe alors dans le cas "classique" (affichage dans le tableau et dans le détail du message).
Ajout d'un test spécifique au point de situation.