### PR TITLE
Fiabiliser des tests

### DIFF
--- a/sv/tests/test_evenement_contact_add.py
+++ b/sv/tests/test_evenement_contact_add.py
@@ -67,12 +67,20 @@ def test_add_multiple_contacts_agents_to_an_evenement(live_server, page, choice_
     page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
     page.get_by_role("tab", name="Contacts").click()
     choice_js_fill(
-        page, "#add-contact-agent-form .choices", contact_agent_1.agent.nom, contact_agent_1.display_with_agent_unit
+        page,
+        "#add-contact-agent-form .choices",
+        contact_agent_1.agent.nom,
+        contact_agent_1.display_with_agent_unit,
+        use_locator_as_parent_element=True,
     )
     page.get_by_role("tab", name="Contacts").click()
     page.wait_for_timeout(1000)
     choice_js_fill(
-        page, "#add-contact-agent-form .choices", contact_agent_2.agent.nom, contact_agent_2.display_with_agent_unit
+        page,
+        "#add-contact-agent-form .choices",
+        contact_agent_2.agent.nom,
+        contact_agent_2.display_with_agent_unit,
+        use_locator_as_parent_element=True,
     )
     page.locator("#add-contact-agent-form").get_by_role("button", name="Ajouter").click()
 

--- a/sv/tests/test_evenement_structure_add.py
+++ b/sv/tests/test_evenement_structure_add.py
@@ -26,9 +26,11 @@ def test_add_structure_form_hides_empty_emails(live_server, page):
     page.get_by_role("tab", name="Contacts").click()
     page.query_selector("#add-contact-structure-form .choices").click()
 
-    expect(page.get_by_label("Ajouter une structure").get_by_role("option", name="Level 1")).to_be_visible()
-    expect(page.get_by_label("Ajouter une structure").get_by_role("option", name="Level 2")).not_to_be_visible()
-    expect(page.get_by_label("Ajouter une structure").get_by_role("option", name="Level 3")).to_be_visible()
+    expect(page.get_by_label("Ajouter une structure").get_by_role("option", name="Level 1", exact=True)).to_be_visible()
+    expect(
+        page.get_by_label("Ajouter une structure").get_by_role("option", name="Level 2", exact=True)
+    ).not_to_be_visible()
+    expect(page.get_by_label("Ajouter une structure").get_by_role("option", name="Level 3", exact=True)).to_be_visible()
 
 
 @pytest.mark.django_db
@@ -41,10 +43,14 @@ def test_add_structure_form_hides_structure_without_active_user(live_server, pag
     page.query_selector("#add-contact-structure-form .choices").click()
 
     expect(
-        page.get_by_label("Ajouter une structure").get_by_role("option", name=str(visible_structure.structure))
+        page.get_by_label("Ajouter une structure").get_by_role(
+            "option", name=str(visible_structure.structure), exact=True
+        )
     ).to_be_visible()
     expect(
-        page.get_by_label("Ajouter une structure").get_by_role("option", name=str(unvisible_structure.structure))
+        page.get_by_label("Ajouter une structure").get_by_role(
+            "option", name=str(unvisible_structure.structure), exact=True
+        )
     ).not_to_be_visible()
 
 


### PR DESCRIPTION
- Dans `test_add_structure_form_hides_structure_without_active_user` il est possible que 2 structures aient un nom similaire (par exemple Thing et Something) ce qui fausse le test.
- Pour `test_add_multiple_contacts_agents_to_an_evenement` rend le sélecteur plus précis.