### PR TITLE
Afficher les cartographies en gallerie d'images

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -187,6 +187,10 @@ class Document(models.Model):
     def __str__(self):
         return f"{self.nom} ({self.document_type})"
 
+    @property
+    def is_cartographie(self):
+        return self.document_type == Document.TypeDocument.CARTOGRAPHIE
+
 
 class Message(models.Model):
     MESSAGE = "message"

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -283,6 +283,8 @@ CSP_SCRIPT_SRC = ("'self'", "cdn.jsdelivr.net")
 CSP_STYLE_SRC = ("'self'", "cdn.jsdelivr.net")
 CSP_FONT_SRC = ("'self'", "cdn.jsdelivr.net")
 CSP_IMG_SRC = ("'self'", "data:")
+if DEBUG:
+    CSP_IMG_SRC = ("'self'", "data:", "127.0.0.1:9000")
 CSP_CONNECT_SRC = ("'self'", "geo.api.gouv.fr")
 SENTRY_ENV = env("SENTRY_ENVIRONMENT", default="demo")
 SENTRY_REPORT_URL = env("SENTRY_REPORT_URL")

--- a/sv/static/sv/evenement_details.js
+++ b/sv/static/sv/evenement_details.js
@@ -35,6 +35,20 @@ function updateURLParameters(paramName, paramValue) {
     window.history.pushState({}, '', `?${params.toString()}`);
 }
 
+function showImage(element, direction){
+    const currentModal = element.closest("dialog")
+    dsfr(currentModal).modal.conceal()
+    const modalBtn = document.querySelector(`[aria-controls="${currentModal.getAttribute('id')}"]`)
+
+    let button = null
+    if (direction === "left"){
+        button = document.querySelector(`[data-thumbnail="${parseInt(modalBtn.dataset.thumbnail) - 1}"]`)
+    } else {
+        button = document.querySelector(`[data-thumbnail="${parseInt(modalBtn.dataset.thumbnail) + 1}"]`)
+    }
+    button.click()
+}
+
 document.addEventListener('DOMContentLoaded', function() {
     setTimeout(() => {
         selectZoneTab();
@@ -55,4 +69,15 @@ document.addEventListener('DOMContentLoaded', function() {
     showOnlyActionsForDetection(selectedTagDocument.getAttribute("id").replace("tabpanel-", ""))
 
     initializeDetectionTags();
+
+    document.querySelectorAll(".next-modal").forEach(element =>{
+        element.addEventListener("click", event =>{
+            showImage(element, "right")
+        })
+    })
+    document.querySelectorAll(".previous-modal").forEach(element =>{
+        element.addEventListener("click", event =>{
+            showImage(element, "left")
+        })
+    })
 });

--- a/sv/static/sv/fichezonedelimitee_detail.css
+++ b/sv/static/sv/fichezonedelimitee_detail.css
@@ -15,3 +15,19 @@
         height: 100%;
     }
 }
+
+.img-cartographie {
+    width: 95%;
+}
+.img-cartographie img{
+    max-width: 95%;
+}
+
+.img-cartographie--container {
+    display: flex;
+}
+
+
+.cartographies .fr-modal--opened, .cartographies .fr-modal {
+    transition: none !important;
+}

--- a/sv/templates/sv/_fichezonedelimitee_cartographies.html
+++ b/sv/templates/sv/_fichezonedelimitee_cartographies.html
@@ -1,0 +1,43 @@
+<div class="white-container fr-mt-4w cartographies">
+    <p class="fr-h6">Cartographies</p>
+    <div>
+        <div class="fr-container--fluid">
+            <div class="fr-grid-row fr-grid-row--gutters">
+                {% for document in document_filter.qs %}
+                    {% if document.is_cartographie and document.is_infected is False %}
+                        <div class="fr-col-12 fr-col-md-2">
+                            <img src="{{ document.file.url }}" loading="lazy"  class="fr-responsive-img img-thumbnail" data-thumbnail="{{ forloop.counter0 }}" data-fr-opened="false" aria-controls="fr-document-image-{{ document.pk }}">
+                            <dialog aria-labelledby="fr-modal-title-modal-document-{{ document.pk }}" role="dialog" id="fr-document-image-{{ document.pk }}" class="fr-modal" data-fr-concealing-backdrop="true">
+                                <div class="fr-container fr-container--fluid fr-container-md">
+                                    <div class="fr-grid-row fr-grid-row--center">
+                                        <div class="fr-col-12 fr-col-md-12 fr-col-lg-12">
+                                            <div class="fr-modal__body">
+                                                <div class="fr-modal__header">
+                                                    <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-document-image-{{ document.pk }}">Fermer</button>
+                                                </div>
+                                                <div class="fr-modal__content">
+                                                    <div class="img-cartographie--container">
+                                                        {% if not forloop.first %}
+                                                            <span class="fr-icon-arrow-left-line fr-icon--lg fr-my-auto previous-modal"></span>
+                                                        {% endif %}
+                                                        <div class="img-cartographie">
+                                                            <img src="{{ document.file.url }}" loading="lazy"  >
+                                                        </div>
+                                                        {% if not forloop.last %}
+                                                            <span class="fr-icon-arrow-right-line fr-icon--lg fr-my-auto next-modal"></span>
+                                                        {% endif %}
+                                                    </div>
+                                                    <span class="fr-hint-text fr-mt-4v">Ajouté le {{ document.date_creation }} par {{ document.created_by_structure }}</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </dialog>
+                        </div>
+                    {% endif %}
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+</div>

--- a/sv/templates/sv/fichezonedelimitee_detail.html
+++ b/sv/templates/sv/fichezonedelimitee_detail.html
@@ -46,3 +46,4 @@
 
 {% include "sv/_fichezonedelimitee_detail_zones_infestees.html" %}
 {% include "sv/_fichezonedelimitee_detail_zone_tampon.html" %}
+{% include "sv/_fichezonedelimitee_cartographies.html" %}


### PR DESCRIPTION
Pour les documents de type cartographie les afficher sous forme de galerie d'images pour pouvoir les consulter plus rapidement.