### PR TITLE
Modification du tri dans la liste des contacts

### DIFF
--- a/core/managers.py
+++ b/core/managers.py
@@ -1,7 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Case, When, Value, IntegerField, QuerySet, Q, Manager
 
-from core.constants import MUS_STRUCTURE, BSV_STRUCTURE, AC_STRUCTURE, SERVICE_ACCOUNT_NAME
+from core.constants import MUS_STRUCTURE, BSV_STRUCTURE, SERVICE_ACCOUNT_NAME
 
 
 class DocumentManager(Manager):
@@ -55,20 +55,8 @@ class ContactQueryset(QuerySet):
     def can_be_emailed(self):
         return self.exclude_empty_emails().with_active_agent() | self.exclude_empty_emails().structures_only()
 
-    def services_deconcentres_first(self):
-        return self.annotate(
-            services_deconcentres_first=Case(
-                When(structure__niveau1__exact=AC_STRUCTURE, then=2),
-                default=1,
-                output_field=IntegerField(),
-            )
-        )
-
     def order_by_structure_and_name(self):
-        return self.order_by("services_deconcentres_first", "agent__structure__niveau2", "agent__nom")
-
-    def order_by_structure_and_niveau2(self):
-        return self.order_by("services_deconcentres_first", "structure__niveau2")
+        return self.order_by("agent__structure__libelle", "agent__nom", "agent__prenom")
 
 
 class LienLibreQueryset(QuerySet):

--- a/core/mixins.py
+++ b/core/mixins.py
@@ -78,10 +78,7 @@ class WithContactListInContextMixin:
                 "contact": contact,
                 "is_in_fin_suivi": contact.agent.structure_id in structures_fin_suivi_ids,
             }
-            for contact in obj.contacts.agents_only()
-            .prefetch_related("agent__structure")
-            .services_deconcentres_first()
-            .order_by_structure_and_name()
+            for contact in obj.contacts.agents_only().prefetch_related("agent__structure").order_by_structure_and_name()
         ]
 
         context["contacts_structures"] = [
@@ -89,10 +86,7 @@ class WithContactListInContextMixin:
                 "contact": contact,
                 "is_in_fin_suivi": contact.structure_id in structures_fin_suivi_ids,
             }
-            for contact in obj.contacts.structures_only()
-            .services_deconcentres_first()
-            .order_by_structure_and_niveau2()
-            .select_related("structure")
+            for contact in obj.contacts.structures_only().order_by("structure__libelle").select_related("structure")
         ]
 
         context["content_type"] = ContentType.objects.get_for_model(obj)


### PR DESCRIPTION
Cette PR permet de modifier le tri dans la liste des contacts (sur le détail d'un évènement) :
- pour les structures → triée par libellé
- pour les agents → triée par : 
  1. libellé des structures
  2. nom de l’agent
  3. prénom de l’agent