### PR TITLE
Contraindre les extensions selon le type de document (Cartographie)

### DIFF
--- a/core/static/core/document.js
+++ b/core/static/core/document.js
@@ -26,3 +26,79 @@ export function validateFileSize(fileInput) {
     fileInput.setCustomValidity('');
     return true;
 }
+
+export function getAcceptAllowedExtensionsAttributeValue(fileInput, documentTypeSelect) {
+    const attributeName = "data-accept-allowed-extensions";
+    const acceptAllowedExtensionsAttributeJson = fileInput.getAttribute(attributeName);
+
+    if (acceptAllowedExtensionsAttributeJson === null) {
+        console.error(`Erreur de configuration: l'attribut '${attributeName}' est manquant`);
+        fileInput.setCustomValidity("Erreur de configuration: extensions autorisées non définies");
+        fileInput.reportValidity();
+        return null;
+    }
+
+    let allowedExtensions;
+    try {
+        allowedExtensions = JSON.parse(acceptAllowedExtensionsAttributeJson);
+    } catch (error) {
+        console.error(`Erreur de configuration: l'attribut '${attributeName}' contient un JSON invalide`, error);
+        fileInput.setCustomValidity("Erreur de configuration: format des extensions autorisées invalide");
+        fileInput.reportValidity();
+        return null;
+    }
+
+    const currentDocumentType = documentTypeSelect.value;
+    const documentTypeAllowedExtensions = allowedExtensions[currentDocumentType];
+    if (!documentTypeAllowedExtensions) {
+        console.error(`Erreur de configuration: aucune extension définie dans l'attribut '${attributeName}' pour le type '${currentDocumentType}' ou pas de valeur par défaut`);
+        fileInput.setCustomValidity(`Erreur de configuration: aucune extension définie pour ce type de document`);
+        fileInput.reportValidity();
+        fileInput.setAttribute('accept', "");
+        return null;
+    }
+
+    return documentTypeAllowedExtensions;
+}
+
+export function isSelectedFileExtensionValid(fileInput, documentTypeAllowedExtensions) {
+    fileInput.setCustomValidity('');
+
+    if (!fileInput.files || fileInput.files.length === 0) {
+        return true;
+    }
+
+    // Extraire l'extension du fichier
+    const fileName = fileInput.files[0].name;
+    const fileExtension = fileName.lastIndexOf('.') !== -1 ? fileName.slice(fileName.lastIndexOf('.') + 1).toLowerCase() : '';
+    if (!fileExtension) {
+        fileInput.setCustomValidity("Le fichier sélectionné n'a pas d'extension");
+        fileInput.reportValidity();
+        return false;
+    }
+
+    // Normaliser les extensions autorisées
+    const formattedExtensions = documentTypeAllowedExtensions.split(',').map(ext => ext.replace(/^\./, ''));
+
+    // Vérifier si l'extension est autorisée
+    if (!formattedExtensions.includes(fileExtension)) {
+        fileInput.setCustomValidity(`L'extension du fichier n'est pas autorisé pour le type de document sélectionné (extensions autorisées : ${formattedExtensions.join(', ')})`);
+        fileInput.reportValidity();
+        return false;
+    }
+
+    return true;
+}
+
+export function updateAcceptAttributeFileInput(fileInput, documentTypeSelect, documentTypeAllowedExtensions, extensionsInfoSpan) {
+    // MAJ de l'attribut accept et de l'affichage des extensions autorisées
+    fileInput.setAttribute('accept', documentTypeAllowedExtensions);
+    extensionsInfoSpan.textContent = documentTypeAllowedExtensions.split(',').map(ext => ext.replace('.', '')).join(', ');
+}
+
+export function removeEmptyOptionIfExist(selectElement) {
+    const emptyOption = Array.from(selectElement.options).find(option => option.value === "");
+    if (emptyOption) {
+        emptyOption.remove();
+    }
+}

--- a/core/static/core/document_form.css
+++ b/core/static/core/document_form.css
@@ -1,0 +1,3 @@
+#allowed-extensions-infos .fr-hint-text {
+    display:inline;
+}

