### PR TITLE
Améliorer la gestion des erreurs pour Redis

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -11,6 +11,10 @@ from .filters import DocumentFilter
 from core.models import Document, LienLibre, Contact, Message, Visibilite, Structure
 from .notifications import notify_message
 from .redirect import safe_redirect
+from celery.exceptions import OperationalError
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class WithDocumentUploadFormMixin:
@@ -166,6 +170,9 @@ class AllowACNotificationMixin(models.Model):
                 self._add_bsv_and_mus_to_contacts()
         except ValidationError as e:
             raise ValidationError(f"Une erreur s'est produite lors de la notification : {e.message}")
+        except OperationalError:
+            logger.error("Could not connect to Redis")
+            raise ValidationError("Une erreur s'est produite lors de l'envoi du message de notification.")
 
     class Meta:
         abstract = True

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -255,3 +255,19 @@ if not CELERY_TASK_ALWAYS_EAGER:
 
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SECURE = True
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+        },
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["console"],
+            "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
+        },
+    },
+}


### PR DESCRIPTION
Dans le cas où Redis ne serait pas joignable on améliore la gestion des erreurs.
Au lieu d'afficher une erreur 500, on affiche un message d'erreur et on loggue l'erreur dans Sentry pour être capable de détecter le problème.