### PR TITLE
Ajout d'un bandeau sur la recette et en local

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,3 +1,6 @@
+# ENVIRONMENT (dev, recette, prod)
+ENVIRONMENT=
+
 # SECURITY WARNING: don't run with the debug turned on in production!
 DEBUG=True
 

--- a/core/static/core/base.css
+++ b/core/static/core/base.css
@@ -128,3 +128,27 @@ label:has(+ .choices select[data-required="true"])::after,
     border-radius: .25rem;
     color: white;
 }
+
+.environment-banner::before {
+    position: fixed;
+    top: 20px;
+    left: -55px;
+    width: 175px;
+    color: white;
+    text-align: center;
+    padding: 5px 0;
+    font-weight: bold;
+    font-size: 14px;
+    z-index: 9999;
+    transform: rotate(-45deg);
+    transform-origin: center;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.3);
+}
+.environment-recette::before {
+    content: "RECETTE";
+    background-color: red;
+}
+.environment-dev::before {
+    content: "DEV";
+    background-color: green;
+}

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -28,7 +28,7 @@
         {% block extrahead %}{% endblock %}
     </head>
 
-    <body>
+    <body class="{{ environment_class }}">
         {% block aside %}
         {% endblock aside %}
         <header role="banner" class="fr-header">

--- a/seves/context_processors.py
+++ b/seves/context_processors.py
@@ -3,3 +3,13 @@ from django.conf import settings
 
 def select_empty_choice(request):
     return {"select_empty_choice": settings.SELECT_EMPTY_CHOICE}
+
+
+def environment_class(request):
+    match settings.ENVIRONMENT:
+        case "recette":
+            return {"environment_class": "environment-banner environment-recette"}
+        case "dev":
+            return {"environment_class": "environment-banner environment-dev"}
+        case _:
+            return {"environment_class": ""}

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -99,6 +99,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "seves.context_processors.select_empty_choice",
+                "seves.context_processors.environment_class",
             ],
         },
     },
@@ -288,9 +289,10 @@ CSP_CONNECT_SRC = (
     "geo.api.gouv.fr",
     "api.insee.fr",
 )
-SENTRY_ENV = env("SENTRY_ENVIRONMENT", default="demo")
+
+ENVIRONMENT = env("ENVIRONMENT", default=None)
 SENTRY_REPORT_URL = env("SENTRY_REPORT_URL")
-CSP_REPORT_URI = f"{SENTRY_REPORT_URL}&sentry_environment={SENTRY_ENV}"
+CSP_REPORT_URI = f"{SENTRY_REPORT_URL}&sentry_environment={ENVIRONMENT}"
 
 SIRENE_CONSUMER_KEY = env("SIRENE_CONSUMER_KEY", default="")
 SIRENE_CONSUMER_SECRET = env("SIRENE_CONSUMER_SECRET", default="")


### PR DESCRIPTION
Cette PR permet d'ajouter un bandeau "Recette" fixe sur l'environnement de recette.
![image](https://github.com/user-attachments/assets/c8581d85-cca6-4261-9f1c-509ce2dfb525)
Dans les settings, j'ai ajouté la variable d'environnement `ENVIRONMENT` pour distinguer les différents environnements (dev, recette, prod).
Pour l'instant elle est utilisée uniquement pour la recette (cf. fonction `environment_class()` dans `seves/context_processors.py`.
Sur Scalingo, la variable `ENVIRONMENT` a été ajouté dans l'app de la recette.