--- a/core/static/core/document_form.js
+++ b/core/static/core/document_form.js
@@ -1,9 +1,60 @@
-import { validateFileSize } from './document.js';
+import {
+    validateFileSize,
+    updateAcceptAttributeFileInput,
+    getAcceptAllowedExtensionsAttributeValue,
+    isSelectedFileExtensionValid,
+    removeEmptyOptionIfExist
+}  from './document.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     const uploadModal = document.getElementById('fr-modal-add-doc');
-    if (!!uploadModal){
-        const fileInput = uploadModal.querySelector('input[type="file"]');
-        fileInput.addEventListener('change', () => validateFileSize(fileInput));
-    }
+    if (!uploadModal) return;
+
+    const fileInput = uploadModal.querySelector('input[type="file"]');
+    const documentTypeSelect = uploadModal.querySelector('select[name="document_type"]');
+    const submitButton = uploadModal.querySelector('button[type="submit"]');
+    const extensionsInfoSpan = uploadModal.querySelector("#allowed-extensions-list");
+
+    fileInput.addEventListener('change', () => onFileInputChange(fileInput, documentTypeSelect));
+    documentTypeSelect.addEventListener('change', () => onDocumentTypeChange(fileInput, documentTypeSelect, extensionsInfoSpan, submitButton));
+    submitButton.addEventListener("click", (event) => onFormSubmit(event, fileInput, documentTypeSelect));
 });
+
+function onFileInputChange(fileInput, documentTypeSelect) {
+    if (!validateFileSize(fileInput)) {
+        return;
+    }
+    const documentTypeAllowedExtensions = getAcceptAllowedExtensionsAttributeValue(fileInput, documentTypeSelect);
+    isSelectedFileExtensionValid(fileInput, documentTypeAllowedExtensions);
+}
+
+function onDocumentTypeChange(fileInput, documentTypeSelect, extensionsInfoSpan, submitButton) {
+    const documentTypeAllowedExtensions = getAcceptAllowedExtensionsAttributeValue(fileInput, documentTypeSelect);
+    if (documentTypeAllowedExtensions === null) {
+        submitButton.setAttribute("disabled", "true");
+        return;
+    }
+    removeEmptyOptionIfExist(documentTypeSelect);
+    fileInput.removeAttribute("disabled");
+    submitButton.removeAttribute("disabled");
+    updateAcceptAttributeFileInput(fileInput, documentTypeSelect, documentTypeAllowedExtensions, extensionsInfoSpan);
+    isSelectedFileExtensionValid(fileInput, documentTypeAllowedExtensions);
+}
+
+function onFormSubmit(event, fileInput, documentTypeSelect) {
+    event.preventDefault();
+    const form = event.target.closest("form");
+    if (!validateFileSize(fileInput)) {
+        return;
+    }
+    const documentTypeAllowedExtensions = getAcceptAllowedExtensionsAttributeValue(fileInput, documentTypeSelect);
+    if (documentTypeAllowedExtensions === null) {
+        return;
+    }
+    isSelectedFileExtensionValid(fileInput, documentTypeAllowedExtensions);
+    if(!form.checkValidity()) {
+        form.reportValidity()
+        return;
+    }
+    form.submit();
+}

--- a/core/static/core/message_form.js
+++ b/core/static/core/message_form.js
@@ -1,4 +1,11 @@
-import { validateFileSize } from "./document.js";
+import {
+    getAcceptAllowedExtensionsAttributeValue,
+    updateAcceptAttributeFileInput,
+    validateFileSize,
+    isSelectedFileExtensionValid,
+    removeEmptyOptionIfExist
+} from "./document.js";
+
 let currentID = 0
 
 function cloneDocumentInput(input, currentID, destination){
@@ -31,22 +38,29 @@ function addDocumentCard(currentID, fileInput){
     });
 }
 
