### PR TITLE
Fix failles de sécurité concernant l'accès à des actions non autorisées

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -308,7 +308,10 @@ class PublishView(View):
         return safe_redirect(request.POST.get("next"))
 
 
-class ACNotificationView(PreventActionIfVisibiliteBrouillonMixin, View):
+class ACNotificationView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTestMixin, View):
+    def test_func(self):
+        return self.obj.can_user_access(self.request.user)
+
     def get_fiche_object(self):
         content_type_id = self.request.POST.get("content_type_id")
         content_id = self.request.POST.get("content_id")

--- a/sv/tests/test_evenement_ac_notification.py
+++ b/sv/tests/test_evenement_ac_notification.py
@@ -1,8 +1,9 @@
+import pytest
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from playwright.sync_api import Page, expect
 
-from core.factories import ContactStructureFactory
+from core.factories import ContactStructureFactory, StructureFactory
 from core.models import Structure, Contact, Message
 from core.constants import MUS_STRUCTURE, BSV_STRUCTURE, AC_STRUCTURE
 from ..factories import EvenementFactory, FicheDetectionFactory
@@ -123,3 +124,26 @@ def test_bsv_and_mus_are_added_to_contact_when_notify_ac(live_server, page: Page
     evenement.refresh_from_db()
     assert evenement.contacts.filter(structure__niveau2=MUS_STRUCTURE).exists()
     assert evenement.contacts.filter(structure__niveau2=BSV_STRUCTURE).exists()
+
+
+@pytest.mark.django_db
+def test_cant_forge_notify_ac_of_evenement_i_cant_see(client):
+    evenement = EvenementFactory(createur=StructureFactory())
+    response = client.get(evenement.get_absolute_url())
+    assert response.status_code == 403
+
+    ContactStructureFactory(structure__niveau1=AC_STRUCTURE, structure__niveau2=MUS_STRUCTURE)
+    ContactStructureFactory(structure__niveau1=AC_STRUCTURE, structure__niveau2=BSV_STRUCTURE)
+
+    response = client.post(
+        reverse("notify-ac"),
+        {
+            "next": evenement.get_absolute_url(),
+            "content_id": evenement.id,
+            "content_type_id": ContentType.objects.get_for_model(Evenement).id,
+        },
+    )
+
+    assert response.status_code == 403
+    evenement.refresh_from_db()
+    assert evenement.is_ac_notified is False

--- a/sv/tests/test_evenement_delete.py
+++ b/sv/tests/test_evenement_delete.py
@@ -1,0 +1,21 @@
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from core.factories import StructureFactory
+from sv.factories import EvenementFactory
+
+
+@pytest.mark.django_db
+def test_cant_delete_evenement_i_cant_see(client):
+    evenement = EvenementFactory(createur=StructureFactory())
+    assert client.get(evenement.get_absolute_url()).status_code == 403
+
+    response = client.post(
+        reverse("soft-delete"),
+        {"content_type_id": ContentType.objects.get_for_model(evenement).id, "content_id": evenement.pk},
+    )
+
+    assert response.status_code == 302
+    evenement.refresh_from_db()
+    assert evenement.is_deleted is False

--- a/sv/tests/test_fichezonedelimitee_add_performance.py
+++ b/sv/tests/test_fichezonedelimitee_add_performance.py
@@ -2,7 +2,7 @@ from django.urls import reverse
 
 from sv.factories import EvenementFactory, FicheDetectionFactory
 
-BASE_NUM_QUERIES = 5
+BASE_NUM_QUERIES = 6
 
 
 def test_add_fiche_zone_delimitee_form_with_multiple_existing_fiche_detection(

--- a/sv/tests/test_fichezonedelimitee_create.py
+++ b/sv/tests/test_fichezonedelimitee_create.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from django.utils import timezone
 from playwright.sync_api import Page, expect
 
+from core.factories import StructureFactory
 from sv.factories import FicheDetectionFactory, EvenementFactory, FicheZoneFactory, ZoneInfesteeFactory
 from sv.models import FicheZoneDelimitee, ZoneInfestee, FicheDetection
 from sv.tests.test_utils import FicheZoneDelimiteeFormPage
@@ -260,3 +261,41 @@ def test_shows_correct_organisme_and_statut(live_server, page: Page, choice_js_f
 
     expect(page.get_by_text(str(evenement.organisme_nuisible))).to_be_visible()
     expect(page.get_by_text(str(evenement.statut_reglementaire))).to_be_visible()
+
+
+def test_cant_access_add_fiche_zone_delimitee_form_of_evenement_i_cant_see(client):
+    evenement = EvenementFactory(createur=StructureFactory())
+    assert client.get(evenement.get_absolute_url()).status_code == 403
+    response = client.get(reverse("sv:fiche-zone-delimitee-creation") + f"?evenement={evenement.pk}")
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_cant_forge_add_fiche_zone_delimitee_of_evenement_i_cant_see(client):
+    evenement = EvenementFactory(createur=StructureFactory())
+    assert client.get(evenement.get_absolute_url()).status_code == 403
+
+    payload = {
+        "evenement": evenement.pk,
+        "latest_version": "0",
+        "commentaire": "",
+        "zoneinfestee_set-TOTAL_FORMS": "1",
+        "zoneinfestee_set-INITIAL_FORMS": "0",
+        "zoneinfestee_set-MIN_NUM_FORMS": "0",
+        "zoneinfestee_set-MAX_NUM_FORMS": "1000",
+        "zoneinfestee_set-0-nom": "",
+        "zoneinfestee_set-0-caracteristique_principale": "",
+        "zoneinfestee_set-0-rayon": "",
+        "zoneinfestee_set-0-unite_rayon": "km",
+        "zoneinfestee_set-0-surface_infestee_totale": "",
+        "zoneinfestee_set-0-unite_surface_infestee_totale": "m2",
+        "rayon_zone_tampon": "",
+        "unite_rayon_zone_tampon": "km",
+        "surface_tampon_totale": "",
+        "unite_surface_tampon_totale": "m2",
+    }
+    response = client.post(reverse("sv:fiche-zone-delimitee-creation"), data=payload)
+
+    evenement.refresh_from_db()
+    assert evenement.fiche_zone_delimitee is None
+    assert response.status_code == 403

--- a/sv/tests/test_fichezonedelimitee_update.py
+++ b/sv/tests/test_fichezonedelimitee_update.py
@@ -2,6 +2,7 @@ import pytest
 from django.urls import reverse
 from playwright.sync_api import Page, expect
 
+from core.factories import StructureFactory
 from core.models import Structure
 from sv.factories import FicheZoneFactory, FicheDetectionFactory, ZoneInfesteeFactory, EvenementFactory
 from sv.models import ZoneInfestee, FicheZoneDelimitee, FicheDetection, Evenement
@@ -307,6 +308,14 @@ def test_fiche_zone_update_has_locking_protection(
     ).to_be_visible()
     page.keyboard.press("Escape")
     page.wait_for_function(f"performance.timing.navigationStart > {initial_timestamp}")
+
+
+def test_cant_access_update_zone_delimitee_form_of_evenement_i_cant_see(client):
+    fiche_zone = FicheZoneFactory()
+    evenement = EvenementFactory(fiche_zone_delimitee=fiche_zone, createur=StructureFactory())
+    assert client.get(evenement.get_absolute_url()).status_code == 403
+
+    assert client.get(fiche_zone.get_update_url()).status_code == 403
 
 
 def test_cant_forge_update_of_zone_delimitee_i_cant_see(client):


### PR DESCRIPTION
Cette PR corrige des accès non autorisés. Liste des actions traitées et/ou améliorées : 

<ins>Publier l’évènement</ins>
- ajout du test `test_cant_publish_evenement_i_cant_see`

<ins>Déclarer à l’AC</ins>
  - ajout de `UserPassesTestMixin` dans la view `ACNotificationView`
  - ajout du test test `test_cant_forge_notify_ac_of_evenement_i_cant_see`

<ins>Modifier la visibilité</ins>
- 2 tests ajoutés : 
  - `test_users_not_from_ac_cant_forge_update_visibilite` et 
  - `test_cant_forge_update_visibilite_of_evenement_i_cant_see`

<ins>Modifier l’évènement</ins>
- ajout du test `test_cant_update_evenement_i_cant_see`

<ins>Supprimer l’évènement</ins>
- ajout du test `test_cant_delete_evenement_i_cant_see`

<ins>Ajouter une détection</ins>
- ajout du mixin `UserPassesTestMixin` dans la view `FicheDetectionCreateView`, 
- 2 tests ajoutés : 
  - `test_cant_access_fiche_detection_form_for_evenement_i_cant_see` et
  - `test_cant_forge_add_fiche_detection_for_evenement_i_cant_see`

<ins>Ajouter une zone</ins>
- ajout du mixin `UserPassesTestMixin` dans la view `FicheZoneDelimiteeCreateView`
- 2 tests ajoutés : 
  - `test_cant_access_add_fiche_zone_delimitee_form_of_evenement_i_cant_see` et
  - `test_cant_forge_add_fiche_zone_delimitee_of_evenement_i_cant_see`

<ins>Modifier une zone</ins>
  - ajout du test : `test_cant_access_update_zone_delimitee_form_of_evenement_i_cant_see`
