### PR TITLE
Ajout ON et statut régl. lecture seule dans form détection

### DIFF
--- a/sv/static/sv/fichedetection_form.css
+++ b/sv/static/sv/fichedetection_form.css
@@ -71,7 +71,9 @@ main {
 #organisme-nuisible,
 #statut-reglementaire,
 #contexte,
-#date-1er-signalement {
+#date-1er-signalement,
+#organisme-nuisible-readonly,
+#statut-reglementaire-readonly {
     display: flex;
     align-items: center;
 }
@@ -97,6 +99,16 @@ main {
 
 #organisme-nuisible .choices {
     flex: 1.42;
+}
+#organisme-nuisible-readonly-label,
+#statut-reglementaire-readonly-label {
+    font-weight: bold;
+}
+#organisme-nuisible-readonly-label {
+    flex: 0.60;
+}
+#statut-reglementaire-readonly-label {
+    flex: 0.95;
 }
 
 

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -71,12 +71,30 @@
                 <div id="objet-evenement">
                     <h2 class="fr-h6">Objet de l'évènement</h2>
 
-                    <p id="organisme-nuisible">
-                        {{ form.organisme_nuisible.label_tag }} {{ form.organisme_nuisible }}
-                    </p>
-                    <p id="statut-reglementaire">
-                        {{ form.statut_reglementaire.label_tag }}{{ form.statut_reglementaire }}
-                    </p>
+                    {% if form.organisme_nuisible %}
+                        <p id="organisme-nuisible">
+                            {{ form.organisme_nuisible.label_tag }} {{ form.organisme_nuisible }}
+                        </p>
+                    {% endif %}
+                    {% if evenement.organisme_nuisible %}
+                        <div id="organisme-nuisible-readonly">
+                            <p id="organisme-nuisible-readonly-label">Organisme nuisible</p>
+                            <p>{{ evenement.organisme_nuisible }}</p>
+                        </div>
+                    {% endif %}
+
+                    {% if form.statut_reglementaire %}
+                        <p id="statut-reglementaire">
+                            {{ form.statut_reglementaire.label_tag }}{{ form.statut_reglementaire }}
+                        </p>
+                    {% endif %}
+                    {% if evenement.statut_reglementaire %}
+                        <div id="statut-reglementaire-readonly">
+                            <p id="statut-reglementaire-readonly-label">Statut réglementaire</p>
+                            <p>{{ evenement.statut_reglementaire }}</p>
+                        </div>
+                    {% endif %}
+
                     <p id="contexte">
                         {{ form.contexte.label_tag }}{{ form.contexte }}
                     </p>

--- a/sv/views.py
+++ b/sv/views.py
@@ -280,6 +280,7 @@ class FicheDetectionCreateView(
             for i in range(0, 10)
         ]
         context["prelevement_forms"] = forms
+        context["evenement"] = self.evenement
         return context
 
     def _get_or_create_evenement(self, request, evenement_form):
@@ -403,6 +404,7 @@ class FicheDetectionUpdateView(
         )
         formset.custom_kwargs = {"convert_required_to_data_required": True}
         context["lieu_formset"] = formset
+        context["evenement"] = self.get_object().evenement
         return context
 
     def get_form_kwargs(self):


### PR DESCRIPTION
Cette PR permet d'ajouter l'organisme nuisible et le statut réglementaire dans le formulaire de la fiche détection lorsque l'évènement existe.
J'ai ajouté une condition d'affichage pour les champs `organisme_nuisible` et `statut_reglementaire` du formulaire pour éviter d'avoir l'espace entre le titre et le premier champ du bloc "Objet de l'évènement".
![image](https://github.com/user-attachments/assets/50abc813-707b-4042-8533-2f8e27fe34de)
