### PR TITLE
Corrige problème alignement (ON et statut) dans form fiche detection

### DIFF
--- a/sv/static/sv/fichedetection_form.css
+++ b/sv/static/sv/fichedetection_form.css
@@ -68,49 +68,9 @@ main {
 }
 
 /* Objet de l'évènement */
-#organisme-nuisible,
-#statut-reglementaire,
-#contexte,
-#date-1er-signalement,
-#organisme-nuisible-readonly,
-#statut-reglementaire-readonly {
-    display: flex;
-    align-items: center;
-}
-#organisme-nuisible label,
-#statut-reglementaire label,
-#contexte label {
-    flex: 0.85;
-}
-#organisme-nuisible select,
-#statut-reglementaire select,
-#contexte select {
-    flex: 1.15;
-}
-#date-1er-signalement label {
-    flex: 0.80;
-}
-#date-1er-signalement input {
-    flex: 1.20;
-}
 #id_commentaire {
     min-height: 10rem;
 }
-
-#organisme-nuisible .choices {
-    flex: 1.42;
-}
-#organisme-nuisible-readonly-label,
-#statut-reglementaire-readonly-label {
-    font-weight: bold;
-}
-#organisme-nuisible-readonly-label {
-    flex: 0.60;
-}
-#statut-reglementaire-readonly-label {
-    flex: 0.95;
-}
-
 
 /* Lieux */
 #lieux-header {

