### PR TITLE
Permettre l'ajout de lien libre sur les fiches produit

### DIFF
--- a/account/forms.py
+++ b/account/forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.contrib.auth import get_user_model
 
 from core.fields import DSFRToogle
-from core.forms import DSFRForm
+from core.form_mixins import DSFRForm
 
 User = get_user_model()
 

--- a/core/filters.py
+++ b/core/filters.py
@@ -2,7 +2,7 @@ import django_filters
 from django.forms import forms
 
 from .models import Document, Structure
-from .forms import DSFRForm
+from .form_mixins import DSFRForm
 
 
 class FilterForm(DSFRForm, forms.Form):

--- a/core/form_mixins.py
+++ b/core/form_mixins.py
@@ -1,0 +1,87 @@
+from collections import defaultdict
+
+from django import forms
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
+
+from core.fields import MultiModelChoiceField
+from core.models import LienLibre
+
+
+class DSFRForm(forms.Form):
+    input_to_class = defaultdict(lambda: "fr-input")
+    input_to_class["ClearableFileInput"] = "fr-upload"
+    input_to_class["Select"] = "fr-select"
+    input_to_class["SelectMultiple"] = "fr-select"
+    input_to_class["SelectWithAttributeField"] = "fr-select"
+    input_to_class["DSFRRadioButton"] = ""
+    input_to_class["DSFRCheckboxSelectMultiple"] = ""
+    manual_render_fields = []
+
+    def get_context(self):
+        context = super().get_context()
+        context["manual_render_fields"] = self.manual_render_fields
+        return context
+
+    def as_dsfr_div(self):
+        return self.render("core/_dsfr_div.html")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.label_suffix = ""
+        for field in self.fields:
+            widget = self.fields[field].widget
+            class_to_add = self.input_to_class[type(widget).__name__]
+            widget.attrs["class"] = widget.attrs.get("class", "") + " " + class_to_add
+
+
+class WithNextUrlMixin:
+    def add_next_field(self, next):
+        if next:
+            self.fields["next"] = forms.CharField(widget=forms.HiddenInput())
+            self.initial["next"] = next
+
+
+class WithContentTypeMixin:
+    def add_content_type_fields(self, obj):
+        if obj:
+            self.fields["content_type"].widget = forms.HiddenInput()
+            self.fields["object_id"].widget = forms.HiddenInput()
+            self.initial["content_type"] = ContentType.objects.get_for_model(obj)
+            self.initial["object_id"] = obj.pk
+
+
+class WithFreeLinksMixin:
+    model_label = "Unknown"
+
+    def save_free_links(self, instance):
+        links_ids_to_keep = []
+        for obj in self.cleaned_data["free_link"]:
+            link = LienLibre.objects.for_both_objects(obj, instance)
+
+            if link:
+                links_ids_to_keep.append(link.id)
+            else:
+                link = LienLibre.objects.create(related_object_1=instance, related_object_2=obj)
+                links_ids_to_keep.append(link.id)
+
+        links_to_delete = LienLibre.objects.for_object(instance).exclude(id__in=links_ids_to_keep)
+        links_to_delete.delete()
+
+    def get_queryset(self, model, user, instance):
+        raise NotImplementedError
+
+    def _add_free_links(self, model):
+        instance = getattr(self, "instance", None)
+        self.fields["free_link"] = MultiModelChoiceField(
+            required=False,
+            label="Sélectionner un objet",
+            model_choices=[
+                (self.model_label, self.get_queryset(model, self.user, instance)),
+            ],
+        )
+
+    def clean_free_link(self):
+        if self.instance and self.instance in self.cleaned_data["free_link"]:
+            raise ValidationError("Vous ne pouvez pas lier un objet a lui-même.")
+        return self.cleaned_data["free_link"]

--- a/core/static/core/free_links.js
+++ b/core/static/core/free_links.js
@@ -1,0 +1,23 @@
+export function setUpFreeLinks(element, dataElement){
+    const freeLinksChoices = new Choices(element, {
+        searchResultLimit: 500,
+        classNames: {
+            containerInner: 'fr-select',
+        },
+        removeItemButton: true,
+        shouldSort: false,
+        itemSelectText: '',
+        noResultsText: 'Aucun résultat trouvé',
+        noChoicesText: 'Aucune fiche à sélectionner',
+        searchFields: ['label'],
+    });
+
+    if (!!dataElement) {
+        const freeLinksIds = JSON.parse(dataElement.textContent);
+        if (!!freeLinksIds) {
+            freeLinksIds.forEach(value => {
+                freeLinksChoices.setChoiceByValue(value);
+            });
+        }
+    }
+}

--- a/core/templates/core/_list_free_links.html
+++ b/core/templates/core/_list_free_links.html
@@ -1,6 +1,6 @@
 {% if free_links_list %}
     <div class="fiche-detail__liens white-container {{ classes }}">
