### PR TITLE
Corriger un bug de remplissage des communes

### DIFF
--- a/sv/static/sv/fichedetection_lieux_form.js
+++ b/sv/static/sv/fichedetection_lieux_form.js
@@ -151,6 +151,12 @@ function setUpCommune(element) {
         inseeInput.value = event.detail.customProperties.inseeCode
         departementInput.value = event.detail.customProperties.departementCode
     })
+
+    choicesCommunes.passedElement.element.addEventListener('removeItem', function (event) {
+        communeInput.value = ""
+        inseeInput.value = ""
+        departementInput.value = ""
+    })
 }
 
 


### PR DESCRIPTION
Lorsqu'on efface la commune via ChoiceJS les champs masqués associés à la commune n'étaient pas effacés.