### PR TITLE
Ajouter une page d'erreur explicite si compte inactif

### DIFF
--- a/core/auth_views.py
+++ b/core/auth_views.py
@@ -1,5 +1,11 @@
+from django.contrib.auth import get_user_model
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
 from django.views.generic import TemplateView
 from django.conf import settings
+from mozilla_django_oidc.views import OIDCAuthenticationCallbackView
+
+User = get_user_model()
 
 
 class LoginView(TemplateView):
@@ -8,3 +14,15 @@ class LoginView(TemplateView):
 
 def logout(request):
     return settings.OIDC_RP_LOGOUT_ENDPOINT
+
+
+class CustomOIDCAuthenticationCallbackView(OIDCAuthenticationCallbackView):
+    def login_failure(self):
+        if self.user and not self.user.is_active:
+            if hasattr(self.user, "agent") and hasattr(self.user.agent, "structure"):
+                users_in_structure = User.objects.filter(agent__structure=self.user.agent.structure, is_active=True)
+                users_in_structure = users_in_structure.select_related("agent__structure")
+                group_name = settings.CAN_GIVE_ACCESS_GROUP
+                admin_users = [u for u in users_in_structure if group_name in u.groups.values_list("name", flat=True)]
+                return render(self.request, "login_denied.html", {"admin_users": admin_users})
+        return HttpResponseRedirect(self.failure_url)

--- a/core/templates/login_denied.html
+++ b/core/templates/login_denied.html
@@ -1,0 +1,43 @@
+{% extends "core/base.html" %}
+{% load static %}
+{% block product %}
+{% endblock product %}
+
+{% block extrahead %}
+    <link rel="stylesheet" href="{% static 'core/errors.css' %}">
+{% endblock %}
+
+{% block content %}
+    <main class="main-container">
+        <div class="fr-container">
+            <div class="fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center">
+                <div class="fr-py-0 fr-col-12 fr-col-md-6">
+                    <h1>Votre compte n'est pas activé</h1>
+                    <p class="fr-text--lead fr-mb-3w">
+                        {% if admin_users %}
+                            Pour accéder à Sèves, votre compte doit être activé par un de vos référents droits d’accès:
+                            <ul>
+                                {% for user in admin_users %}
+                                    <li>{{ user.agent.agent_with_structure }}</li>
+                                {% endfor %}
+                            </ul>
+                        {% else %}
+                            Pour accéder à Sèves, merci d’en faire la demande à notre équipe support : <a href="mailto:support@seves.beta.gouv.fr">support@seves.beta.gouv.fr</a>
+                        {% endif %}
+                    </p>
+                </div>
+                <div class="fr-col-12 fr-col-md-3 fr-col-offset-md-1 fr-px-6w fr-px-md-0 fr-py-0">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="fr-responsive-img fr-artwork" aria-hidden="true" width="160" height="200" viewBox="0 0 160 200">
+                        <use class="fr-artwork-motif" href="{% static 'images/ovoid.svg' %}#artwork-motif"></use>
+                        <use class="fr-artwork-background" href="{% static 'images/ovoid.svg' %}#artwork-background"></use>
+                        <g transform="translate(40, 60)">
+                            <use class="fr-artwork-decorative" href="{% static 'images/technical-error.svg' %}#artwork-decorative"></use>
+                            <use class="fr-artwork-minor" href="{% static 'images/technical-error.svg' %}#artwork-minor"></use>
+                            <use class="fr-artwork-major" href="{% static 'images/technical-error.svg' %}#artwork-major"></use>
+                        </g>
+                    </svg>
+                </div>
+            </div>
+        </div>
+    </main>
+{% endblock %}

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -215,6 +215,8 @@ OIDC_OP_JWKS_ENDPOINT = env("OIDC_RP_JWKS_ENDPOINT")
 OIDC_RP_LOGOUT_ENDPOINT = env("OIDC_RP_LOGOUT_ENDPOINT")
 OIDC_AUTHENTICATION_CALLBACK_URL = "custom_oidc_authentication_callback"
 OIDC_OP_LOGOUT_URL_METHOD = "core.auth_views.logout"
+OIDC_CALLBACK_CLASS = "core.auth_views.CustomOIDCAuthenticationCallbackView"
+OIDC_CREATE_USER = False
 LOGIN_REDIRECT_URL = "/"
 OIDC_RP_SIGN_ALGO = "RS256"
 
@@ -271,3 +273,5 @@ LOGGING = {
         },
     },
 }
+
+CAN_GIVE_ACCESS_GROUP = "access_admin"


### PR DESCRIPTION
En cas de compte existant mais inactif (is_active = False dans le modèle User de Django) personaliser le message d'erreur pour afficher les noms des gens qui peuvent débloquer la situation.

Changement d'un paramètre pour éviter des users aux utilisateurs non-existants dans notre import.