### PR TITLE
Corrige un bug dans la colonne Détections dans la liste des évènements

### DIFF
--- a/sv/managers.py
+++ b/sv/managers.py
@@ -145,7 +145,9 @@ class EvenementQueryset(models.QuerySet):
         )
 
     def with_nb_fiches_detection(self):
-        return self.annotate(nb_fiches_detection=Count("detections", distinct=True))
+        return self.annotate(
+            nb_fiches_detection=Count("detections", filter=Q(detections__is_deleted=False), distinct=True)
+        )
 
     def optimized_for_list(self):
         return self.select_related("organisme_nuisible", "statut_reglementaire", "createur", "fiche_zone_delimitee")

--- a/sv/tests/test_evenement_search.py
+++ b/sv/tests/test_evenement_search.py
@@ -337,3 +337,13 @@ def test_cant_see_duplicate_fiche_detection_when_multiple_lieu_with_same_region(
     page.get_by_role("button", name="Rechercher").click()
 
     expect(page.get_by_role("cell", name=str(lieu.fiche_detection.evenement.numero))).to_have_count(1)
+
+
+def test_filter_deleted_detection_in_count_column(live_server, page):
+    evenement = EvenementFactory()
+    FicheDetectionFactory(evenement=evenement)
+    FicheDetectionFactory(evenement=evenement, is_deleted=True)
+
+    page.goto(f"{live_server.url}{get_fiche_detection_search_form_url()}")
+
+    assert page.locator(".evenements__list-row:nth-child(1) td:nth-child(9)").inner_text().strip() == "1"


### PR DESCRIPTION
Problème :
Si un évènement comporte trois fiches détections et que j'en supprime une, le nombre de détections affichées dans la liste des évènements (colonne Détections) est à trois au lieu de deux.

Solution :
Dans la colonne Détections dans la page liste des évènements, filtrer pour ne plus prendre en compte les fiches détections supprimées