### PR TITLE
Ajouter l'autocomplete sur les adresses

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -7,3 +7,8 @@ fileignoreconfig:
   checksum: 462c90d5f00940a51e6fa0f1c176daa4c1a23e0cb14dacb70e0d0a30caecfcf2
 - filename: ssa/views/produit.py
   checksum: eadd0e65dfa86ad93c0666ab7abafa1f6a0ed07908892e5852324b17ab35797a
+- filename: seves/settings.py
+  checksum: 29175afed1b25ca8075dbdeb1d839316d873b9e725b39066fedefa5fd0fbec96
+- filename: ssa/static/ssa/_etablissement_form.js
+  checksum: d94c97728a3f7afe71f035d1cb6b6c3155fc74c694d7d24251274b76cb897a1e
+version: "1.0"

--- a/core/static/core/ban_autocomplete.js
+++ b/core/static/core/ban_autocomplete.js
@@ -1,0 +1,51 @@
+export function fetchAddress(query) {
+    return fetch(`https://api-adresse.data.gouv.fr/search/?q=${query}&limit=15`)
+        .then(response => response.json())
+        .then(data => {
+            const results = data["features"].map(item => ({
+                value: item.properties.name,
+                label: item.properties.label,
+                customProperties: {
+                    "inseeCode": item.properties.citycode,
+                    "city": item.properties.city,
+                    "context": item.properties.context
+                }
+            }))
+            return [{
+                value: query,
+                label: `${query} (Forcer la valeur)`,
+                customProperties: {
+                    "inseeCode": null,
+                    "city": null,
+                    "context": null,
+                }
+            }, ...results];
+        })
+        .catch(error => {
+            console.error('Erreur lors de la récupération des données:', error);
+            return []
+        });
+}
+
+export function setUpAddressChoices(element) {
+    const addressCommunes = new Choices(element, {
+        removeItemButton: true,
+        placeholderValue: 'Recherchez...',
+        noResultsText: 'Aucun résultat trouvé',
+        noChoicesText: 'Aucun résultat trouvé',
+        shouldSort: false,
+        searchResultLimit: 10,
+        classNames: {containerInner: 'fr-select'},
+        itemSelectText: '',
+    });
+    addressCommunes.input.element.addEventListener('input', function (event) {
+        const query = addressCommunes.input.element.value
+        if (query.length > 5) {
+            fetchAddress(query).then(results => {
+                addressCommunes.clearChoices()
+                addressCommunes.setChoices(results, 'value', 'label', true)
+            })
+        }
+    })
+    return addressCommunes
+}

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -298,6 +298,7 @@ CSP_CONNECT_SRC = (
     "geo.api.gouv.fr",
     "api.insee.fr",
     "data.economie.gouv.fr",
+    "api-adresse.data.gouv.fr",
 )
 
 SENTRY_REPORT_URL = env("SENTRY_REPORT_URL")

--- a/ssa/forms.py
+++ b/ssa/forms.py
@@ -95,6 +95,7 @@ class EtablissementForm(DSFRForm, forms.ModelForm):
         ),
     )
     code_insee = forms.CharField(widget=forms.HiddenInput(), required=False)