--- a/sv/static/sv/fichedetection_form.js
+++ b/sv/static/sv/fichedetection_form.js
@@ -5,7 +5,8 @@ function setUpOrganismeNuisible(){
         classNames: {
             containerInner: 'fr-select',
         },
-        itemSelectText: ''
+        itemSelectText: '',
+        position: 'bottom'
     });
 
     choices.passedElement.element.addEventListener("choice", (event)=> {

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -70,43 +70,46 @@
 
                 <div id="objet-evenement">
                     <h2 class="fr-h6">Objet de l'évènement</h2>
-
-                    {% if form.organisme_nuisible %}
-                        <p id="organisme-nuisible">
-                            {{ form.organisme_nuisible.label_tag }} {{ form.organisme_nuisible }}
-                        </p>
-                    {% endif %}
-                    {% if evenement.organisme_nuisible %}
-                        <div id="organisme-nuisible-readonly">
-                            <p id="organisme-nuisible-readonly-label">Organisme nuisible</p>
-                            <p>{{ evenement.organisme_nuisible }}</p>
+                    <div class="fr-container--fluid">
+                        {% if form.organisme_nuisible %}
+                            <div id="organisme-nuisible" class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+                                <div class="fr-col-12 fr-col-lg-5 required-field">{{ form.organisme_nuisible.label_tag }}</div>
+                                <div class="fr-col">{{ form.organisme_nuisible }}</div>
+                            </div>
+                        {% endif %}
+                        {% if evenement.organisme_nuisible %}
+                            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-1w">
+                                <div class="fr-col-12 fr-col-lg-5 bold">Organisme nuisible</div>
+                                <div class="fr-col">{{ evenement.organisme_nuisible }}</div>
+                            </div>
+                        {% endif %}
+                        {% if form.statut_reglementaire %}
+                            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+                                <div class="fr-col-12 fr-col-lg-5 required-field">{{ form.statut_reglementaire.label_tag }}</div>
+                                <div class="fr-col">{{ form.statut_reglementaire }}</div>
+                            </div>
+                        {% endif %}
+                        {% if evenement.statut_reglementaire %}
+                            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-1w">
+                                <div class="fr-col-12 fr-col-lg-5 bold">Statut réglementaire</div>
+                                <div class="fr-col">{{ evenement.statut_reglementaire }}</div>
+                            </div>
+                        {% endif %}
+                        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+                            <div class="fr-col-12 fr-col-lg-5">{{ form.contexte.label_tag }}</div>
+                            <div class="fr-col">{{ form.contexte }}</div>
                         </div>
-                    {% endif %}
-
-                    {% if form.statut_reglementaire %}
-                        <p id="statut-reglementaire">
-                            {{ form.statut_reglementaire.label_tag }}{{ form.statut_reglementaire }}
-                        </p>
-                    {% endif %}
-                    {% if evenement.statut_reglementaire %}
-                        <div id="statut-reglementaire-readonly">
-                            <p id="statut-reglementaire-readonly-label">Statut réglementaire</p>
-                            <p>{{ evenement.statut_reglementaire }}</p>
+                        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+                            <div class="fr-col-12 fr-col-lg-5">{{ form.date_premier_signalement.label_tag }}</div>
+                            <div class="fr-col">{{ form.date_premier_signalement }}</div>
                         </div>
-                    {% endif %}
-
-                    <p id="contexte">
-                        {{ form.contexte.label_tag }}{{ form.contexte }}
-                    </p>
-                    <p id="date-1er-signalement">
-                        {{ form.date_premier_signalement.label_tag }}{{ form.date_premier_signalement }}
-                    </p>
-                    <p>
-                        {{ form.vegetaux_infestes.label_tag }}{{ form.vegetaux_infestes }}
-                    </p>
-                    <p>
-                        {{ form.commentaire.label_tag }}{{ form.commentaire }}
-                    </p>
+                        <p class="fr-mt-3w">
+                            {{ form.vegetaux_infestes.label_tag }}{{ form.vegetaux_infestes }}
+                        </p>
+                        <p>
+                            {{ form.commentaire.label_tag }}{{ form.commentaire }}
+                        </p>
+                    </div>
                 </div>
 
                 <div id="lieux">

--- a/sv/tests/conftest.py
+++ b/sv/tests/conftest.py
@@ -29,11 +29,11 @@ def prelevement_form_elements(page: Page):
     return PrelevementFormDomElements(page)
 
 
-def check_select_options(page, label, expected_options):
-    options = page.locator(f"label:has-text('{label}') ~ select option").element_handles()
+def check_select_options(page, select_id, expected_options):
+    options = page.locator(f"#{select_id} option").element_handles()
     option_texts = [option.inner_text() for option in options]
     assert option_texts == [settings.SELECT_EMPTY_CHOICE] + expected_options, (
-        f"Les options pour {label} ne correspondent pas aux options attendues"
+        f"Les options pour {select_id} ne correspondent pas aux options attendues"
     )
 
 

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -81,7 +81,7 @@ def test_new_fiche_detection_form_content(live_server, page: Page, form_elements
     expect(form_elements.statut_evenement_input).to_contain_text(settings.SELECT_EMPTY_CHOICE)
     expect(form_elements.statut_evenement_input).to_have_value("")
     statuts_evenement = list(StatutEvenement.objects.values_list("libelle", flat=True))
-    check_select_options(page, "Statut évènement", statuts_evenement)
+    check_select_options(page, "id_statut_evenement", statuts_evenement)
 
     expect(form_elements.organisme_nuisible_label).to_be_visible()
     expect(form_elements.organisme_nuisible_input).to_contain_text(settings.SELECT_EMPTY_CHOICE)
@@ -91,14 +91,14 @@ def test_new_fiche_detection_form_content(live_server, page: Page, form_elements
     expect(form_elements.statut_reglementaire_input).to_contain_text(settings.SELECT_EMPTY_CHOICE)
     expect(form_elements.statut_reglementaire_input).to_have_value("")
     statuts_reglementaire = list(StatutReglementaire.objects.values_list("libelle", flat=True))
-    check_select_options(page, "Statut réglementaire", statuts_reglementaire)
+    check_select_options(page, "id_statut_reglementaire", statuts_reglementaire)
 
     expect(form_elements.contexte_label).to_be_visible()
     expect(form_elements.contexte_input).to_be_visible()
     expect(form_elements.contexte_input).to_contain_text(settings.SELECT_EMPTY_CHOICE)
     expect(form_elements.contexte_input).to_have_value("")
     contextes = list(Contexte.objects.values_list("nom", flat=True))
-    check_select_options(page, "Contexte", contextes)
+    check_select_options(page, "id_contexte", contextes)
 
     expect(form_elements.date_1er_signalement_label).to_be_visible()
     expect(form_elements.date_1er_signalement_input).to_be_visible()


### PR DESCRIPTION
Cette PR corrige un problème d'alignement des champs organisme nuisible et statut réglementaire dans le formulaire de la fiche détection (si évènement existant).