### PR TITLE
Corriger la sauvegarde du site d'inspection sur le lieu

### DIFF
--- a/sv/models/lieux.py
+++ b/sv/models/lieux.py
@@ -148,9 +148,8 @@ class Lieu(models.Model):
         "raison_sociale_etablissement",
         "adresse_etablissement",
         "siret_etablissement",
-        "site_inspection",
-        "position_chaine_distribution_etablissement",
         "code_inupp_etablissement",
+        "position_chaine_distribution_etablissement",
     ]
 
     def __str__(self):


### PR DESCRIPTION
Dans la mesure où le site d'inspection était dans la liste `ETABLISSEMENT_FIELDS` le champ était vidé si la case d'établissement n'était pas cochée.