### PR TITLE
Supprime doublons dans la colonne Commune dans la liste des évènements

### DIFF
--- a/sv/templates/sv/evenement_list.html
+++ b/sv/templates/sv/evenement_list.html
@@ -71,19 +71,19 @@
                                     {{ evenement.createur|truncatechars:30 }}
                                 </td>
                                 <td>
-                                    {% with evenement.all_lieux_with_commune|length as num_lieux %}
-                                        {% if num_lieux == 0 %}
+                                    {% with evenement.communes_uniques|length as nb_communes %}
+                                        {% if nb_communes == 0 %}
                                             nc.
                                         {% endif %}
-                                        {% if num_lieux <= 3 %}
-                                            {% for lieu in evenement.all_lieux_with_commune %}
-                                                {{ lieu.commune|default:"nc." }}{% if not forloop.last %}, {% endif %}
+                                        {% if nb_communes <= 3 %}
+                                            {% for commune in evenement.communes_uniques %}
+                                                {{ commune|default:"nc." }}{% if not forloop.last %}, {% endif %}
                                             {% endfor %}
                                         {% else %}
-                                            {% for lieu in evenement.all_lieux_with_commune|slice:":3" %}
-                                                {{ lieu.commune|default:"nc." }}{% if not forloop.last %}, {% endif %}
+                                            {% for commune in evenement.communes_uniques|slice:":3" %}
+                                                {{ commune|default:"nc." }}{% if not forloop.last %}, {% endif %}
                                             {% endfor %}
-                                            ... +{{ num_lieux|add:"-3" }}
+                                            ... +{{ nb_communes|add:"-3" }}
                                         {% endif %}
                                     {% endwith %}
                                 </td>

--- a/sv/tests/test_evenement_list.py
+++ b/sv/tests/test_evenement_list.py
@@ -1,7 +1,7 @@
 from django.urls import reverse
 from playwright.sync_api import Page, expect
 
-from sv.factories import FicheDetectionFactory, LieuFactory
+from sv.factories import FicheDetectionFactory, LieuFactory, EvenementFactory
 
 
 def test_commune_column_with_multiple_communes(live_server, page: Page):
@@ -36,3 +36,14 @@ def test_commune_column_without_lieu(live_server, page: Page):
     FicheDetectionFactory()
     page.goto(f"{live_server}{reverse('sv:evenement-liste')}")
     expect(page.get_by_text("nc.", exact=True)).to_be_visible()
+
+
+def test_duplicate_commune_appears_only_once(live_server, page: Page):
+    e = EvenementFactory()
+    LieuFactory(commune="La Rochelle", fiche_detection__evenement=e)
+    LieuFactory(commune="La Rochelle", fiche_detection__evenement=e)
+    LieuFactory(commune="Bordeaux", fiche_detection__evenement=e)
+
+    page.goto(f"{live_server}{reverse('sv:evenement-liste')}")
+
+    expect(page.get_by_text("Bordeaux, La Rochelle", exact=True)).to_be_visible()

--- a/sv/views.py
+++ b/sv/views.py
@@ -92,9 +92,12 @@ class EvenementListView(ListView):
             evenement.readable_etat = etat_data["readable_etat"]
 
             evenement.all_lieux_with_commune = []
+            communes_set = set()
             for detection in evenement.detections.all():
-                if hasattr(detection, "lieux_list_with_commune"):
-                    evenement.all_lieux_with_commune.extend(detection.lieux_list_with_commune)
+                lieux = getattr(detection, "lieux_list_with_commune", [])
+                evenement.all_lieux_with_commune.extend(lieux)
+                communes_set.update(lieu.commune for lieu in lieux if lieu.commune)
+            evenement.communes_uniques = communes_set
 
         return context
 


### PR DESCRIPTION
Cette PR permet de supprimer les doublons lorsque qu'un évènement possède une ou plusieurs détections ayant des lieux avec la même commune.