### PR TITLE
Ajout notice et lien vers l'onglet Documents depuis le bloc Cartographies

### DIFF
--- a/sv/static/sv/evenement_details.css
+++ b/sv/static/sv/evenement_details.css
@@ -101,3 +101,6 @@
     background-color: var(--hover-tint) !important;
     border: 1px solid transparent;
 }
+#notice-carto {
+    color: var(--text-default-info);
+}

--- a/sv/static/sv/evenement_details.js
+++ b/sv/static/sv/evenement_details.js
@@ -80,4 +80,9 @@ document.addEventListener('DOMContentLoaded', function() {
             showImage(element, "left")
         })
     })
+    document.querySelectorAll(".bloc-commun-gestion .fr-tabs__tab").forEach(element => {
+        element.addEventListener("click", event => {
+            window.location.hash = event.target.getAttribute("id");
+        });
+    });
 });

--- a/sv/templates/sv/_fichezonedelimitee_cartographies.html
+++ b/sv/templates/sv/_fichezonedelimitee_cartographies.html
@@ -40,5 +40,8 @@
                 {% endfor %}
             </div>
         </div>
+        <p id="notice-carto" class="fr-mt-2w fr-mb-0">
+            <span class="fr-icon-info-fill fr-mr-1w" aria-hidden="true"></span>Vous pouvez ajouter, supprimer ou modifier une cartographie dans l'onglet <a href="#tabpanel-documents-panel">documents</a>.
+        </p>
     </div>
 </div>

--- a/sv/tests/test_evenement_details.py
+++ b/sv/tests/test_evenement_details.py
@@ -365,3 +365,18 @@ def test_detections_are_order_by_detection_number_not_by_id(live_server, page: P
     expect(page.locator("#tabpanel-detection-panel ul > li")).to_contain_text(
         [detection_1.numero, detection_2.numero, detection_3.numero, detection_10.numero]
     )
+
+
+def test_documents_panel_is_visible_when_clicking_on_documents_link_twice(live_server, page: Page):
+    fiche_zone = FicheZoneFactory()
+    evenement = EvenementFactory(fiche_zone_delimitee=fiche_zone)
+    FicheDetectionFactory(evenement=evenement)
+
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+
+    page.get_by_role("tab", name="Zone").click()
+    page.get_by_role("link", name="documents").click()
+    expect(page.get_by_label("Documents")).to_be_visible()
+    page.get_by_test_id("contacts").click()
+    page.get_by_role("link", name="documents").click()
+    expect(page.get_by_label("Documents")).to_be_visible()


### PR DESCRIPTION
- Dans le bloc Cartographie de l'onglet zone, ajout d'une notice d'information avec lien vers l'onglet Documents.
- Ajout du hash d'ID dans l'URL lors du clic sur les onglets
Le système d'onglets ne détectait pas correctement les changements d'URL, ce qui empêchait la navigation entre onglets après avoir cliqué sur le lien documents de la notice (l'event listener sur le hash ne détecte pas de changement d'url).