+    adresse_lieu_dit = forms.CharField(widget=forms.Select(), required=False)
     pays = CountryField(blank=True).formfield()
     type_exploitant = SEVESChoiceField(choices=TypeExploitant.choices, label="Type d'exploitant", required=False)
     position_dossier = SEVESChoiceField(

--- a/ssa/static/ssa/_etablissement_form.js
+++ b/ssa/static/ssa/_etablissement_form.js
@@ -1,4 +1,6 @@
-document.documentElement.addEventListener('dsfr.ready', () => {
+import {setUpAddressChoices} from "/static/core/ban_autocomplete.js";
+
+document.addEventListener('DOMContentLoaded', () => {
     function getNextIdToUse() {
         let num = 0
         while (document.getElementById(`id_etablissements-${num}-raison_sociale`)) {
@@ -28,6 +30,18 @@ document.documentElement.addEventListener('dsfr.ready', () => {
                 }
             });
         }, 10)
+
+        const addressChoices = setUpAddressChoices(modal.querySelector('[id$=adresse_lieu_dit]'))
+        addressChoices.passedElement.element.addEventListener("choice", (event)=> {
+            modal.querySelector('[id$=commune]').value = event.detail.customProperties.city
+            modal.querySelector('[id$=code_insee]').value = event.detail.customProperties.inseeCode
+            if (!!event.detail.customProperties.context)
+            {
+                modal.querySelector('[id$=pays]').value = "FR"
+                modal.querySelector('[id$=departement]').value = event.detail.customProperties.context.split(",")[1].trim()
+            }
+        })
+
 
         modal.querySelector("[id^=etablissement-save-btn-]").addEventListener("click", event => {
             event.preventDefault()

--- a/ssa/templates/ssa/evenement_produit_form.html
+++ b/ssa/templates/ssa/evenement_produit_form.html
@@ -8,8 +8,8 @@
 {% block scripts %}
     <script type="text/javascript" src="{% static 'core/forms.js' %}"></script>
     <script type="text/javascript" src="{% static 'ssa/_rappel_conso_form.js' %}"></script>
-    <script type="text/javascript" src="{% static 'ssa/_etablissement_form.js' %}"></script>
     <script type="module" src="{% static 'ssa/evenement_produit_form.js' %}"></script>
+    <script type="module" src="{% static 'ssa/_etablissement_form.js' %}"></script>
 {% endblock %}
 
 {% block content %}

--- a/ssa/tests/test_evenement_produit_creation.py
+++ b/ssa/tests/test_evenement_produit_creation.py
@@ -1,3 +1,5 @@
+import json
+
 from playwright.sync_api import Page, expect
 
 from core.constants import AC_STRUCTURE
@@ -6,7 +8,6 @@ from ssa.factories import EvenementProduitFactory, EtablissementFactory
 from ssa.models import EvenementProduit, Etablissement
 from ssa.models import TypeEvenement, Source
 from ssa.tests.pages import EvenementProduitCreationPage
-
 
 FIELD_TO_EXCLUDE_ETABLISSEMENT = ["_state", "id", "code_insee", "evenement_produit_id"]
 
@@ -244,3 +245,91 @@ def test_cant_add_free_links_for_etat_brouillon(live_server, page: Page, choice_
     creation_page.fill_required_fields(evenement)
     numero = "Événement produit : " + str(evenement_1.numero)
     choice_js_cant_pick(creation_page.page, "#liens-libre .choices", numero, numero)
+
+
+def test_can_create_etablissement_with_ban_auto_complete(live_server, page: Page, choice_js_fill_from_element):
+    evenement = EvenementProduitFactory.build()
+
+    def handle(route):
+        response = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "properties": {
+                        "label": "251 Rue de Vaugirard 75015 Paris",
+                        "name": "251 Rue de Vaugirard",
+                        "citycode": "75115",
+                        "city": "Paris",
+                        "context": "75, Paris, Île-de-France",
+                    }
+                },
+            ],
+        }
+        route.fulfill(status=200, content_type="application/json", body=json.dumps(response))
+
+    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page.navigate()
+    creation_page.fill_required_fields(evenement)
+    creation_page.page.route(
+        "https://api.insee.fr/entreprises/sirene/siret?q=siren%3A120079017*%20AND%20-periode(etatAdministratifEtablissement:F)",
+        handle,
+    )
+
+    creation_page.open_etablissement_modal()
+    creation_page.current_modal_raison_sociale_field.fill("Foo")
+    choice_js_fill_from_element(
+        page, creation_page.current_modal_address_field, "251 Rue de Vaugirard", "251 Rue de Vaugirard 75015 Paris"
+    )
+    creation_page.close_etablissement_modal()
+    creation_page.submit_as_draft()
+    creation_page.page.wait_for_timeout(600)
+
+    etablissement = Etablissement.objects.get()
+    assert etablissement.adresse_lieu_dit == "251 Rue de Vaugirard"
+    assert etablissement.commune == "Paris"
+    assert etablissement.code_insee == "75115"
+    assert etablissement.pays.name == "France"
+    assert etablissement.departement == "Paris"
+
+
+def test_can_create_etablissement_force_ban_auto_complete(live_server, page: Page, choice_js_fill_from_element):
+    evenement = EvenementProduitFactory.build()
+
+    def handle(route):
+        response = {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "properties": {
+                        "label": "251 Rue de Vaugirard 75015 Paris",
+                        "name": "251 Rue de Vaugirard",
+                        "citycode": "75115",
+                        "city": "Paris",
+                        "context": "75, Paris, Île-de-France",
+                    }
+                },
+            ],
+        }
+        route.fulfill(status=200, content_type="application/json", body=json.dumps(response))
+
+    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page.navigate()
+    creation_page.fill_required_fields(evenement)
+    creation_page.page.route(
+        "https://api.insee.fr/entreprises/sirene/siret?q=siren%3A120079017*%20AND%20-periode(etatAdministratifEtablissement:F)",
+        handle,
+    )
+
+    creation_page.open_etablissement_modal()
+    creation_page.current_modal_raison_sociale_field.fill("Foo")
+    creation_page.force_etablissement_adresse("Mon addresse qui n'existe pas")
+    creation_page.close_etablissement_modal()
+    creation_page.submit_as_draft()
+    creation_page.page.wait_for_timeout(600)
+
+    etablissement = Etablissement.objects.get()
+    assert etablissement.adresse_lieu_dit == "Mon addresse qui n'existe pas"
+    assert etablissement.commune == ""
+    assert etablissement.code_insee == ""
+    assert etablissement.pays.name == ""
+    assert etablissement.departement == ""


### PR DESCRIPTION
En utilisant l'API de la BAN on permet l'autocomplétion sur le champ adresse (ajout de la ville, département, etc.).
Permet aussi de forcer la valeur si jamais l'information n'est pas présente dans la BAN et/ou pour des adresses à l'étranger.