-        <h2 class="fr-h6">Événements en lien libre</h2>
+        <h2 class="fr-h6">{{ title }}</h2>
         {% for link in free_links_list %}
             {% if link.related_object_1 == object and not link.related_object_2.is_deleted %}
                 <a class="fr-link fr-mr-2v" href="{{ link.related_object_2.get_absolute_url }}" target="_blank">{{ link.related_object_2 }}</a>
@@ -8,8 +8,6 @@
             {% if link.related_object_2 == object and not link.related_object_1.is_deleted %}
                 <a class="fr-link fr-mr-2v" href="{{ link.related_object_1.get_absolute_url }}" target="_blank">{{ link.related_object_1 }}</a>
             {% endif %}
-        {% empty %}
-            <p>Pas de lien pour cet événement.</p>
         {% endfor %}
     </div>
 {% endif %}

--- a/ssa/form_mixins.py
+++ b/ssa/form_mixins.py
@@ -1,0 +1,14 @@
+from core.form_mixins import WithFreeLinksMixin
+from ssa.models import EvenementProduit
+
+
+class WithEvenementProduitFreeLinksMixin(WithFreeLinksMixin):
+    model_label = "Événement produit"
+
+    def get_queryset(self, model, user, instance):
+        queryset = (
+            model.objects.all().order_by_numero().get_user_can_view(user).exclude(etat=EvenementProduit.Etat.BROUILLON)
+        )
+        if instance:
+            queryset = queryset.exclude(id=instance.id)
+        return queryset

--- a/ssa/managers.py
+++ b/ssa/managers.py
@@ -1,0 +1,17 @@
+from django.db import models
+from django.db.models import Q
+
+
+class EvenementProduitManager(models.Manager):
+    def get_queryset(self):
+        return EvenementProduitQueryset(self.model, using=self._db).all()
+
+
+class EvenementProduitQueryset(models.QuerySet):
+    def order_by_numero(self):
+        return self.order_by("-numero_annee", "-numero_evenement")
+
+    def get_user_can_view(self, user):
+        from ssa.models import EvenementProduit
+
+        return self.filter(Q(createur=user.agent.structure) | ~Q(etat=EvenementProduit.Etat.BROUILLON))

--- a/ssa/models/evenement_produit.py
+++ b/ssa/models/evenement_produit.py
@@ -7,6 +7,7 @@ from reversion.models import Version
 from core.mixins import WithEtatMixin, WithNumeroMixin
 from core.models import Structure
 from core.versions import get_versions_from_ids
+from ssa.managers import EvenementProduitManager
 from ssa.models.validators import validate_numero_rasff, rappel_conso_validator
 
 
@@ -106,6 +107,8 @@ class EvenementProduit(WithEtatMixin, WithNumeroMixin, models.Model):
     numeros_rappel_conso = ArrayField(
         models.CharField(max_length=12, validators=[rappel_conso_validator]), blank=True, null=True
     )
+
+    objects = EvenementProduitManager()
 
     SOURCES_FOR_HUMAN_CASE = [Source.DO_LISTERIOSE, Source.CAS_GROUPES, Source.TIACS]
 

--- a/ssa/static/ssa/evenement_produit_form.css
+++ b/ssa/static/ssa/evenement_produit_form.css
@@ -51,3 +51,7 @@
 .modal-etablissement input, .modal-etablissement select{
     margin-top: 0.5rem;
 }
+
+#liens-libre input {
+    margin-bottom: 0rem;
+}

