### PR TITLE
Corrige affichage de la date création dans formulaire de fiche détection

### DIFF
--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -60,7 +60,7 @@
                     <div id="informations-content">
                         <div id="date-creation">
                             <label class="fr-label" for="date-creation-input">Date de création</label>
-                            <input type="text" id="date-creation-input" class="fr-input" value="{% now 'd/m/Y' %}" disabled>
+                            <input type="text" id="date-creation-input" class="fr-input" value="{% if form.instance.date_creation %}{{ form.instance.date_creation|date:"d/m/Y" }}{% else %}{% now 'd/m/Y' %}{% endif %}" disabled>
                         </div>
                         <div id="statut-evenement">
                             {{ form.statut_evenement.label_tag }} {{ form.statut_evenement }}

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -22,6 +22,7 @@ from ..factories import (
     DepartementFactory,
     PositionChaineDistributionFactory,
     StructurePreleveuseFactory,
+    FicheDetectionFactory,
 )
 from ..models import (
     FicheDetection,
@@ -132,6 +133,14 @@ def test_date_creation_field_is_current_day(live_server, page: Page, form_elemen
     """Test que la date de création soit egale à la date du jour"""
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
     expect(form_elements.date_creation_input).to_have_value(datetime.now().strftime("%d/%m/%Y"))
+
+
+def test_update_detection_form_show_date_creation(
+    live_server, page: Page, form_elements: FicheDetectionFormDomElements
+):
+    detection = FicheDetectionFactory()
+    page.goto(f"{live_server.url}{detection.get_update_url()}")
+    expect(form_elements.date_creation_input).to_have_value(detection.date_creation.strftime("%d/%m/%Y"))
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Cette PR corrige l'affichage de la date de création dans le formulaire d'une fiche détection.
La date affichait la date du jour même lors de la modification de la fiche.