### PR TITLE
Fiabiliser des tests

### DIFF
--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -90,6 +90,7 @@ class EvenementProduitCreationPage:
         modal.locator('[id$="-quantite_en_stock"]').fill(str(etablissement.quantite_en_stock))
         modal.locator('[id$="-numero_agrement"]').fill(etablissement.numero_agrement)
         modal.locator(".save-btn").click()
+        modal.wait_for(state="hidden", timeout=2_000)
 
     def etablissement_card(self, index=0):
         return self.page.locator(".etablissement-card").nth(index)

--- a/sv/tests/test_fichezonedelimitee_detail.py
+++ b/sv/tests/test_fichezonedelimitee_detail.py
@@ -17,17 +17,20 @@ def test_fichezonedelimitee_with_zoneinfestee_detail(live_server, page: Page, mo
     expect(page.get_by_text(f"{rayon_zone_tampon} {fiche_zone_delimitee.unite_rayon_zone_tampon}")).to_be_visible()
     surface_tampon_totale = str(fiche_zone_delimitee.surface_tampon_totale).rstrip("0").rstrip(".")
     expect(
-        page.get_by_text(f"{surface_tampon_totale} {fiche_zone_delimitee.unite_surface_tampon_totale}")
+        page.get_by_text(f"{surface_tampon_totale} {fiche_zone_delimitee.unite_surface_tampon_totale}", exact=True)
     ).to_be_visible()
     expect(page.get_by_role("link", name=f"{str(fiche_detection_fiche_zone_delimitee.numero)}")).to_be_visible()
-    expect(page.get_by_text(f"{zone_infestee_1.nom}")).to_be_visible()
-    expect(page.get_by_text(f"{zone_infestee_1.get_caracteristique_principale_display()}")).to_be_visible()
+    expect(page.get_by_text(f"{zone_infestee_1.nom}", exact=True)).to_be_visible()
+    expect(page.get_by_text(f"{zone_infestee_1.get_caracteristique_principale_display()}", exact=True)).to_be_visible()
     expect(
-        page.get_by_text(f"{str(zone_infestee_1.rayon).rstrip('0').rstrip('.')} {zone_infestee_1.unite_rayon}")
+        page.get_by_text(
+            f"{str(zone_infestee_1.rayon).rstrip('0').rstrip('.')} {zone_infestee_1.unite_rayon}", exact=True
+        )
     ).to_be_visible()
     expect(
         page.get_by_text(
-            f"{str(zone_infestee_1.surface_infestee_totale).rstrip('0').rstrip('.')} {zone_infestee_1.unite_surface_infestee_totale}"
+            f"{str(zone_infestee_1.surface_infestee_totale).rstrip('0').rstrip('.')} {zone_infestee_1.unite_surface_infestee_totale}",
+            exact=True,
         )
     ).to_be_visible()
     expect(page.get_by_role("link", name=f"{str(fiche_detection_zone_infestee_1.numero)}")).to_be_visible()


### PR DESCRIPTION
- Pour `test_fichezonedelimitee_with_zoneinfestee_detail` il est possible que certains détails de la fiche contiennent un texte similaire (par exemple 32 km2 et 2 km2 pour la surface infestée totale et la surface tampon totale) ce qui fausse le test.
- Pour la modification d'attente du status de la modale je n'ai aucune certitude que cela va fonctionner (le test `test_can_add_and_delete_etablissements` pouvait échouer de manière aléatoire, mais je ne reproduis pas sur 10+ lancements).