### PR TITLE
Corrige la date max du 1er signalement dans formulaire fiche détection

### DIFF
--- a/sv/forms.py
+++ b/sv/forms.py
@@ -256,7 +256,7 @@ class FicheDetectionForm(DSFRForm, WithLatestVersionLocking, forms.ModelForm):
     date_premier_signalement = forms.DateField(
         label="Date 1er signalement",
         required=False,
-        widget=forms.DateInput(format="%Y-%m-%d", attrs={"max": datetime.date.today(), "type": "date"}),
+        widget=forms.DateInput(format="%Y-%m-%d", attrs={"type": "date"}),
     )
     statut_reglementaire = forms.ModelChoiceField(
         label="Statut réglementaire", queryset=StatutReglementaire.objects.all(), required=True
@@ -286,6 +286,7 @@ class FicheDetectionForm(DSFRForm, WithLatestVersionLocking, forms.ModelForm):
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user")
         super().__init__(*args, **kwargs)
+        self.fields["date_premier_signalement"].widget.attrs["max"] = datetime.date.today().isoformat()
 
         if (kwargs.get("data") and kwargs.get("data").get("evenement")) or (
             self.instance.pk and self.instance.evenement


### PR DESCRIPTION
## Problème
Scénario à suivre pour reproduire le bug (effectué le 15/04/2025) : 
- Une fiche dont la date de création est le 14/04/2025,
- Je la modifie,
- Date de 1er signalement : je ne peux rentrer qu’une valeur antérieure à 11/04/2025.

La date max du 1er signalement est censé être égale à la date du jour (15/04/2025). Au moment ou j'ai reproduit le bug, je vois que le dernier déploiement date du 11/04/2025.

## Solution
Déplace l'évaluation de `datetime.date.today()` dans la méthode `__init__` du formulaire pour éviter que la date maximum ne soit figée au démarrage du serveur. 
Assure ainsi que la contrainte de date maximale reflète toujours la date courante, quel que soit le moment du dernier déploiement.