### PR TITLE
Validation champs obligatoires côté front pour ajout elements de suivi

### DIFF
--- a/core/static/core/message_form.js
+++ b/core/static/core/message_form.js
@@ -172,6 +172,13 @@ document.addEventListener('DOMContentLoaded', function () {
 
     document.getElementById("message-send-btn").addEventListener("click", event =>{
         event.preventDefault()
+
+        const form = event.target.closest("form");
+        if (!form.checkValidity()){
+            form.reportValidity()
+            return;
+        }
+
         event.target.disabled = true
         const isDocumentBlockVisible = !document.querySelector(".document-form").classList.contains("fr-hidden")
         const hasFile = !!document.getElementById('id_file').files[0]


### PR DESCRIPTION
Cette PR permet de restituer la validation côté front pour le formulaire d'ajout d'un élément de suivi.