--- a/ssa/static/ssa/evenement_produit_form.js
+++ b/ssa/static/ssa/evenement_produit_form.js
@@ -1,4 +1,6 @@
-document.documentElement.addEventListener('dsfr.ready', () => {
+import {setUpFreeLinks} from "/static/core/free_links.js";
+
+document.addEventListener('DOMContentLoaded', () => {
     function disableSourceOptions(typeEvenementInput, sourceInput) {
         const isHumanCase = typeEvenementInput.value === "investigation_cas_humain";
         sourceInput.querySelectorAll('option').forEach(option => {
@@ -15,4 +17,5 @@ document.documentElement.addEventListener('dsfr.ready', () => {
         disableSourceOptions(typeEvenementInput, sourceInput)
     })
     disableSourceOptions(typeEvenementInput, sourceInput)
+    setUpFreeLinks(document.getElementById("id_free_link"), null)
 });

--- a/ssa/templates/ssa/evenement_produit_detail.html
+++ b/ssa/templates/ssa/evenement_produit_detail.html
@@ -143,6 +143,7 @@
             </div>
           </div>
         </div>
+        {% include "core/_list_free_links.html" with classes="fr-mt-4v" object=evenement title="Liaisons" object=object %}
       </div>
     </div>
   </main>

--- a/ssa/templates/ssa/evenement_produit_form.html
+++ b/ssa/templates/ssa/evenement_produit_form.html
@@ -9,7 +9,7 @@
     <script type="text/javascript" src="{% static 'core/forms.js' %}"></script>
     <script type="text/javascript" src="{% static 'ssa/_rappel_conso_form.js' %}"></script>
     <script type="text/javascript" src="{% static 'ssa/_etablissement_form.js' %}"></script>
-    <script type="text/javascript" src="{% static 'ssa/evenement_produit_form.js' %}"></script>
+    <script type="module" src="{% static 'ssa/evenement_produit_form.js' %}"></script>
 {% endblock %}
 
 {% block content %}
@@ -140,6 +140,13 @@
             </div>
 
             {% include "ssa/_etablissement_block.html" %}
+            <div id="liens-libre" class="white-container fr-mt-2w">
+                <h3>Liens libres</h3>
+                <span class="fr-hint-text fr-mb-1w">Pour lier un événement saisissez son numéro ci-dessous.</span>
+                <div>
+                    {{ form.free_link }}
+                </div>
+            </div>
         </main>
     </form>
 

--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -97,6 +97,9 @@ class EvenementProduitCreationPage:
     def delete_etablissement(self, index):
         return self.page.locator(".etablissement-card").nth(index).locator(".etablissement-delete-btn").click()
 
+    def add_free_link(self, numero, choice_js_fill):
+        choice_js_fill(self.page, "#liens-libre .choices", str(numero), "Événement produit : " + str(numero))
+
 
 class EvenementProduitDetailsPage:
     def __init__(self, page: Page, base_url):

--- a/ssa/tests/test_evenement_produit_details_performances.py
+++ b/ssa/tests/test_evenement_produit_details_performances.py
@@ -1,19 +1,37 @@
+from core.models import LienLibre
 from ssa.factories import EvenementProduitFactory, EtablissementFactory
+
+NUMBER_BASE_QUERIES = 6
 
 
 def test_evenement_produit_performances(client, django_assert_num_queries):
     evenement = EvenementProduitFactory()
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(5):
+    with django_assert_num_queries(NUMBER_BASE_QUERIES):
         client.get(evenement.get_absolute_url())
 
     EtablissementFactory(evenement_produit=evenement)
 
-    with django_assert_num_queries(6):
+    with django_assert_num_queries(NUMBER_BASE_QUERIES + 1):
         client.get(evenement.get_absolute_url())
 
     EtablissementFactory.create_batch(3, evenement_produit=evenement)
 
-    with django_assert_num_queries(6):
+    with django_assert_num_queries(NUMBER_BASE_QUERIES + 1):
+        client.get(evenement.get_absolute_url())
+
+
+def test_evenement_produit_performances_with_free_links(client, django_assert_num_queries):
+    evenement = EvenementProduitFactory()
+    client.get(evenement.get_absolute_url())
+
+    with django_assert_num_queries(NUMBER_BASE_QUERIES):
+        client.get(evenement.get_absolute_url())
+
+    LienLibre.objects.create(related_object_1=evenement, related_object_2=EvenementProduitFactory())
+    LienLibre.objects.create(related_object_1=evenement, related_object_2=EvenementProduitFactory())
+    LienLibre.objects.create(related_object_1=evenement, related_object_2=EvenementProduitFactory())
+
+    with django_assert_num_queries(NUMBER_BASE_QUERIES + 6):
         client.get(evenement.get_absolute_url())

--- a/ssa/views/produit.py
+++ b/ssa/views/produit.py
@@ -1,11 +1,11 @@
+from django.contrib import messages
 from django.http import HttpResponseRedirect, Http404
 from django.views.generic import CreateView, DetailView
 
-from core.mixins import WithEtatMixin, WithFormErrorsAsMessagesMixin
+from core.mixins import WithFormErrorsAsMessagesMixin, WithFreeLinksListInContextMixin
 from ssa.forms import EvenementProduitForm
-from ssa.models import EvenementProduit
-from django.contrib import messages
 from ssa.formsets import EtablissementFormSet
+from ssa.models import EvenementProduit
 
 
 class EvenementProduitCreateView(WithFormErrorsAsMessagesMixin, CreateView):
@@ -42,12 +42,7 @@ class EvenementProduitCreateView(WithFormErrorsAsMessagesMixin, CreateView):
         return self.form_valid(form)
 
     def form_valid(self, form):
-        self.object = form.save(commit=False)
-        if self.request.POST.get("action") == "publish":
-            self.object.etat = WithEtatMixin.Etat.EN_COURS
-        self.object.createur = self.request.user.agent.structure
-        self.object.save()
-
+        self.object = form.save()
         self.etablissement_formset.instance = self.object
         self.etablissement_formset.save()
 
@@ -61,7 +56,7 @@ class EvenementProduitCreateView(WithFormErrorsAsMessagesMixin, CreateView):
         return context
 
 
-class EvenementProduitDetailView(DetailView):
+class EvenementProduitDetailView(WithFreeLinksListInContextMixin, DetailView):
     model = EvenementProduit
     template_name = "ssa/evenement_produit_detail.html"
 

--- a/sv/filters.py
+++ b/sv/filters.py
@@ -3,7 +3,7 @@ import re
 import django_filters
 from django.db.models import OuterRef, Exists
 
-from core.forms import DSFRForm
+from core.form_mixins import DSFRForm
 from seves import settings
 from .models import FicheDetection, Region, OrganismeNuisible, Evenement
 from django.forms.widgets import DateInput, TextInput

--- a/sv/forms.py
+++ b/sv/forms.py
@@ -10,9 +10,14 @@ from django.utils.translation import ngettext
 
 from core.constants import AC_STRUCTURE, MUS_STRUCTURE, BSV_STRUCTURE
 from core.fields import DSFRRadioButton, DSFRCheckboxSelectMultiple
-from core.forms import DSFRForm, VisibiliteUpdateBaseForm
+from core.form_mixins import DSFRForm
+from core.forms import VisibiliteUpdateBaseForm
 from core.models import Structure, Visibilite
-from sv.form_mixins import WithDataRequiredConversionMixin, WithFreeLinksMixin, WithLatestVersionLocking
+from sv.form_mixins import (
+    WithDataRequiredConversionMixin,
+    WithLatestVersionLocking,
+    WithEvenementFreeLinksMixin,
+)
 from sv.models import (
     FicheZoneDelimitee,
     ZoneInfestee,
@@ -508,7 +513,7 @@ class EvenementForm(DSFRForm, forms.ModelForm):
         return instance
 
 
-class EvenementUpdateForm(DSFRForm, WithFreeLinksMixin, WithLatestVersionLocking, forms.ModelForm):
+class EvenementUpdateForm(DSFRForm, WithEvenementFreeLinksMixin, WithLatestVersionLocking, forms.ModelForm):
     class Meta:
         model = Evenement
         fields = [

--- a/sv/static/sv/evenement_form.js
+++ b/sv/static/sv/evenement_form.js
@@ -1,3 +1,5 @@
+import {setUpFreeLinks} from "/static/core/free_links.js";
+
 function setUpOrganismeNuisible(){
     const statusToNuisibleId =  JSON.parse(document.getElementById('status-to-organisme-nuisible-id').textContent)
     const element = document.getElementById('id_organisme_nuisible');
@@ -26,29 +28,8 @@ function setUpOrganismeNuisible(){
 }
 
 
-function setUpFreeLinks(){
-    const freeLinksChoices = new Choices(document.getElementById("id_free_link"), {
-        searchResultLimit: 500,
-        classNames: {
-            containerInner: 'fr-select',
-        },
-        removeItemButton: true,
-        shouldSort: false,
-        itemSelectText: '',
-        noResultsText: 'Aucun résultat trouvé',
-        noChoicesText: 'Aucune fiche à sélectionner',
-        searchFields: ['label'],
-    });
-    const freeLinksIds = JSON.parse(document.getElementById('free-links-id').textContent);
-    if (!!freeLinksIds) {
-        freeLinksIds.forEach(value => {
-            freeLinksChoices.setChoiceByValue(value);
-        });
-    }
-}
-
 
 document.addEventListener('DOMContentLoaded', function() {
     setUpOrganismeNuisible()
-    setUpFreeLinks()
+    setUpFreeLinks(document.getElementById("id_free_link"), document.getElementById('free-links-id'))
 });

--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -103,7 +103,7 @@
             </div>
         </div>
 
-        {% include "sv/_list_free_links.html" with classes="fr-mb-4v" object=evenement %}
+        {% include "core/_list_free_links.html" with classes="fr-mb-4v" object=evenement title="Événements en lien libre" %}
 
         <div id="detail-content">
             <div class="fr-tabs">

--- a/sv/templates/sv/evenement_form.html
+++ b/sv/templates/sv/evenement_form.html
@@ -8,8 +8,7 @@
 {% endblock %}
 
 {% block scripts %}
-    <script type="text/javascript" src="{% static 'sv/evenement_form.js' %}"></script>
-
+    <script type="module" src="{% static 'sv/evenement_form.js' %}"></script>
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Dans SSA permettre l'ajout de lien libres à la création de la fiche, les liens peuvent alors être vus depuis la page détails de la fiche.

- Factoriser les forms mixins de core dans un fichier à part
- Factoriser de la logique depuis SV dans core pour pouvoir l'utiliser dans SSA
- Changer le form et la vue pour gérer les liens libres