### PR TITLE
Filtrer l'accès à la page ÉvénementProduit sur SSA

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -5,3 +5,5 @@ fileignoreconfig:
   checksum: 7ccb261773dbfaf7198e498afaaf320784524d4f50ec9a1096ea516a77695c35
 - filename: seves/settings.py
   checksum: 462c90d5f00940a51e6fa0f1c176daa4c1a23e0cb14dacb70e0d0a30caecfcf2
+- filename: ssa/views/produit.py
+  checksum: eadd0e65dfa86ad93c0666ab7abafa1f6a0ed07908892e5852324b17ab35797a

--- a/ssa/models/evenement_produit.py
+++ b/ssa/models/evenement_produit.py
@@ -167,6 +167,11 @@ class EvenementProduit(WithEtatMixin, WithNumeroMixin, models.Model):
             return None
         return max(versions, key=lambda obj: obj.revision.date_created)
 
+    def can_user_access(self, user):
+        if user.agent.is_in_structure(self.createur):
+            return True
+        return not self.is_draft
+
     class Meta:
         constraints = [
             models.CheckConstraint(

--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -108,7 +108,7 @@ class EvenementProduitDetailsPage:
         self.base_url = base_url
 
     def navigate(self, object):
-        self.page.goto(f"{self.base_url}{object.get_absolute_url()}")
+        return self.page.goto(f"{self.base_url}{object.get_absolute_url()}")
 
     @property
     def title(self):

--- a/ssa/views/produit.py
+++ b/ssa/views/produit.py
@@ -1,4 +1,5 @@
 from django.contrib import messages
+from django.contrib.auth.mixins import UserPassesTestMixin
 from django.http import HttpResponseRedirect, Http404
 from django.views.generic import CreateView, DetailView
 
@@ -56,9 +57,12 @@ class EvenementProduitCreateView(WithFormErrorsAsMessagesMixin, CreateView):
         return context
 
 
-class EvenementProduitDetailView(WithFreeLinksListInContextMixin, DetailView):
+class EvenementProduitDetailView(WithFreeLinksListInContextMixin, UserPassesTestMixin, DetailView):
     model = EvenementProduit
     template_name = "ssa/evenement_produit_detail.html"
+
+    def test_func(self):
+        return self.get_object().can_user_access(self.request.user)
 
     def get_queryset(self):
         return EvenementProduit.objects.all().select_related("createur")


### PR DESCRIPTION
Vérifier que l'utilisateur a bien le droit d'accèder à la fiche.