### PR TITLE
Modification du process de clôture d'un évènement

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -288,18 +288,14 @@ class WithEtatMixin(models.Model):
         """Un seul contact sans fin de suivi qui appartient à la structure de l'utilisateur"""
         return len(contacts_not_in_fin_suivi) == 1 and contacts_not_in_fin_suivi[0].structure == user.agent.structure
 
-    def can_be_cloturer(self, user, contacts_not_in_fin_suivi) -> bool:
-        if self.is_draft or self.is_cloture or not self.can_be_cloturer_by(user):
-            return False
-
-        if not contacts_not_in_fin_suivi:
-            return True
-
-        if self.is_the_only_remaining_structure(user, contacts_not_in_fin_suivi):
-            return True
-
-        # Plusieurs contacts sans fin de suivi
-        return False
+    def can_be_cloturer(self, user) -> tuple[bool, str]:
+        if self.is_draft:
+            return False, "L'événement est en brouillon et ne peut pas être clôturé."
+        if self.is_cloture:
+            return False, f"L'événement n°{self.numero} est déjà clôturé."
+        if not self.can_be_cloturer_by(user):
+            return False, "Vous n'avez pas les droits pour clôturer cet événement."
+        return True, ""
 
     def get_publish_success_message(self):
         return "Objet publié avec succès"

--- a/sv/templates/sv/_cloturer_modal.html
+++ b/sv/templates/sv/_cloturer_modal.html
@@ -11,31 +11,30 @@
                             <span class="fr-icon-arrow-right-line fr-icon--lg"></span>
                             Clôturer un événement
                         </h1>
-                        {% if is_evenement_can_be_cloturer %}
-                            <p>Étes-vous sûr.e de vouloir clôturer l'événement {{ evenement.numero }} ?</p>
-                        {% else %}
-                            <p>Vous ne pouvez pas clôturer l'événement n°{{ evenement.numero }} car les structures suivantes n'ont pas signalé la fin de suivi : </p>
+                        {% if contacts_not_in_fin_suivi %}
+                            <p class="fr-mb-2w">Pour information, les structures suivantes n’ont pas signalé la fin de suivi : </p>
                             <ul data-testid="structures-not-in-fin-suivi">
                                 {% for contact in contacts_not_in_fin_suivi %}
                                     <li>{{ contact.structure }}</li>
                                 {% endfor %}
                             </ul>
+                            <p class="fr-mt-3w">Souhaitez-vous tout de même procéder à la clôture de l'événement {{ evenement.numero }} ?</p>
+                        {% else %}
+                            <p>Étes-vous sûr.e de vouloir clôturer l'événement {{ evenement.numero }} ?</p>
                         {% endif %}
                     </div>
-                    {% if is_evenement_can_be_cloturer %}
-                        <div class="fr-modal__footer">
-                            <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
-                                <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-cloturer-evenement">
-                                    Annuler
-                                </button>
-                                <form method="post" action="{% url 'sv:evenement-cloturer' evenement.pk %}">
-                                    {% csrf_token %}
-                                    <input type="hidden" name="content_type_id" value="{{ content_type.pk }}">
-                                    <button type="submit" class="fr-btn">Confirmer la clôture</button>
-                                </form>
-                            </div>
+                    <div class="fr-modal__footer">
+                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                            <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-cloturer-evenement">
+                                Annuler
+                            </button>
+                            <form method="post" action="{% url 'sv:evenement-cloturer' evenement.pk %}">
+                                {% csrf_token %}
+                                <input type="hidden" name="content_type_id" value="{{ content_type.pk }}">
+                                <button type="submit" class="fr-btn">Clôturer</button>
+                            </form>
                         </div>
-                    {% endif %}
+                    </div>
                 </div>
             </div>
         </div>

--- a/sv/templates/sv/_evenement_action_navigation.html
+++ b/sv/templates/sv/_evenement_action_navigation.html
@@ -1,4 +1,4 @@
-{% if can_be_ac_notified or can_update_visibilite or can_be_updated or is_evenement_can_be_cloturer_by_user and not is_cloture or can_be_deleted %}
+{% if can_be_ac_notified or can_update_visibilite or can_be_updated or is_evenement_can_be_cloturer or can_be_deleted %}
     <nav role="navigation" class="fr-translate fr-nav">
         <div class="fr-nav__item">
             <button class="fr-translate__btn fr-btn fr-btn--lg" aria-controls="action-1"
@@ -23,7 +23,7 @@
                     {% if can_be_updated %}
                         <li><a class="fr-translate__language fr-nav__link" href="{{ evenement.get_update_url}}" ><span class="fr-icon-edit-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Modifier l'événement</a></li>
                     {% endif %}
-                    {%  if is_evenement_can_be_cloturer_by_user and not is_cloture %}
+                    {%  if is_evenement_can_be_cloturer %}
                         <li><a class="fr-translate__language fr-nav__link" href="#" data-fr-opened="false" aria-controls="fr-modal-cloturer-evenement"><span class="fr-icon-close-circle-fill fr-mr-2v fr-icon--sm" aria-hidden="true"></span>Clôturer l'événement</a></li>
                     {% endif %}
                     {% if can_be_deleted %}
@@ -38,7 +38,7 @@
 {% if can_update_visibilite %}
     {% include "sv/_update_visibilite_modale.html" %}
 {% endif %}
-{% if is_evenement_can_be_cloturer_by_user and not is_cloture %}
+{% if is_evenement_can_be_cloturer%}
     {% include "sv/_cloturer_modal.html" %}
 {% endif %}
 {% if can_be_deleted %}

--- a/sv/view_mixins.py
+++ b/sv/view_mixins.py
@@ -115,12 +115,7 @@ class WithClotureContextMixin:
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         evenement = self.get_object()
-        context["contacts_not_in_fin_suivi"] = contacts_not_in_fin_suivi = (
-            evenement.get_contacts_structures_not_in_fin_suivi()
-        )
-        context["is_evenement_can_be_cloturer_by_user"] = evenement.can_be_cloturer_by(self.request.user)
-        context["is_evenement_can_be_cloturer"] = evenement.can_be_cloturer(
-            self.request.user, contacts_not_in_fin_suivi
-        )
-        context["is_cloture"] = evenement.is_cloture
+        user = self.request.user
+        context["contacts_not_in_fin_suivi"] = evenement.get_contacts_structures_not_in_fin_suivi()
+        context["is_evenement_can_be_cloturer"], _ = evenement.can_be_cloturer(user)
         return context


### PR DESCRIPTION
Problème :
Aujourd’hui, si l’AC veut clôturer une fiche, il faut que toutes les structures de la fiche aient mis “fin de suivi”.

Ce qui a été fait :
- Suppression de la règle de dépendance de la clôture à la fin de suivi par toutes les structures de la fiche,
- L’AC peut clôturer même si aucune structure n’a mis fin au suivi,
- Modification du message d’avertissement à la clôture,
- Conservation de l'ajout automatique de la structure (MUS ou BSV) en fin de suivi si c'est la seule qui ne l'est pas.