### PR TITLE
Améliorer la fiabilité d'un test

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -45,7 +45,10 @@ def mocked_authentification_user(db):
 @pytest.fixture
 def choice_js_fill(db, page):
     def _choice_js_fill(page, locator, fill_content, exact_name, use_locator_as_parent_element=False):
-        page.query_selector(locator).click()
+        if use_locator_as_parent_element:
+            page.locator(locator).locator("input.choices__input").click()
+        else:
+            page.query_selector(locator).click()
         page.wait_for_selector("input:focus", state="visible", timeout=2_000)
         page.locator("*:focus").fill(fill_content)
         if use_locator_as_parent_element:

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -191,7 +191,6 @@ def test_can_add_and_see_message_with_multiple_recipients_and_copies(live_server
         agents[0].contact_set.get().display_with_agent_unit,
         use_locator_as_parent_element=True,
     )
-    page.keyboard.press("Escape")
     choice_js_fill(
         page,
         'label[for="id_recipients"] ~ div.choices',
@@ -199,8 +198,9 @@ def test_can_add_and_see_message_with_multiple_recipients_and_copies(live_server
         agents[1].contact_set.get().display_with_agent_unit,
         use_locator_as_parent_element=True,
     )
-    page.keyboard.press("Escape")
 
+    page.locator("#message-type-title").click()
+    page.wait_for_timeout(500)
     # Add multiples recipients as copy
     choice_js_fill(
         page,
@@ -209,7 +209,6 @@ def test_can_add_and_see_message_with_multiple_recipients_and_copies(live_server
         agents[2].contact_set.get().display_with_agent_unit,
         use_locator_as_parent_element=True,
     )
-    page.keyboard.press("Escape")
     choice_js_fill(
         page,
         'label[for="id_recipients_copy"] ~ div.choices',


### PR DESCRIPTION
- Change la méthode pour sortir du picker quand on a fini de sélectionner les agents (clic ailleurs à la place de la touche Echap)
- Rend plus précis l'endroit où le clic est fait