### PR TITLE
Désactive les actions quand l’évènement est clôturé

### DIFF
--- a/core/templates/core/_carte_resume_contact_agent.html
+++ b/core/templates/core/_carte_resume_contact_agent.html
@@ -9,8 +9,12 @@
     <a href="#" class="fr-link email message-panel" data-message-type="message" data-recipient="{{ contact.pk }}">{{ contact.email }}</a>
 </div>
 <div class="fr-col-3 phone">{{ contact.agent.telephone }}</div>
-<div class="fr-col-1">
-    <a href="#" class="fr-icon-delete-line fr-btn fr-btn--sm fr-btn--tertiary" data-fr-opened="false" aria-controls="fr-modal-contact-{{ contact.pk }}"></a>
-</div>
+{% if can_delete_contact %}
+    <div class="fr-col-1">
+        <a href="#" class="fr-icon-delete-line fr-btn fr-btn--sm fr-btn--tertiary" data-fr-opened="false" aria-controls="fr-modal-contact-{{ contact.pk }}"></a>
+    </div>
+{% endif %}
 
-{% include "core/_modale_suppression_contact.html" %}
+{% if can_delete_contact %}
+    {% include "core/_modale_suppression_contact.html" %}
+{% endif %}

--- a/core/templates/core/_carte_resume_contact_structure.html
+++ b/core/templates/core/_carte_resume_contact_structure.html
@@ -6,8 +6,13 @@
 </div>
 <div class="fr-col-5"><a href="#" class="fr-link email message-panel" data-message-type="message" data-recipient="{{ contact.pk }}">{{ contact.email }}</a></div>
 <div class="fr-col-offset-1"></div>
-<div class="fr-col">
-    <a href="#" class="fr-icon-delete-line fr-btn fr-btn--sm fr-btn--tertiary" data-fr-opened="false" aria-controls="fr-modal-contact-{{ contact.pk }}"></a>
-</div>
 
-{% include "core/_modale_suppression_contact.html" %}
+{% if can_delete_contact %}
+    <div class="fr-col">
+        <a href="#" class="fr-icon-delete-line fr-btn fr-btn--sm fr-btn--tertiary" data-fr-opened="false" aria-controls="fr-modal-contact-{{ contact.pk }}"></a>
+    </div>
+{% endif %}
+
+{% if can_delete_contact %}
+    {% include "core/_modale_suppression_contact.html" %}
+{% endif %}

--- a/core/templates/core/_carte_resume_document.html
+++ b/core/templates/core/_carte_resume_document.html
@@ -24,17 +24,21 @@
         {% if not document.is_deleted %}
             <div class="fr-card__footer">
                 <ul class="fr-btns-group fr-btns-group--inline-reverse fr-btns-group--inline">
-                    <li>
-                        <a href="#" class="fr-icon-edit-line fr-btn fr-btn--tertiary" data-fr-opened="false" aria-controls="fr-modal-edit-{{ document.pk }}"></a>
-                    </li>
-                    {% if document.is_infected is False %}
+                    {% if can_update_document %}
+                        <li>
+                            <a href="#" class="fr-icon-edit-line fr-btn fr-btn--tertiary" data-fr-opened="false" aria-controls="fr-modal-edit-{{ document.pk }}"></a>
+                        </li>
+                    {% endif %}
+                    {% if document.is_infected is False and can_download_document %}
                         <li>
                             <a href="{{ document.file.url }}" target="_blank" class="fr-icon-download-line fr-btn fr-btn--tertiary fr-mr-1w"></a>
                         </li>
                     {% endif %}
-                    <li>
-                        <a href="#" class="fr-icon-delete-line fr-btn fr-btn--tertiary" data-fr-opened="false" aria-controls="fr-modal-{{ document.pk }}"></a>
-                    </li>
+                    {% if can_delete_document %}
+                        <li>
+                            <a href="#" class="fr-icon-delete-line fr-btn fr-btn--tertiary" data-fr-opened="false" aria-controls="fr-modal-{{ document.pk }}"></a>
+                        </li>
+                    {% endif %}
                 </ul>
                 {% include "core/_modale_edition_document.html" %}
                 {% include "core/_modale_suppression_document.html" %}

--- a/core/templates/core/_contacts.html
+++ b/core/templates/core/_contacts.html
@@ -1,32 +1,40 @@
 <div class="fr-container--fluid">
