### PR TITLE
Corriger un bug sur les picker de commune

### DIFF
--- a/sv/static/sv/fichedetection_lieux_form.js
+++ b/sv/static/sv/fichedetection_lieux_form.js
@@ -71,7 +71,7 @@ function showLieuModal(event){
     modalHTMLContent[currentModal.dataset.id] = currentModal.querySelector(".fr-modal__content").innerHTML
     dsfr(currentModal).modal.disclose()
     dataRequiredToRequired(currentModal)
-
+    setUpCommune(currentModal.querySelector("[id^=commune-select-]"))
 }
 
 function buildLieuCardFromModal(element){
@@ -201,7 +201,12 @@ function setupCharacterCounter(element) {
 
     document.querySelector("#add-lieu-bouton").addEventListener("click", showLieuModal)
     document.querySelectorAll(".lieu-save-btn").forEach(button => button.addEventListener("click", saveLieu))
-    document.querySelectorAll("[id^=commune-select-]").forEach(setUpCommune)
+    document.querySelectorAll("[id^=commune-select-]").forEach(communeSelect =>{
+        const communeField = communeSelect.parentNode.parentNode.querySelector('[id$="-commune"]')
+        if (!!communeField.value){
+            setUpCommune(communeSelect)
+        }
+    })
     document.getElementById("delete-lieu-confirm-btn").addEventListener("click", deleteLieu)
     document.querySelectorAll("[id^=modal-add-lieu-]").forEach(modal => modal.addEventListener('dsfr.disclose', saveModalWhenOpening))
     document.querySelectorAll("[id^=modal-add-lieu-] .fr-btn--close").forEach(element => element.addEventListener("click", closeDSFRModal))


### PR DESCRIPTION
- Déclencher la création du composant ChoicesJS au dernier moment permet de corriger le problème qui arrivait dans un scénario ouverture du modale, fermeture sans compléter, ouverture de la même modale. Le composant n'était alors plus intéractif (probablement car on manipule le DOM en même temps).

Cette solution permet aussi d'éxecuter du JS supplémentaire uniquement quand on en a besoin.