### PR TITLE
Migrer les check en condition dans les modèles

### DIFF
--- a/core/migrations/0009_agent_structure_alter_contact_options_and_more.py
+++ b/core/migrations/0009_agent_structure_alter_contact_options_and_more.py
@@ -112,7 +112,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="contact",
             constraint=models.CheckConstraint(
-                check=models.Q(("structure__isnull", False), ("agent__isnull", False), _connector="OR"),
+                condition=models.Q(("structure__isnull", False), ("agent__isnull", False), _connector="OR"),
                 name="contact_has_structure_or_agent",
             ),
         ),

--- a/core/migrations/0015_lienlibre_lienlibre_no_self_relation.py
+++ b/core/migrations/0015_lienlibre_lienlibre_no_self_relation.py
@@ -46,7 +46,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="lienlibre",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     ("content_type_1", models.F("content_type_2")),
                     ("object_id_1", models.F("object_id_2")),
                     _negated=True,

--- a/core/migrations/0021_remove_contact_contact_has_structure_or_agent_and_more.py
+++ b/core/migrations/0021_remove_contact_contact_has_structure_or_agent_and_more.py
@@ -16,7 +16,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="contact",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(("structure__isnull", False), ("agent__isnull", True)),
                     models.Q(("structure__isnull", True), ("agent__isnull", False)),
                     _connector="OR",

--- a/core/models.py
+++ b/core/models.py
@@ -81,7 +81,7 @@ class Contact(models.Model):
         ordering = ["structure", "agent"]
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     (Q(structure__isnull=False) & Q(agent__isnull=True))
                     | (Q(structure__isnull=True) & Q(agent__isnull=False))
                 ),
@@ -266,7 +266,7 @@ class LienLibre(models.Model):
     class Meta:
         constraints = [
             CheckConstraint(
-                check=~Q(content_type_1=models.F("content_type_2"), object_id_1=models.F("object_id_2")),
+                condition=~Q(content_type_1=models.F("content_type_2"), object_id_1=models.F("object_id_2")),
                 name="no_self_relation",
             ),
         ]

--- a/sv/migrations/0027_remove_zoneinfestee_numero_and_more.py
+++ b/sv/migrations/0027_remove_zoneinfestee_numero_and_more.py
@@ -71,7 +71,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="fichedetection",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     models.Q(("hors_zone_infestee__isnull", True), ("zone_infestee__isnull", True)),
                     models.Q(("hors_zone_infestee__isnull", True), ("zone_infestee__isnull", False)),
                     models.Q(("hors_zone_infestee__isnull", False), ("zone_infestee__isnull", True)),

--- a/sv/migrations/0030_alter_fichedetection_numero_and_more.py
+++ b/sv/migrations/0030_alter_fichedetection_numero_and_more.py
@@ -49,7 +49,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="fichedetection",
             constraint=models.CheckConstraint(
-                check=models.Q(("visibilite", "brouillon"), ("numero__isnull", False), _negated=True),
+                condition=models.Q(("visibilite", "brouillon"), ("numero__isnull", False), _negated=True),
                 name="check_numero_fiche_is_null_when_visibilite_is_brouillon",
             ),
         ),

--- a/sv/migrations/0041_alter_fichezonedelimitee_numero_and_more.py
+++ b/sv/migrations/0041_alter_fichezonedelimitee_numero_and_more.py
@@ -56,7 +56,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="fichezonedelimitee",
             constraint=models.CheckConstraint(
-                check=models.Q(("visibilite", "brouillon"), ("numero__isnull", False), _negated=True),
+                condition=models.Q(("visibilite", "brouillon"), ("numero__isnull", False), _negated=True),
                 name="check_fiche_zone_delimitee_numero_fiche_is_null_when_visibilite_is_brouillon",
             ),
         ),

--- a/sv/migrations/0054_prelevement_check_officiel_fields_empty_or_null.py
+++ b/sv/migrations/0054_prelevement_check_officiel_fields_empty_or_null.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name="prelevement",
             constraint=models.CheckConstraint(
-                check=models.Q(
+                condition=models.Q(
                     ("is_officiel", True),
                     models.Q(
                         ("laboratoire_agree__isnull", True),

--- a/sv/models/fiches_detection.py
+++ b/sv/models/fiches_detection.py
@@ -145,7 +145,7 @@ class FicheDetection(
         ordering = ["numero_detection"]
         constraints = [
             models.CheckConstraint(
-                check=(
+                condition=(
                     Q(hors_zone_infestee__isnull=True) & Q(zone_infestee__isnull=True)
                     | Q(hors_zone_infestee__isnull=True) & Q(zone_infestee__isnull=False)
                     | Q(hors_zone_infestee__isnull=False) & Q(zone_infestee__isnull=True)

--- a/sv/models/prelevements.py
+++ b/sv/models/prelevements.py
@@ -99,7 +99,7 @@ class Prelevement(models.Model):
         db_table = "sv_prelevement"
         constraints = [
             models.CheckConstraint(
-                check=Q(is_officiel=True) | Q(numero_rapport_inspection=""),
+                condition=Q(is_officiel=True) | Q(numero_rapport_inspection=""),
                 name="check_numero_officiel_empty_or_null",
             )
         ]


### PR DESCRIPTION
Afin de rester compatibles avec les prochaines versions de Django, check étant devenu déprécié. Permet de retirer quelques warnings dans les tests.