-function allowToUploadWhenTypeIsSelected(typeInput, fileInput,messageAddDocumentButton){
-    typeInput.addEventListener("change", ()=>{
-        if (typeInput.value !== ""){
-            fileInput.removeAttribute("disabled")
-        } else {
-            messageAddDocumentButton.setAttribute("disabled", "true")
-        }
-    })
+function onDocumentTypeChange(typeInput, fileInput, messageAddDocumentButton, extensionsInfoSpan) {
+    const documentTypeAllowedExtensions = getAcceptAllowedExtensionsAttributeValue(fileInput, typeInput);
+    if (documentTypeAllowedExtensions === null) {
+        messageAddDocumentButton.setAttribute("disabled", "true");
+        return;
+    }
+    removeEmptyOptionIfExist(typeInput);
+    fileInput.removeAttribute("disabled");
+    updateAcceptAttributeFileInput(fileInput, typeInput, documentTypeAllowedExtensions, extensionsInfoSpan);
+    const hasValidFile = fileInput.files && fileInput.files.length > 0 && isSelectedFileExtensionValid(fileInput, documentTypeAllowedExtensions);
+    if (hasValidFile) {
+        messageAddDocumentButton.removeAttribute("disabled");
+    }
+    else {
+        messageAddDocumentButton.setAttribute("disabled", "true");
+    }
 }
 
-function allowToValidateWhenDocumentIsSelectedAndValidSize(typeInput, fileInput,messageAddDocumentButton){
-    fileInput.addEventListener("change", ()=>{
-        if (typeInput.value !== "" && validateFileSize(fileInput)){
-            messageAddDocumentButton.removeAttribute("disabled")
-        }
-    })
+function onFileInputChange(fileInput, typeInput, messageAddDocumentButton) {
+    const documentTypeAllowedExtensions = getAcceptAllowedExtensionsAttributeValue(fileInput, typeInput);
+    if (typeInput.value !== "" && validateFileSize(fileInput) && documentTypeAllowedExtensions !== null && isSelectedFileExtensionValid(fileInput, documentTypeAllowedExtensions)) {
+        messageAddDocumentButton.removeAttribute("disabled")
+    }
 }
 
 function addStructuresToRecipients(event, choiceElements){
@@ -137,21 +151,30 @@ function initializeChoices(element){
     })
 }
 
+function addEmptyOptionInDocumentTypeSelect(typeInput) {
+    const emptyOption = document.createElement("option");
+    emptyOption.value = "";
+    emptyOption.text = "Sélectionnez un type";
+    typeInput.insertBefore(emptyOption, typeInput.firstChild);
+}
+
+function resetAddDocumentForm(typeInput, fileInput) {
+    addEmptyOptionInDocumentTypeSelect(typeInput);
+    typeInput.selectedIndex = 0;
+    fileInput.value = null;
+    fileInput.setAttribute("disabled", "true");
+    document.getElementById("message-add-document").setAttribute("disabled", "true");
+    currentID += 1;
+    document.querySelector(".add-document-form-btn").classList.remove("fr-hidden");
+    document.querySelector(".document-form").classList.add("fr-hidden");
+}
+
 function validateDocument(event, typeInput, fileInput, inputDestination){
     event.preventDefault();
-
     cloneDocumentInput(fileInput, currentID, inputDestination)
     cloneDocumentTypeInput(typeInput, currentID, inputDestination)
     addDocumentCard(currentID, fileInput)
-
-    // Reset form
-    typeInput.selectedIndex = 0
-    fileInput.value = null
-    fileInput.setAttribute("disabled", "true")
-    document.getElementById("message-add-document").setAttribute("disabled", "true")
-    currentID += 1;
-    document.querySelector(".add-document-form-btn").classList.remove("fr-hidden")
-    document.querySelector(".document-form").classList.add("fr-hidden")
+    resetAddDocumentForm(typeInput, fileInput);
 }
 
 document.addEventListener('DOMContentLoaded', function () {
@@ -160,9 +183,10 @@ document.addEventListener('DOMContentLoaded', function () {
     const fileInput = document.getElementById('id_file');
     const typeInput = document.getElementById('id_document_type');
     const inputDestination = document.getElementById("inputs-for-upload")
+    const extensionsInfoSpan = document.getElementById("allowed-extensions-list");
 
-    allowToUploadWhenTypeIsSelected(typeInput, fileInput, messageAddDocumentButton)
-    allowToValidateWhenDocumentIsSelectedAndValidSize(typeInput, fileInput, messageAddDocumentButton)
+    typeInput.addEventListener("change", () => onDocumentTypeChange(typeInput, fileInput, messageAddDocumentButton, extensionsInfoSpan));
+    fileInput.addEventListener("change", () => onFileInputChange(fileInput, typeInput, messageAddDocumentButton));
 
     addDocumentFormButton.addEventListener("click", event =>{
         event.preventDefault();

--- a/core/templates/core/_modale_ajout_document.html
+++ b/core/templates/core/_modale_ajout_document.html
@@ -13,13 +13,16 @@
                             class="fr-icon-arrow-right-line fr-icon--lg"></span>Ajouter un document</h1>
 
                             {{ document_form.as_dsfr_div }}
-                            <span class="fr-hint-text">Formats supportés : {{ allowed_extensions|join:", " }}</span>
+                            <div id="allowed-extensions-infos">
+                                <span class="fr-hint-text">Formats supportés : </span>
+                                <span id="allowed-extensions-list" class="fr-hint-text">{{ allowed_extensions|join:", " }}</span>
+                            </div>
                             <span class="fr-hint-text">Taille maximale autorisée : {{ max_upload_size_mb }} Mo</span>
 
                         </div>
                         <div class="fr-modal__footer">
                             <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg">
-                                <button type="submit" class="fr-btn" data-testid="documents-send">Envoyer</button>
+                                <button type="submit" class="fr-btn" data-testid="documents-send" disabled>Envoyer</button>
                             </div>
                         </div>
                     </form>

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -23,6 +23,7 @@
         <link rel="stylesheet" href="{% static 'core/fil_de_suivi.css' %}">
         <link rel="stylesheet" href="{% static 'core/contact_list.css' %}">
         <link rel="stylesheet" href="{% static 'core/contact_add_form.css' %}">
+        <link rel="stylesheet" href="{% static 'core/document_form.css' %}">
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js@11.0.4/public/assets/styles/choices.min.css" />
         <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/remixicon@4.3.0/fonts/remixicon.css"/>
         {% block extrahead %}{% endblock %}

--- a/core/validators.py
+++ b/core/validators.py
@@ -1,46 +1,47 @@
 import magic
 from django.core.exceptions import ValidationError
+from django.db import models
 from django.utils.deconstruct import deconstructible
 
 MAX_UPLOAD_SIZE_MEGABYTES = 15
 MAX_UPLOAD_SIZE_BYTES = MAX_UPLOAD_SIZE_MEGABYTES * 1024 * 1024
 
-AUTHORIZED_EXTENSIONS = [
-    "png",
-    "jpg",
-    "jpeg",
-    "gif",
-    "pdf",
-    "doc",
-    "docx",
-    "xls",
-    "xlsx",
-    "odt",
-    "ods",
-    "csv",
-    "qgs",
-    "qgz",
-    "txt",
-    "eml",
-]
 
-AUTHORIZED_MIME_TYPES = [
-    "image/png",
-    "image/jpeg",
-    "image/gif",
-    "application/pdf",
-    "application/msword",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    "application/vnd.ms-excel",
-    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    "application/vnd.oasis.opendocument.text",
-    "application/vnd.oasis.opendocument.spreadsheet",
-    "text/csv",
-    "application/x-qgis",
-    "application/x-qgis-project",
-    "text/plain",
-    "message/rfc822",
-]
+class AllowedExtensions(models.TextChoices):
+    PNG = "png"
+    JPG = "jpg"
+    JPEG = "jpeg"
+    GIF = "gif"
+    PDF = "pdf"
+    DOC = "doc"
+    DOCX = "docx"
+    XLS = "xls"
+    XLSX = "xlsx"
+    ODT = "odt"
+    ODS = "ods"
+    CSV = "csv"
+    QGS = "qgs"
+    QGZ = "qgz"
+    TXT = "txt"
+    EML = "eml"
+
+
+class AllowedMimeTypes(models.TextChoices):
+    IMAGE_PNG = "image/png"
+    IMAGE_JPEG = "image/jpeg"
+    IMAGE_GIF = "image/gif"
+    APPLICATION_PDF = "application/pdf"
+    APPLICATION_MSWORD = "application/msword"
+    APPLICATION_DOCX = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    APPLICATION_XLS = "application/vnd.ms-excel"
+    APPLICATION_XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    APPLICATION_ODT = "application/vnd.oasis.opendocument.text"
+    APPLICATION_ODS = "application/vnd.oasis.opendocument.spreadsheet"
+    TEXT_CSV = "text/csv"
+    APPLICATION_QGIS = "application/x-qgis"
+    APPLICATION_QGIS_PROJECT = "application/x-qgis-project"
+    TEXT_PLAIN = "text/plain"
+    MESSAGE_RFC822 = "message/rfc822"
 
 
 @deconstructible
@@ -48,7 +49,7 @@ class MagicMimeValidator:
     def __call__(self, file):
         file_mime = magic.from_buffer(file.read(2048), mime=True)
         file.seek(0)
-        if file_mime not in AUTHORIZED_MIME_TYPES:
+        if file_mime not in AllowedMimeTypes.values:
             raise ValidationError(f"Type de fichier non autorisé: {file_mime}")
 
 

--- a/core/widgets.py
+++ b/core/widgets.py
@@ -1,11 +1,15 @@
+import json
+
 from django.forms.widgets import FileInput
 
-from core.validators import AUTHORIZED_EXTENSIONS, MAX_UPLOAD_SIZE_BYTES
+from core.models import Document
+from core.validators import MAX_UPLOAD_SIZE_BYTES
 
 
 class RestrictedFileWidget(FileInput):
     def __init__(self, attrs=None):
         attrs = attrs or {}
-        attrs["accept"] = ",".join(f".{ext}" for ext in AUTHORIZED_EXTENSIONS)
+        accept_attribute_per_document_type = Document.get_accept_attribute_per_document_type()
+        attrs["data-accept-allowed-extensions"] = json.dumps(accept_attribute_per_document_type)
         attrs["data-max-size"] = MAX_UPLOAD_SIZE_BYTES
         super().__init__(attrs)

--- a/sv/templates/sv/_sidebar_message_form.html
+++ b/sv/templates/sv/_sidebar_message_form.html
@@ -27,7 +27,10 @@
             <button class="fr-btn fr-btn--tertiary-no-outline btn-full add-document-form-btn"><span class="fr-icon-add-line" aria-hidden="true"></span>Ajouter un document</button>
             <div class="fr-hidden document-form">
                 {{ add_document_form.as_dsfr_div }}
-                <span class="fr-hint-text">Formats supportés : {{ allowed_extensions|join:", " }}</span>
+                <div id="allowed-extensions-infos">
+                    <span class="fr-hint-text">Formats supportés : </span>
+                    <span id="allowed-extensions-list" class="fr-hint-text">{{ allowed_extensions|join:", " }}</span>
+                </div>
                 <span class="fr-hint-text">Taille maximale autorisée : {{ max_upload_size_mb }} Mo</span>
                 <div class="message-documents-actions">
                     <button class="fr-btn fr-btn--tertiary btn-full" id="message-add-document" disabled>Valider l'ajout du document</button>

--- a/sv/views.py
+++ b/sv/views.py
@@ -33,7 +33,7 @@ from core.mixins import (
 )
 from core.models import Visibilite, Contact
 from core.redirect import safe_redirect
-from core.validators import AUTHORIZED_EXTENSIONS, MAX_UPLOAD_SIZE_MEGABYTES
+from core.validators import MAX_UPLOAD_SIZE_MEGABYTES, AllowedExtensions
 from sv.forms import (
     FicheZoneDelimiteeForm,
     ZoneInfesteeFormSet,
@@ -208,7 +208,7 @@ class EvenementDetailView(
             next=self.get_object().get_absolute_url(),
         )
         context["add_document_form"] = MessageDocumentForm()
-        context["allowed_extensions"] = AUTHORIZED_EXTENSIONS
+        context["allowed_extensions"] = AllowedExtensions.values
         contact = self.request.user.agent.structure.contact_set.get()
         context["etat"] = self.get_object().get_etat_data_for_contact(contact)
         context["active_detection"] = (


### PR DESCRIPTION
Cette PR permet d'introduire la possibilité de restreindre des extensions de fichier par type de document (dans les formulaires d'ajout de document dans l'onglet Documents et l'ajout d'un élément de suivi).
Pour l'instant, seul le type de document "Cartographie" est géré.

Côté backend :
- Dans le modele `Document`, ajout d'un dictionnaire (`ALLOWED_EXTENSIONS_PER_DOCUMENT_TYPE`) permettant de stocker les extensions autorisés par type de document,
- Conversion de la liste des extensions autorisés en `TextChoices` pour éviter la répétition des extensions sous forme de chaîne de caractères et d'éventuelles erreurs de recopie,
- Idem pour la liste des MimeType autorisés (pour garder une cohérence),
- Dans le modèle `Document`, ajout d'une méthode `validate_file_extention_for_document_type` pour valider l'extension en fonction du type de document sélectionné,
- Ajout de la vérification de l'extension en fonction du type de document sélectionné dans le form (via `clean_file`) et lors de l'enregistrement en base du fichier (via `clean`),
- Dans `RestrictedFileWidget`, passage ajout de l'attribut `data-accept-allowed-extensions` permettant de stocker la liste des extensions autorisées pour chaque type de document. ~Pour les documents qui n'ont pas de restrictions particulières, la liste des extensions autorisées est stockée dans `default`.~

Côté frontend :
- MAJ de l'attribut `accept` et de la liste des extensions autorisées affichée sur le formulaire lors du changement de type de document,
- Dans `getAcceptAllowedExtensionsAttributeValue`, contrôle de l'attribut `data-accept-allowed-extensions` et gestion des différents cas d'erreurs,

Aussi, dans le formulaire d'ajout de document (ajout d'un élément de suivi), j'ai ajouté le fait de supprimer l'option vide dans le select du type de document une fois celui-ci sélectionné pour gérer plus facilement l'input du fichier (attribut `accept` , disabled du champ...).