-    <div class="fr-grid-row fr-grid-row--gutters">
-        <div class="fr-col-12 fr-col-lg-6">
-            <form action="{% url 'structure-add' %}" method="post" id="add-contact-structure-form">
-                {% csrf_token %}
-                {{ add_contact_structure_form.content_id }}
-                {{ add_contact_structure_form.content_type_id }}
-                <p class="fr-mb-3v">{{ add_contact_structure_form.contacts_structures.label_tag }}</p>
-                <p class="fr-mb-3v">{{ add_contact_structure_form.contacts_structures.help_text }}</p>
-                <div class="contact-form-container">
-                    <div class="contact-form-input">{{ add_contact_structure_form.contacts_structures }}</div>
-                    <input type="submit" value="Ajouter" class="contact-form-btn fr-btn fr-btn--secondary">
+
+    {% if can_add_structure or can_add_agent %}
+        <div class="fr-grid-row fr-grid-row--gutters">
+            {% if can_add_structure %}
+                <div class="fr-col-12 fr-col-lg-6">
+                    <form action="{% url 'structure-add' %}" method="post" id="add-contact-structure-form">
+                        {% csrf_token %}
+                        {{ add_contact_structure_form.content_id }}
+                        {{ add_contact_structure_form.content_type_id }}
+                        <p class="fr-mb-3v">{{ add_contact_structure_form.contacts_structures.label_tag }}</p>
+                        <p class="fr-mb-3v">{{ add_contact_structure_form.contacts_structures.help_text }}</p>
+                        <div class="contact-form-container">
+                            <div class="contact-form-input">{{ add_contact_structure_form.contacts_structures }}</div>
+                            <input type="submit" value="Ajouter" class="contact-form-btn fr-btn fr-btn--secondary">
+                        </div>
+                    </form>
                 </div>
-            </form>
-        </div>
-        <div class="fr-col-12 fr-col-lg-6">
-            <form action="{% url 'agent-add' %}" method="post" id="add-contact-agent-form">
-                {% csrf_token %}
-                {{ add_contact_agent_form.content_id }}
-                {{ add_contact_agent_form.content_type_id }}
-                <p class="fr-mb-3v">{{ add_contact_agent_form.contacts_agents.label_tag }}</p>
-                <p class="fr-mb-3v">{{ add_contact_agent_form.contacts_agents.help_text }}</p>
-                <div class="contact-form-container">
-                    <div class="contact-form-input">{{ add_contact_agent_form.contacts_agents }}</div>
-                    <input type="submit" value="Ajouter" class="contact-form-btn fr-btn fr-btn--secondary">
+            {% endif %}
+            {% if can_add_agent %}
+                <div class="fr-col-12 fr-col-lg-6">
+                    <form action="{% url 'agent-add' %}" method="post" id="add-contact-agent-form">
+                        {% csrf_token %}
+                        {{ add_contact_agent_form.content_id }}
+                        {{ add_contact_agent_form.content_type_id }}
+                        <p class="fr-mb-3v">{{ add_contact_agent_form.contacts_agents.label_tag }}</p>
+                        <p class="fr-mb-3v">{{ add_contact_agent_form.contacts_agents.help_text }}</p>
+                        <div class="contact-form-container">
+                            <div class="contact-form-input">{{ add_contact_agent_form.contacts_agents }}</div>
+                            <input type="submit" value="Ajouter" class="contact-form-btn fr-btn fr-btn--secondary">
+                        </div>
+                    </form>
                 </div>
-            </form>
+            {% endif %}
         </div>
-    </div>
+    {% endif %}
+
     <div id="contacts" class="fr-grid-row fr-grid-row--gutters">
         <div class="fr-col-12 fr-col-lg-6">
             {% for contact in contacts_structures %}
@@ -43,4 +51,5 @@
             {% endfor %}
         </div>
     </div>
+
 </div>

--- a/core/templates/core/_documents.html
+++ b/core/templates/core/_documents.html
@@ -8,13 +8,15 @@
 
         </div>
         <div class="fr-col-1 fr-col-xl-5"></div>
-        <div class="fr-col-3">
-            <div class="fr-btns-group--right fr-mt-3w">
-                <button class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-circle-line" data-testid="documents-add" data-fr-opened="false" aria-controls="fr-modal-add-doc">
-                    Ajouter un document
-                </button>
+        {% if can_add_document %}
+            <div class="fr-col-3">
+                <div class="fr-btns-group--right fr-mt-3w">
+                    <button class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-circle-line" data-testid="documents-add" data-fr-opened="false" aria-controls="fr-modal-add-doc">
+                        Ajouter un document
+                    </button>
+                </div>
             </div>
-        </div>
+        {% endif %}
     </div>
 </div>
 {% include "core/_modale_ajout_document.html" %}

