### PR TITLE
Affichage msg erreur côté front pour champs required gérés via Choicesjs

### DIFF
--- a/core/static/core/base.css
+++ b/core/static/core/base.css
@@ -121,6 +121,19 @@ label:has(+ .choices select[data-required="true"])::after,
     content: "*";
 }
 
+/* -- Champs obligatoires (choices-js) -- */
+.choices__input[hidden][required] {
+    display: block !important;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    pointer-events: none;
+    top: 0;
+    left: 0;
+}
+
+
 .ac-notified {
     background-color: #faa18d;
     min-height: 1.5rem;

--- a/core/static/core/message.css
+++ b/core/static/core/message.css
@@ -37,14 +37,3 @@ label[for=id_recipients], label[for=id_recipients_copy], label[for=id_recipients
     display: flex;
     justify-content: space-between;
 }
-
-#message-form .choices [hidden]{
-    display: block !important;
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    opacity: 0;
-    pointer-events: none;
-    top: 0;
-    left: 0;
-}

--- a/sv/tests/test_evenement_contact_add.py
+++ b/sv/tests/test_evenement_contact_add.py
@@ -1,6 +1,6 @@
 import pytest
 from django.contrib.contenttypes.models import ContentType
-from playwright.sync_api import expect
+from playwright.sync_api import expect, Page
 from django.urls import reverse
 
 from core.constants import MUS_STRUCTURE
@@ -213,3 +213,15 @@ def test_cant_forge_add_contact_agent_on_evenement_i_cant_see(client, mocked_aut
     assert response.status_code == 403
     evenement.refresh_from_db()
     assert evenement.contacts.count() == 0
+
+
+@pytest.mark.django_db
+def test_add_contact_agent_without_value_shows_front_error(live_server, page: Page):
+    evenement = EvenementFactory()
+
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    page.get_by_role("tab", name="Contacts").click()
+    page.locator("#add-contact-agent-form").get_by_role("button", name="Ajouter").click()
+
+    validation_message = page.locator("#id_contacts_agents").evaluate("el => el.validationMessage")
+    assert validation_message in ["Please select an item in the list.", "Sélectionnez un élément dans la liste."]

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -701,3 +701,17 @@ def test_create_fiche_detection_with_lieu_using_siret(
     assert lieu_from_db.siret_etablissement == "12007901700030"
     assert lieu_from_db.pays_etablissement == "France"
     assert lieu_from_db.adresse_etablissement == "175 RUE DU CHEVALERET - 75013 PARIS"
+
+
+def test_fiche_detection_without_organisme_nuisible_shows_error(
+    live_server,
+    page: Page,
+):
+    statut_reglementaire = StatutReglementaire.objects.first()
+
+    page.goto(f"{live_server.url}{reverse('fiche-detection-creation')}")
+    page.get_by_label("Statut réglementaire").select_option(value=str(statut_reglementaire.id))
+    page.get_by_role("button", name="Enregistrer").click()
+
+    validation_message = page.locator("#id_organisme_nuisible").evaluate("el => el.validationMessage")
+    assert validation_message in ["Please select an item in the list.", "Sélectionnez un élément dans la liste."]


### PR DESCRIPTION
Cette PR permet d'afficher un message d'erreur côté front pour tous les champs select required gérés via Choicesjs.