### PR TITLE
Ajoute un deuxième niveau dans le filtre “Région” (formulaire de recherche d'évènements)

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -15,3 +15,24 @@ SSA_STRUCTURES = [
     "SIVEP",
     "BICMA",
 ]
+
+REGION_STRUCTURE_MAPPING = {
+    "Auvergne-Rhône-Alpes": "DRAAF-AUVERGNE-RHONE-ALPES",
+    "Bourgogne-Franche-Comté": "DRAAF-BOURGOGNE-FRANCHE-COMTE",
+    "Bretagne": "DRAAF-BRETAGNE",
+    "Centre-Val de Loire": "DRAAF-CENTRE-VAL-DE-LOIRE",
+    "Corse": "DRAAF-CORSE",
+    "Grand Est": "DRAAF-GRAND-EST",
+    "Hauts-de-France": "DRAAF-HAUTS-DE-FRANCE",
+    "Île-de-France": "DRAAF-ILE-DE-FRANCE",
+    "Normandie": "DRAAF-NORMANDIE",
+    "Nouvelle-Aquitaine": "DRAAF-NOUVELLE-AQUITAINE",
+    "Occitanie": "DRAAF-OCCITANIE",
+    "Pays de la Loire": "DRAAF-PAYS-DE-LA-LOIRE",
+    "Provence-Alpes-Côte d'Azur": "DRAAF-PACA",
+    "Guadeloupe": "DAAF971",
+    "Martinique": "DAAF972",
+    "Guyane": "DAAF973",
+    "La Réunion": "DAAF974",
+    "Mayotte": "DAAF976",
+}

--- a/sv/tests/test_evenement_search.py
+++ b/sv/tests/test_evenement_search.py
@@ -4,6 +4,9 @@ from playwright.sync_api import Page, expect
 
 from core.factories import ContactStructureFactory, ContactAgentFactory
 from core.models import Contact
+from core.constants import REGION_STRUCTURE_MAPPING
+from core.factories import StructureFactory
+from core.models import Visibilite
 from seves import settings
 from ..factories import (
     FicheDetectionFactory,
@@ -167,6 +170,53 @@ def test_search_with_region(live_server, page: Page, mocked_authentification_use
 
     expect(page.get_by_role("cell", name=str(lieu.fiche_detection.evenement.numero))).to_be_visible()
     expect(page.get_by_role("cell", name=str(other_lieu.fiche_detection.evenement.numero))).not_to_be_visible()
+
+
+@pytest.mark.django_db
+def test_search_with_region_structure_mapping(live_server, page: Page) -> None:
+    """Test que le filtre région retourne aussi les événements créés par une structure de la région
+    lorsque les lieux n'ont pas de région spécifiée."""
+    nouvelle_aquitaine = "Nouvelle-Aquitaine"
+    region_nouvelle_aquitaine = RegionFactory(nom=nouvelle_aquitaine)
+    structure_region_nouvelle_aquitaine = REGION_STRUCTURE_MAPPING.get(nouvelle_aquitaine)
+    structure_nouvelle_aquitaine = StructureFactory(
+        niveau2=REGION_STRUCTURE_MAPPING.get(nouvelle_aquitaine), libelle=structure_region_nouvelle_aquitaine
+    )
+
+    # Evenements avec lieu(x)
+    evenement_lieu_sans_region_structure_autre = LieuFactory(departement=None).fiche_detection.evenement
+    evenement_lieu_naq_structure_autre = LieuFactory(
+        departement__region=region_nouvelle_aquitaine
+    ).fiche_detection.evenement
+    evenement_lieu_autre_region_structure_autre = LieuFactory(departement__nom="Finistère").fiche_detection.evenement
+    evenement_lieu_naq_structure_naq = LieuFactory(
+        commune="La Rochelle",
+        departement__nom="Charente-Maritime",
+        fiche_detection__evenement__createur=structure_nouvelle_aquitaine,
+    ).fiche_detection.evenement
+    fiche_detection = FicheDetectionFactory(createur=structure_nouvelle_aquitaine)
+    LieuFactory(fiche_detection=fiche_detection, departement__nom="Finistère", commune="Quimper")
+    LieuFactory(fiche_detection=fiche_detection, departement=None, commune="")
+    evenement_structure_naq = fiche_detection.evenement
+
+    # Evenements sans lieu
+    evenement_sans_lieu_structure_naq = FicheDetectionFactory(createur=structure_nouvelle_aquitaine).evenement
+    evenement_sans_lieu_structure_autre = FicheDetectionFactory().evenement
+    Evenement.objects.update(visibilite=Visibilite.NATIONALE)
+
+    page.goto(f"{live_server.url}{get_fiche_detection_search_form_url()}")
+    page.get_by_label("Région").select_option(str(region_nouvelle_aquitaine.id))
+    page.get_by_role("button", name="Rechercher").click()
+
+    expect(page.get_by_role("cell", name=str(evenement_lieu_sans_region_structure_autre.numero))).not_to_be_visible()
+    expect(page.get_by_role("cell", name=str(evenement_lieu_autre_region_structure_autre.numero))).not_to_be_visible()
+    expect(page.get_by_role("cell", name=str(evenement_sans_lieu_structure_autre.numero))).not_to_be_visible()
+    expect(page.get_by_role("cell", name=str(evenement_lieu_naq_structure_autre.numero))).to_be_visible()
+    expect(page.get_by_role("cell", name=str(evenement_lieu_naq_structure_naq.numero))).to_be_visible()
+    expect(page.get_by_role("cell", name=str(evenement_lieu_naq_structure_naq.numero))).to_have_count(1)
+    expect(page.get_by_role("cell", name=str(evenement_sans_lieu_structure_naq.numero))).to_be_visible()
+    expect(page.get_by_role("cell", name=str(evenement_structure_naq.numero))).to_be_visible()
+    expect(page.locator("body")).to_contain_text("4 sur un total de 4")
 
 
 def test_search_with_organisme_nuisible(live_server, page: Page, mocked_authentification_user, choice_js_fill) -> None:


### PR DESCRIPTION
Problème :
Le filtre “Région” se base sur la commune indiquée dans les lieux. Si aucune commune n’est ajoutée (comme le champ n’est pas obligatoire), alors la fiche ne sera pas remontée avec le filtre région.

Solution :
Ajouter un deuxième niveau dans le filtre “Région” : si la commune est vide dans la fiche, filtrer sur la région de la structure créatrice.

Ce qui a été fait : 
- ajout d'un mapping entre les régions (`nom)` et les structures (`niveau2`) concernées par SV,
- modification de la méthode `filter_region` pour prendre en compte sur le filtre sur la région de la structure créatrice,
- ajout d'un test.