--- a/core/views.py
+++ b/core/views.py
@@ -39,7 +39,7 @@ class DocumentUploadView(
         return get_object_or_404(ModelClass, pk=self.request.POST.get("object_id"))
 
     def test_func(self):
-        return self.get_fiche_object().can_user_access(self.request.user)
+        return self.get_fiche_object().can_add_document(self.request.user)
 
     def post(self, request, *args, **kwargs):
         form = DocumentUploadForm(request.POST, request.FILES)
@@ -83,7 +83,7 @@ class DocumentDeleteView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTest
         return self.document.content_object
 
     def test_func(self):
-        return self.get_fiche_object().can_user_access(self.request.user)
+        return self.get_fiche_object().can_delete_document(self.request.user)
 
     def post(self, request, *args, **kwargs):
         self.document.is_deleted = True
@@ -99,7 +99,7 @@ class DocumentUpdateView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTest
     http_method_names = ["post"]
 
     def test_func(self) -> bool | None:
-        return self.get_fiche_object().can_user_access(self.request.user)
+        return self.get_fiche_object().can_update_document(self.request.user)
 
     def get_fiche_object(self):
         self.document = get_object_or_404(Document, pk=self.kwargs.get("pk"))
@@ -122,7 +122,7 @@ class ContactDeleteView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTestM
         return self.fiche
 
     def test_func(self):
-        return self.get_fiche_object().can_user_access(self.request.user)
+        return self.get_fiche_object().can_delete_contact(self.request.user)
 
     def post(self, request, *args, **kwargs):
         contact = Contact.objects.get(pk=self.request.POST.get("pk"))
@@ -342,7 +342,7 @@ class StructureAddView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTestMi
         return self.obj
 
     def test_func(self) -> bool | None:
-        return self.get_fiche_object().can_user_access(self.request.user)
+        return self.get_fiche_object().can_add_structure(self.request.user)
 
     def post(self, request, *args, **kwargs):
         form = StructureAddForm(request.POST)
@@ -375,7 +375,7 @@ class AgentAddView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTestMixin,
         return self.obj
 
     def test_func(self) -> bool | None:
-        return self.get_fiche_object().can_user_access(self.request.user)
+        return self.get_fiche_object().can_add_agent(self.request.user)
 
     def post(self, request, *args, **kwargs):
         form = AgentAddForm(request.POST)

--- a/sv/models/fiches_detection.py
+++ b/sv/models/fiches_detection.py
@@ -169,6 +169,9 @@ class FicheDetection(
     def can_user_delete(self, user):
         return self.evenement.can_user_access(user)
 
+    def can_be_deleted(self, user):
+        return self.can_user_delete(user) and not self.evenement.is_cloture
+
     def __str__(self):
         return self.numero
 

--- a/sv/models/fiches_zone_delimitee.py
+++ b/sv/models/fiches_zone_delimitee.py
@@ -64,8 +64,11 @@ class FicheZoneDelimitee(models.Model):
             return str(self.evenement.numero)
         return ""
 
-    def can_user_delete(self, user):
-        return self.evenement.can_user_access(user)
+    def can_be_deleted(self, user):
+        return self.evenement._user_can_interact(user)
+
+    def can_be_updated(self, user):
+        return self.evenement._user_can_interact(user)
 
     def save(self, *args, **kwargs):
         with reversion.create_revision():

--- a/sv/templates/sv/_evenement_action_navigation.html
+++ b/sv/templates/sv/_evenement_action_navigation.html
@@ -1,13 +1,12 @@
-{% include "sv/_update_visibilite_modale.html" %}
-<nav role="navigation" class="fr-translate fr-nav">
-    <div class="fr-nav__item">
-        <button class="fr-translate__btn fr-btn fr-btn--lg" aria-controls="action-1"
-                aria-expanded="false" title="Sélectionner une action">Actions</button>
-        <div class="fr-collapse fr-translate__menu fr-menu" id="action-1">
-            <ul class="fr-menu__list">
-                {% if not evenement.is_draft and not user.agent.structure.is_ac %}
-                    <li>
-                        {% if can_be_ac_notified %}
+{% if can_be_ac_notified or can_update_visibilite or can_be_updated or is_evenement_can_be_cloturer_by_user and not is_cloture or can_be_deleted %}
+    <nav role="navigation" class="fr-translate fr-nav">
+        <div class="fr-nav__item">
+            <button class="fr-translate__btn fr-btn fr-btn--lg" aria-controls="action-1"
+                    aria-expanded="false" title="Sélectionner une action">Actions</button>
+            <div class="fr-collapse fr-translate__menu fr-menu" id="action-1">
+                <ul class="fr-menu__list">
+                    {% if can_be_ac_notified %}
+                        <li>
                             <form action="{% url 'notify-ac' %}" method="post">
                                 <button class="fr-translate__language fr-nav__link" href="#" type="submit"><span class="fr-icon-notification-3-fill fr-mr-2v fr-icon--sm" aria-hidden="true">
                                     {% csrf_token %}
@@ -16,22 +15,32 @@
                                     <input type="hidden" value="{{ evenement.pk }}" name="content_id">
                                 </span>Déclarer à l'AC</button>
                             </form>
-                        {% else %}
-                            <button class="fr-translate__language fr-nav__link" href="#" type="submit" disabled><span class="fr-icon-notification-3-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Déclarer à l'AC</button>
-                        {% endif %}
-                    </li>
-                {% endif %}
-                {% if can_update_visibilite %}
-                    <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-edit-visibilite"><span class="fr-icon-eye-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Modifier la visibilité</a></li>
-                {% endif %}
-                <li><a class="fr-translate__language fr-nav__link" href="{{ evenement.get_update_url}}" ><span class="fr-icon-edit-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Modifier l'événement</a></li>
-                {%  if is_evenement_can_be_cloturer_by_user and not is_cloture %}
-                    <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-cloturer-evenement"><span class="fr-icon-close-circle-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Clôturer l'événement</a></li>
-                {% endif %}
-                <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-delete-evenement"><span class="fr-icon-close-circle-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Supprimer l'événement</a></li>
-            </ul>
-
+                        </li>
+                    {% endif %}
+                    {% if can_update_visibilite %}
+                        <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-edit-visibilite"><span class="fr-icon-eye-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Modifier la visibilité</a></li>
+                    {% endif %}
+                    {% if can_be_updated %}
+                        <li><a class="fr-translate__language fr-nav__link" href="{{ evenement.get_update_url}}" ><span class="fr-icon-edit-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Modifier l'événement</a></li>
+                    {% endif %}
+                    {%  if is_evenement_can_be_cloturer_by_user and not is_cloture %}
+                        <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-cloturer-evenement"><span class="fr-icon-close-circle-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Clôturer l'événement</a></li>
+                    {% endif %}
+                    {% if can_be_deleted %}
+                        <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-delete-evenement"><span class="fr-icon-close-circle-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Supprimer l'événement</a></li>
+                    {% endif %}
+                </ul>
+            </div>
         </div>
-    </div>
-</nav>
-{% include "sv/_delete_evenement_modal.html" %}
+    </nav>
+{% endif %}
+
+{% if can_update_visibilite %}
+    {% include "sv/_update_visibilite_modale.html" %}
+{% endif %}
+{% if is_evenement_can_be_cloturer_by_user and not is_cloture %}
+    {% include "sv/_cloturer_modal.html" %}
+{% endif %}
+{% if can_be_deleted %}
+    {% include "sv/_delete_evenement_modal.html" %}
+{% endif %}

--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -63,7 +63,6 @@
                         </form>
                     {% endif %}
                     {% include "sv/_evenement_action_navigation.html" %}
-                    {% include "sv/_cloturer_modal.html" %}
                 </div>
             </div>
             {% include "sv/_evenement_badges.html" %}
@@ -129,21 +128,27 @@
                                                 aria-controls="tabpanel-{{ fichedetection.pk }}-panel">{{ fichedetection }}</button>
                                     </li>
                                 {% endfor %}
-                                <li>
-                                    <a id="add-detection-link" href="{% url 'sv:fiche-detection-creation' %}?evenement={{ evenement.pk }}" class="fr-tag fr-tag--tertiary fr-mx-1w">
-                                        <span class="fr-icon-add-line" aria-hidden="true"></span> Ajouter une détection</a>
-                                </li>
+                                {% if can_add_fiche_detection %}
+                                    <li>
+                                        <a id="add-detection-link" href="{% url 'sv:fiche-detection-creation' %}?evenement={{ evenement.pk }}" class="fr-tag fr-tag--tertiary fr-mx-1w">
+                                            <span class="fr-icon-add-line" aria-hidden="true"></span> Ajouter une détection</a>
+                                    </li>
+                                {% endif %}
                             </ul>
 
                             {% for fichedetection in evenement.detections.all %}
                                 <div id="detection-actions-{{ fichedetection.pk }}" {% if not fichedetection.pk == active_detection %}class="fr-hidden"{% endif %}>
-                                    <button class="fr-btn fr-btn--delete fr-mr-2w" data-fr-opened="false" aria-controls="fr-modal-delete-detection-{{ fichedetection.pk }}">
-                                        Supprimer la détection
-                                    </button>
-                                    {% include "sv/_delete_fiche_modal.html" with prefix="detection" content_type=fiche_detection_content_type object_pk=fichedetection.pk %}
-                                    <button class="fr-btn fr-btn--secondary">
-                                        <a href="{% url 'sv:fiche-detection-modification' fichedetection.pk %}">Modifier</a>
-                                    </button>
+                                    {% if can_delete_fiche_detection %}
+                                        <button class="fr-btn fr-btn--delete fr-mr-2w" data-fr-opened="false" aria-controls="fr-modal-delete-detection-{{ fichedetection.pk }}">
+                                            Supprimer la détection
+                                        </button>
+                                        {% include "sv/_delete_fiche_modal.html" with prefix="detection" content_type=fiche_detection_content_type object_pk=fichedetection.pk %}
+                                    {% endif %}
+                                    {% if can_update_fiche_detection %}
+                                        <button class="fr-btn fr-btn--secondary">
+                                            <a href="{% url 'sv:fiche-detection-modification' fichedetection.pk %}">Modifier</a>
+                                        </button>
+                                    {% endif %}
                                 </div>
                             {% endfor %}
 

--- a/sv/templates/sv/fichezonedelimitee_detail.html
+++ b/sv/templates/sv/fichezonedelimitee_detail.html
@@ -6,13 +6,17 @@
         {% include "core/_latest_revision.html" with latest_version=fiche.latest_version %}
     </div>
     <div class="fiche-action">
-        <button class="fr-btn fr-btn--delete fr-mr-2w" data-fr-opened="false" aria-controls="fr-modal-delete-zone-{{ fiche.pk }}">
-            Supprimer la zone
-        </button>
-        {% include "sv/_delete_fichezonedelimitee_modal.html" %}
-        <button class="fr-btn fr-btn--secondary fr-mr-2w">
-            <a href="{{ fiche.get_update_url }}"><span class="fr-icon-edit-fill">Modifier</span></a>
-        </button>
+        {% if can_delete_fiche_zone_delimitee %}
+            <button class="fr-btn fr-btn--delete fr-mr-2w" data-fr-opened="false" aria-controls="fr-modal-delete-zone-{{ fiche.pk }}">
+                Supprimer la zone
+            </button>
+            {% include "sv/_delete_fichezonedelimitee_modal.html" %}
+        {% endif %}
+        {% if can_update_fiche_zone_delimitee %}
+            <button class="fr-btn fr-btn--secondary fr-mr-2w">
+                <a href="{{ fiche.get_update_url }}"><span class="fr-icon-edit-fill">Modifier</span></a>
+            </button>
+        {% endif %}
     </div>
 </div>
 

--- a/sv/tests/test_evenement_ac_notification.py
+++ b/sv/tests/test_evenement_ac_notification.py
@@ -30,7 +30,7 @@ def test_can_notify_ac(live_server, page: Page, mailoutbox):
     assert page.text_content(cell_selector) == "Notification à l'administration centrale"
 
     page.get_by_role("button", name="Actions").click()
-    expect(page.get_by_role("button", name="Déclarer à l'AC")).to_be_disabled()
+    expect(page.get_by_role("button", name="Déclarer à l'AC")).not_to_be_visible()
 
     evenement.refresh_from_db()
     assert evenement.is_ac_notified is True
@@ -145,5 +145,29 @@ def test_cant_forge_notify_ac_of_evenement_i_cant_see(client):
     )
 
     assert response.status_code == 403
+    evenement.refresh_from_db()
+    assert evenement.is_ac_notified is False
+
+
+def test_cant_see_notify_ac_btn_if_evenement_is_cloture(live_server, page: Page):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    expect(page.get_by_role("button", name="Actions")).not_to_be_visible()
+    expect(page.get_by_role("button", name="Déclarer à l'AC")).not_to_be_visible()
+
+
+def test_cant_notify_ac_if_evenement_is_cloture(client):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+
+    response = client.post(
+        reverse("notify-ac"),
+        {
+            "next": evenement.get_absolute_url(),
+            "content_id": evenement.id,
+            "content_type_id": ContentType.objects.get_for_model(Evenement).id,
+        },
+    )
+
+    assert response.status_code == 302
     evenement.refresh_from_db()
     assert evenement.is_ac_notified is False

--- a/sv/tests/test_evenement_contact_add.py
+++ b/sv/tests/test_evenement_contact_add.py
@@ -233,3 +233,43 @@ def test_add_contact_agent_without_value_shows_front_error(live_server, page: Pa
 
     validation_message = page.locator("#id_contacts_agents").evaluate("el => el.validationMessage")
     assert validation_message in ["Please select an item in the list.", "Sélectionnez un élément dans la liste."]
+
+
+def test_cant_see_add_contact_form_if_evenement_is_cloturer(live_server, page):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    page.get_by_role("tab", name="Contacts").click()
+
+    expect(page.locator("#add-contact-agent-form")).not_to_be_visible()
+    expect(page.locator("#add-contact-structure-form")).not_to_be_visible()
+
+
+def test_cant_forge_add_agent_if_evenement_is_cloturer(client):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+
+    payload = {
+        "content_type_id": ContentType.objects.get_for_model(evenement).id,
+        "content_id": evenement.pk,
+        "contacts_agents": [Contact.objects.get(agent=ContactAgentFactory().agent)],
+    }
+    response = client.post(reverse("agent-add"), data=payload)
+
+    assert response.status_code == 403
+    evenement.refresh_from_db()
+    assert evenement.contacts.count() == 0
+
+
+def test_cant_forge_add_structure_if_evenement_is_cloturer(client):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+
+    payload = {
+        "content_type_id": ContentType.objects.get_for_model(evenement).id,
+        "content_id": evenement.pk,
+        "contacts_structures": [Contact.objects.get(structure=ContactStructureFactory().structure)],
+    }
+    response = client.post(reverse("structure-add"), data=payload)
+
+    assert response.status_code == 403
+    evenement.refresh_from_db()
+    assert evenement.contacts.count() == 0

--- a/sv/tests/test_evenement_contacts_remove.py
+++ b/sv/tests/test_evenement_contacts_remove.py
@@ -1,10 +1,11 @@
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
-from playwright.sync_api import expect
+from playwright.sync_api import expect, Page
 
 from core.factories import ContactAgentFactory
 from core.models import Structure
 from sv.factories import EvenementFactory
+from sv.models import Evenement
 
 
 def test_can_remove_myself_from_an_evenement(live_server, page, mocked_authentification_user):
@@ -65,3 +66,29 @@ def test_cant_forge_contact_deletion_of_evenement_i_cant_see(client):
 
     assert response.status_code == 403
     assert evenement.contacts.count() == 1
+
+
+def test_cant_see_delete_button_if_evenement_is_cloture(live_server, page: Page):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    page.get_by_role("tab", name="Contacts").click()
+
+    page.get_by_test_id("contacts-structures").get_by_role("link").nth(1)
+    page.get_by_test_id("contacts-agents").get_by_role("link").nth(1)
+
+
+def test_cant_forge_delete_button_if_evenement_is_cloture(client):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+
+    payload = {
+        "fiche_pk": evenement.pk,
+        "content_type_pk": ContentType.objects.get_for_model(evenement).pk,
+        "pk": ContactAgentFactory().pk,
+        "next": evenement.get_absolute_url(),
+    }
+    response = client.post(reverse("contact-delete"), data=payload)
+
+    evenement.refresh_from_db()
+    assert response.status_code == 403
+    assert evenement.contacts.count() == 0

--- a/sv/tests/test_evenement_details.py
+++ b/sv/tests/test_evenement_details.py
@@ -131,6 +131,29 @@ def test_delete_evenement_will_delete_associated_detections(live_server, page):
     assert FicheDetection._base_manager.filter(evenement=evenement).count() == 3
 
 
+def test_delete_button_not_visible_if_evenement_cloture(live_server, page):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    expect(page.get_by_text("Actions")).not_to_be_visible()
+    expect(page.get_by_text("Supprimer l'événement", exact=True)).not_to_be_visible()
+
+
+@pytest.mark.django_db
+def test_cant_delete_if_evenement_is_cloture(client):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+
+    payload = {
+        "content_type_id": ContentType.objects.get_for_model(evenement).id,
+        "content_id": evenement.pk,
+    }
+    response = client.post(reverse("soft-delete"), data=payload)
+
+    evenement.refresh_from_db()
+    assert response.status_code == 302
+    assert evenement.is_deleted is False
+
+
 def test_evenement_can_view_basic_data(live_server, page: Page):
     evenement = EvenementFactory(visibilite=Visibilite.NATIONALE)
     page.goto(f"{live_server.url}{evenement.get_absolute_url()}")

--- a/sv/tests/test_evenement_performance_details.py
+++ b/sv/tests/test_evenement_performance_details.py
@@ -10,7 +10,7 @@ from sv.factories import (
     LieuFactory,
 )
 
-BASE_NUM_QUERIES = 21  # Please note a first call is made without assertion to warm up any possible cache
+BASE_NUM_QUERIES = 20  # Please note a first call is made without assertion to warm up any possible cache
 
 
 @pytest.mark.django_db

--- a/sv/tests/test_evenement_update.py
+++ b/sv/tests/test_evenement_update.py
@@ -265,3 +265,16 @@ def test_fiche_detection_update_cant_forge_form_to_edit_rasff_europhyt(
     evenement.refresh_from_db()
     assert evenement.numero_europhyt == ""
     assert evenement.numero_rasff == ""
+
+
+def test_edit_button_not_visible_if_evenement_cloture(live_server, page: Page):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    expect(page.get_by_role("button", name="Actions")).not_to_be_visible()
+    expect(page.get_by_role("link", name="Modifier l'événement")).not_to_be_visible()
+
+
+def test_cant_access_update_page_if_evenement_cloture(live_server, page: Page):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+    page.goto(f"{live_server.url}{evenement.get_update_url()}")
+    expect(page.get_by_text("Vous n'avez pas le droit d'accéder à cette page.")).to_be_visible()

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -769,3 +769,26 @@ def test_cant_forge_add_fiche_detection_for_evenement_i_cant_see(client):
     assert response.status_code == 403
     evenement.refresh_from_db()
     assert evenement.detections.count() == 0
+
+
+def test_cant_see_add_detection_btn_to_existing_evenement_cloture(live_server, page: Page):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    page.get_by_role("tab", name="Détections")
+    expect(page.get_by_role("link", name="Ajouter une détection")).not_to_be_visible()
+
+
+def test_cant_access_add_detection_form_to_existing_evenement_cloture(client):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+    response = client.get(reverse("sv:fiche-detection-creation"), data={"evenement": evenement.id})
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_cant_add_detection_to_existing_evenement_cloture(client):
+    evenement = EvenementFactory(etat=Evenement.Etat.CLOTURE)
+    response = client.post(
+        reverse("sv:fiche-detection-creation"), data={"evenement": evenement.id, "latest_version": 0}
+    )
+    assert response.status_code == 403
+    assert evenement.detections.count() == 0

--- a/sv/view_mixins.py
+++ b/sv/view_mixins.py
@@ -122,5 +122,5 @@ class WithClotureContextMixin:
         context["is_evenement_can_be_cloturer"] = evenement.can_be_cloturer(
             self.request.user, contacts_not_in_fin_suivi
         )
-        context["is_cloture"] = evenement.is_cloture()
+        context["is_cloture"] = evenement.is_cloture
         return context

--- a/sv/views.py
+++ b/sv/views.py
@@ -158,16 +158,37 @@ class EvenementDetailView(
     def handle_no_permission(self):
         raise PermissionDenied()
 
+    def get_permission_context(self):
+        user = self.request.user
+        return {
+            "can_publish": self.get_object().can_publish(user),
+            "can_update_visibilite": self.get_object().can_update_visibilite(user),
+            "can_be_ac_notified": self.get_object().can_notifiy(user),
+            "can_be_updated": self.get_object().can_be_updated(user),
+            "can_be_deleted": self.get_object().can_be_deleted(user),
+            "can_add_fiche_detection": self.get_object().can_add_fiche_detection(user),
+            "can_delete_fiche_detection": self.get_object().can_delete_fiche_detection(),
+            "can_update_fiche_detection": self.get_object().can_update_fiche_detection(user),
+            "can_delete_fiche_zone_delimitee": self.get_object().can_delete_fiche_zone_delimitee(user),
+            "can_update_fiche_zone_delimitee": self.get_object().can_update_fiche_zone_delimitee(user),
+            "can_add_fiche_zone_delimitee": self.get_object().can_add_fiche_zone_delimitee(user),
+            "can_add_agent": self.get_object().can_add_agent(user),
+            "can_add_structure": self.get_object().can_add_structure(user),
+            "can_delete_contact": self.get_object().can_delete_contact(user),
+            "can_add_document": self.get_object().can_add_document(user),
+            "can_update_document": self.get_object().can_update_document(user),
+            "can_delete_document": self.get_object().can_delete_document(user),
+            "can_download_document": self.get_object().can_download_document(user),
+        }
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context.update(self.get_permission_context())
         content_type = ContentType.objects.get_for_model(self.get_object())
         context["content_type"] = content_type
         context["fiche_detection_content_type"] = ContentType.objects.get_for_model(FicheDetection)
         context["fiche_zone_content_type"] = ContentType.objects.get_for_model(FicheZoneDelimitee)
-        context["can_publish"] = self.get_object().can_publish(self.request.user)
-        context["can_update_visibilite"] = self.get_object().can_update_visibilite(self.request.user)
         context["visibilite_form"] = EvenementVisibiliteUpdateForm(obj=self.get_object())
-        context["can_be_ac_notified"] = self.object.can_notifiy(self.request.user)
         context["latest_version"] = self.object.latest_version
         fiche_zone = self.get_object().fiche_zone_delimitee
         if fiche_zone:
@@ -216,7 +237,7 @@ class EvenementUpdateView(
         return kwargs
 
     def test_func(self) -> bool | None:
-        return self.get_object().can_user_access(self.request.user)
+        return self.get_object().can_be_updated(self.request.user)
 
     def form_valid(self, form):
         response = super().form_valid(form)
@@ -251,9 +272,7 @@ class FicheDetectionCreateView(
         return super().dispatch(request, *args, **kwargs)
 
     def test_func(self):
-        if not self.evenement:
-            return True
-        return self.evenement.can_user_access(self.request.user)
+        return True if not self.evenement else self.evenement.can_add_fiche_detection(self.request.user)
 
     def get_success_url(self):
         return f"{self.object.evenement.get_absolute_url()}?detection={self.object.pk}"
@@ -352,7 +371,7 @@ class FicheDetectionUpdateView(
         return f"{self.object.evenement.get_absolute_url()}?detection={self.object.pk}"
 
     def test_func(self):
-        return self.get_object().evenement.can_user_access(self.request.user)
+        return self.get_object().evenement.can_update_fiche_detection(self.request.user)
 
     def get_object(self, queryset=None):
         if hasattr(self, "object"):
@@ -462,7 +481,7 @@ class EvenementCloturerView(View):
         evenement = content_type.model_class().objects.get(pk=pk)
         redirect_url = evenement.get_absolute_url()
 
-        if evenement.is_already_cloturer():
+        if evenement.is_cloture:
             messages.error(request, f"L'événement n°{evenement.numero} est déjà clôturé.")
             return redirect(redirect_url)
 
@@ -516,7 +535,7 @@ class FicheZoneDelimiteeCreateView(WithFormErrorsAsMessagesMixin, UserPassesTest
     context_object_name = "fiche"
 
     def test_func(self):
-        return self.evenement.can_user_access(self.request.user)
+        return self.evenement.can_add_fiche_zone_delimitee(self.request.user)
 
     def get_success_url(self):
         return reverse("sv:evenement-details", args=[self.object.evenement.numero]) + "?tab=zone"
@@ -629,7 +648,7 @@ class FicheZoneDelimiteeUpdateView(
         return self.get_object().get_absolute_url() + "?tab=zone"
 
     def test_func(self) -> bool | None:
-        return self.get_object().evenement.can_user_access(self.request.user)
+        return self.get_object().can_be_updated(self.request.user)
 
     def get_object(self, queryset=None):
         return super().get_object(
@@ -748,7 +767,7 @@ class FicheZoneDelimiteeDeleteView(UserPassesTestMixin, DeleteView):
     model = FicheZoneDelimitee
 
     def test_func(self):
-        return self.get_object().can_user_delete(self.request.user)
+        return self.get_object().can_be_deleted(self.request.user)
 
     def handle_no_permission(self):
         raise PermissionDenied()


### PR DESCRIPTION
Cette PR permet de restreindre l'accès à certaines actions lorsqu'un évènement est clôturé. Les seules actions qui restent accessibles sont celles liées au fil de suivi.

Ce qui a été fait : 
- dans les modèles `Evenement`, `FicheDetection`, `FicheZoneDelimitee`, ajout de méthodes pour regrouper la logique d'accès à certaines actions,
- dans la view `EvenementDetailView`, ajout de la méthode `get_permission_context`. Permet d'ajouter dans le context les différentes actions possibles d'effectuer,
- modification des templates pour masquer les actions si nécessaire,
- modification de la méthode `test_func` pour différentes view pour invoquer les méthodes ajoutées dans les modèles `Evenement`, `FicheDetection`, `FicheZoneDelimitee`,
- `is_cloture` en property,
- suppression de la méthode `is_already_cloturer` car redondante avec `is_cloture`,
- tests pour tester le masquage des actions dans l'UI et l'impossibilité de forger ces mêmes actions.