### PR TITLE
Destinataires en obligatoire pour CR sur DI

### DIFF
--- a/core/static/core/message_form.js
+++ b/core/static/core/message_form.js
@@ -93,7 +93,6 @@ function getMessageConfig(){
     return [configuration, allElements, allRequiredInputs]
 }
 
-
 function changeFormBasedOnMessageType(messageType){
     document.getElementById("id_message_type").value=messageType
     document.getElementById("message-type-title").innerText=messageType
@@ -111,6 +110,22 @@ function changeFormBasedOnMessageType(messageType){
     } else {
         document.getElementById("id_title").value = ""
     }
+}
+
+function validateLimitedRecipients() {
+    return Array.from(
+        document.querySelectorAll("input[name='recipients_limited_recipients']")
+    ).some(checkbox => checkbox.checked);
+}
+
+function updateLimitedRecipientsValidation() {
+    const messageType = document.getElementById("id_message_type").value;
+    if (messageType !== "compte rendu sur demande d'intervention") {
+        return;
+    }
+    const firstCheckbox = document.querySelector("input[name='recipients_limited_recipients']");
+    const errorMessage = validateLimitedRecipients() ? "" : "Veuillez sélectionner au moins un destinataire";
+    firstCheckbox.setCustomValidity(errorMessage);
 }
 
 function initializeChoices(element){
@@ -173,6 +188,8 @@ document.addEventListener('DOMContentLoaded', function () {
     document.getElementById("message-send-btn").addEventListener("click", event =>{
         event.preventDefault()
         const messageForm = document.getElementById("message-form")
+
+        updateLimitedRecipientsValidation();
         messageForm.reportValidity()
 
         if (!messageForm.checkValidity()) {

--- a/sv/templates/sv/_sidebar_message_form.html
+++ b/sv/templates/sv/_sidebar_message_form.html
@@ -9,7 +9,7 @@
             Ce point de situation sera envoyé à tous les agents et les structures en contact de cet évènement
         </div>
         <div class=" fr-fieldset__element fr-hidden">
-            <label>Destinataires</label>
+            <label class="required-field">{{ message_form.recipients_limited_recipients.label_tag }}</label>
             {{ message_form.recipients_limited_recipients }}
         </div>
         <div class=" fr-fieldset__element fr-hidden">


### PR DESCRIPTION
Permet de rendre obligatoire la sélection d'au moins une case à cocher dans les destinataire pour un élément de suivi de type "CR sur DI".