### PR TITLE
Changer l'ordre d'affichage des champs du lieu

### DIFF
--- a/sv/templates/sv/fichedetection_detail_lieu.html
+++ b/sv/templates/sv/fichedetection_detail_lieu.html
@@ -63,23 +63,8 @@
                             </div>
                             <div class="fr-grid-row fr-mb-2w">
                                 <div class="fr-col-offset-2"></div>
-                                <div class="fr-col-4 descripteur-label">Description de l’activité</div>
-                                <div class="fr-col-6" data-testid="lieu-{{lieu_index}}-activite-etablissement">{{lieu.activite_etablissement|default:"nc."}}</div>
-                            </div>
-                            <div class="fr-grid-row fr-mb-2w">
-                                <div class="fr-col-offset-2"></div>
-                                <div class="fr-col-4 descripteur-label">Pays</div>
-                                <div class="fr-col-6" data-testid="lieu-{{lieu_index}}-pays-etablissement">{{lieu.pays_etablissement|default:"nc."}}</div>
-                            </div>
-                            <div class="fr-grid-row fr-mb-2w">
-                                <div class="fr-col-offset-2"></div>
                                 <div class="fr-col-4 descripteur-label">Raison sociale</div>
                                 <div class="fr-col-6" data-testid="lieu-{{lieu_index}}-raison-sociale-etablissement">{{lieu.raison_sociale_etablissement|default:"nc."}}</div>
-                            </div>
-                            <div class="fr-grid-row fr-mb-2w">
-                                <div class="fr-col-offset-2"></div>
-                                <div class="fr-col-4 descripteur-label">Adresse</div>
-                                <div class="fr-col-6" data-testid="lieu-{{lieu_index}}-adresse-etablissement">{{lieu.adresse_etablissement|default:"nc."}}</div>
                             </div>
                             <div class="fr-grid-row fr-mb-2w">
                                 <div class="fr-col-offset-2"></div>
@@ -88,8 +73,23 @@
                             </div>
                             <div class="fr-grid-row fr-mb-2w">
                                 <div class="fr-col-offset-2"></div>
+                                <div class="fr-col-4 descripteur-label">Adresse</div>
+                                <div class="fr-col-6" data-testid="lieu-{{lieu_index}}-adresse-etablissement">{{lieu.adresse_etablissement|default:"nc."}}</div>
+                            </div>
+                            <div class="fr-grid-row fr-mb-2w">
+                                <div class="fr-col-offset-2"></div>
+                                <div class="fr-col-4 descripteur-label">Pays</div>
+                                <div class="fr-col-6" data-testid="lieu-{{lieu_index}}-pays-etablissement">{{lieu.pays_etablissement|default:"nc."}}</div>
+                            </div>
+                            <div class="fr-grid-row fr-mb-2w">
+                                <div class="fr-col-offset-2"></div>
                                 <div class="fr-col-4 descripteur-label">Code INUPP</div>
                                 <div class="fr-col-6" data-testid="lieu-{{lieu_index}}-code-inupp-etablissement">{{lieu.code_inupp_etablissement|default:"nc."}}</div>
+                            </div>
+                            <div class="fr-grid-row fr-mb-2w">
+                                <div class="fr-col-offset-2"></div>
+                                <div class="fr-col-4 descripteur-label">Description de l’activité</div>
+                                <div class="fr-col-6" data-testid="lieu-{{lieu_index}}-activite-etablissement">{{lieu.activite_etablissement|default:"nc."}}</div>
                             </div>
                             <div class="fr-grid-row fr-mb-2w">
                                 <div class="fr-col-offset-2"></div>


### PR DESCRIPTION
Dans la modale de détails du lieu changer l'ordre des informations pour correspondre à l'ordre du formulaire.