### PR TITLE
Ajouter un lien dynamique vers rappel conso

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -3,3 +3,5 @@ fileignoreconfig:
   checksum: 4a3cc3b9d5ca2556fe92ff75c8aa339ef5e52aa3e885da682d754df49b0c3aef
 - filename: ssa/models/evenement_produit.py
   checksum: 7ccb261773dbfaf7198e498afaaf320784524d4f50ec9a1096ea516a77695c35
+- filename: seves/settings.py
+  checksum: 462c90d5f00940a51e6fa0f1c176daa4c1a23e0cb14dacb70e0d0a30caecfcf2

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -297,6 +297,7 @@ CSP_CONNECT_SRC = (
     "'self'",
     "geo.api.gouv.fr",
     "api.insee.fr",
+    "data.economie.gouv.fr",
 )
 
 SENTRY_REPORT_URL = env("SENTRY_REPORT_URL")

--- a/ssa/static/ssa/_rappel_conso_link.js
+++ b/ssa/static/ssa/_rappel_conso_link.js
@@ -1,0 +1,15 @@
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll(".rappel-conso-link").forEach(rappel => {
+        fetch(`https://data.economie.gouv.fr/api/records/1.0/search/?dataset=rappelconso-v2-gtin-espaces&refine.numero_fiche=${rappel.innerText}`, {
+            headers: {"Accept": "application/json"}
+        })
+            .then(response => response.json())
+            .then(data => {
+                if (data["nhits"] === 1){
+                    const element = `<a href="https://rappel.conso.gouv.fr/fiche-rappel/${data['records'][0]['fields']['id']}/Interne" class="fr-link" target="_blank">${rappel.innerText}</a>`
+                    rappel.innerHTML = element
+                }
+
+            });
+    });
+})

--- a/ssa/templates/ssa/evenement_produit_detail.html
+++ b/ssa/templates/ssa/evenement_produit_detail.html
@@ -4,6 +4,10 @@
 {% block extrahead %}
   <link rel="stylesheet" href="{% static 'ssa/_etablissement_card.css' %}">
 {% endblock %}
+{% block scripts %}
+  <script type="text/javascript" src="{% static 'ssa/_rappel_conso_link.js' %}"></script>
+{% endblock %}
+
 {% block content %}
   <main class="main-container">
     <div>
@@ -106,7 +110,7 @@
             <div class="white-container">
               <h2 class="fr-h6">Rappel conso</h2>
               {% for numero in object.numeros_rappel_conso %}
-                {{ numero }}
+                <span class="rappel-conso-link fr-mr-1w">{{ numero }}</span>
               {% empty %}
                 nc.
               {% endfor %}


### PR DESCRIPTION
Pour les numéros de rappel conso ajouter dynamiquement un lien vers la bonne fiche si elle est trouvée dans l'API.

Appel réalisé côté frontend pour plusieurs raisons:
- Pas besoin d'authentification
- Possilibité d'avoir plusieurs numéros sur une fiche alors que l'API ne semble gérer qu'un numéro par appel. Il faut donc faire plusieurs appels API ce qui pourrait considérablement ralenti le backend.
- Fonctionnalité qui n'est pas nécessaire au bon fonctionnement de l'application, en cas de problème au niveau de l'API il n'y aura pas d'impact sur le backend.