### PR TITLE
Remplacement de dj-static par WhiteNoise

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -4,13 +4,12 @@ fileignoreconfig:
 - filename: ssa/models/evenement_produit.py
   checksum: 7ccb261773dbfaf7198e498afaaf320784524d4f50ec9a1096ea516a77695c35
 - filename: seves/settings.py
-  checksum: 462c90d5f00940a51e6fa0f1c176daa4c1a23e0cb14dacb70e0d0a30caecfcf2
+  checksum: 063c3c28e61501ebfd8e8e6c45858d37789b10db143814368117bf01c87f9023
 - filename: ssa/views/produit.py
   checksum: eadd0e65dfa86ad93c0666ab7abafa1f6a0ed07908892e5852324b17ab35797a
 - filename: seves/settings.py
   checksum: 29175afed1b25ca8075dbdeb1d839316d873b9e725b39066fedefa5fd0fbec96
 - filename: ssa/static/ssa/_etablissement_form.js
   checksum: d94c97728a3f7afe71f035d1cb6b6c3155fc74c694d7d24251274b76cb897a1e
-version: "1.0"
 - filename: bin/fetch_contacts_agricoll_and_key.sh
   checksum: 8d190b28dc273aa32259925161d1b26e0749cc1a560a8c75949e03f932db4214

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,6 @@ Django
 django-environ
 psycopg2-binary
 gunicorn
-dj-static
 playwright
 ruff
 pre-commit
@@ -27,3 +26,4 @@ redis
 django-csp
 django-countries
 testcontainers[sftp]
+whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,9 @@ asgiref==3.8.1
     #   django
     #   django-countries
 async-timeout==5.0.1
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   redis
 billiard==4.2.1
     # via celery
 bleach[css]==6.1.0
@@ -54,8 +56,6 @@ cryptography==44.0.1
     #   testcontainers
 distlib==0.3.8
     # via virtualenv
-dj-static==0.0.6
-    # via -r requirements.in
 django==5.1.8
     # via
     #   -r requirements.in
@@ -194,8 +194,6 @@ sqlparse==0.5.3
     # via
     #   django
     #   django-debug-toolbar
-static3==0.7.0
-    # via dj-static
 testcontainers[sftp]==4.10.0
     # via -r requirements.in
 text-unidecode==1.3
@@ -231,6 +229,8 @@ webencodings==0.5.1
     # via
     #   bleach
     #   tinycss2
+whitenoise==6.9.0
+    # via -r requirements.in
 wrapt==1.17.2
     # via testcontainers
 

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -78,6 +78,7 @@ if ADMIN_ENABLED:
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
@@ -181,7 +182,7 @@ if SENTRY_DSN:
 STORAGES = {
     "default": {"BACKEND": env("STORAGE_ENGINE")},
     "staticfiles": {
-        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        "BACKEND": "whitenoise.storage.CompressedStaticFilesStorage",
     },
 }
 AWS_S3_OBJECT_PARAMETERS = {

--- a/seves/wsgi.py
+++ b/seves/wsgi.py
@@ -10,8 +10,7 @@ https://docs.djangoproject.com/en/5.0/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
-from dj_static import Cling
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "seves.settings")
 
-application = Cling(get_wsgi_application())
+application = get_wsgi_application()


### PR DESCRIPTION
- La dépendance dj-static fait fail la CI.
- Ajout de la dépendance WhiteNoise pour servir les fichiers static en production.

![image](https://github.com/user-attachments/assets/60dfcb67-9734-4e57-8a11-9b40cf5735f9)

J'ai ajouté le fichier `.talismanrc` pour l'erreur générée lors de l'execution du hook de precommit suivante : 
`seves/settings.py" failed checks against the pattern ^settings.py$`