### PR TITLE
Modification titre et wording modale clôture évènement

### DIFF
--- a/sv/templates/sv/_cloturer_modal.html
+++ b/sv/templates/sv/_cloturer_modal.html
@@ -9,18 +9,18 @@
                     <div class="fr-modal__content">
                         <h1 id="fr-modal-cloturer-evenement-title" class="fr-modal__title">
                             <span class="fr-icon-arrow-right-line fr-icon--lg"></span>
-                            Clôturer un événement
+                            Clôturer l'événement {{ evenement.numero }}
                         </h1>
-                        {% if contacts_not_in_fin_suivi %}
+                        {% if contacts_not_in_fin_suivi and not is_the_only_remaining_structure %}
                             <p class="fr-mb-2w">Pour information, les structures suivantes n’ont pas signalé la fin de suivi : </p>
-                            <ul data-testid="structures-not-in-fin-suivi">
+                            <ul class="fr-mb-3w" data-testid="structures-not-in-fin-suivi">
                                 {% for contact in contacts_not_in_fin_suivi %}
                                     <li>{{ contact.structure }}</li>
                                 {% endfor %}
                             </ul>
-                            <p class="fr-mt-3w">Souhaitez-vous tout de même procéder à la clôture de l'événement {{ evenement.numero }} ?</p>
+                            <p>Souhaitez-vous tout de même procéder à la clôture de l'événement {{ evenement.numero }} ?</p>
                         {% else %}
-                            <p>Étes-vous sûr.e de vouloir clôturer l'événement {{ evenement.numero }} ?</p>
+                            <p>Confirmez-vous la clôture de l’événement {{ evenement.numero }} ?</p>
                         {% endif %}
                     </div>
                     <div class="fr-modal__footer">

--- a/sv/tests/test_evenement_etats.py
+++ b/sv/tests/test_evenement_etats.py
@@ -144,13 +144,13 @@ def test_can_cloturer_evenement_if_creator_structure_not_in_fin_suivi(
     page.get_by_role("link", name="Clôturer l'événement").click()
 
     expect(
-        page.get_by_label("Clôturer un événement").get_by_text(
+        page.get_by_label("Clôturer l'événement").get_by_text(
             "Pour information, les structures suivantes n’ont pas signalé la fin de suivi :"
         )
     ).to_be_visible()
-    expect(page.get_by_label("Clôturer un événement").get_by_text(contact_ac.structure.libelle)).to_be_visible()
+    expect(page.get_by_label("Clôturer l'événement").get_by_text(contact_ac.structure.libelle)).to_be_visible()
     expect(
-        page.get_by_label("Clôturer un événement").get_by_text(
+        page.get_by_label("Clôturer l'événement").get_by_text(
             f"Souhaitez-vous tout de même procéder à la clôture de l'événement {evenement.numero} ?"
         )
     ).to_be_visible()
@@ -178,13 +178,13 @@ def test_can_cloturer_evenement_if_on_off_contacts_structures_not_in_fin_suivi(
     page.get_by_role("link", name="Clôturer l'événement").click()
 
     expect(
-        page.get_by_label("Clôturer un événement").get_by_text(
+        page.get_by_label("Clôturer l'événement").get_by_text(
             "Pour information, les structures suivantes n’ont pas signalé la fin de suivi :"
         )
     ).to_be_visible()
-    expect(page.get_by_label("Clôturer un événement").get_by_text(contact2.structure.libelle)).to_be_visible()
+    expect(page.get_by_label("Clôturer l'événement").get_by_text(contact2.structure.libelle)).to_be_visible()
     expect(
-        page.get_by_label("Clôturer un événement").get_by_text(
+        page.get_by_label("Clôturer l'événement").get_by_text(
             f"Souhaitez-vous tout de même procéder à la clôture de l'événement {evenement.numero} ?"
         )
     ).to_be_visible()
@@ -230,6 +230,7 @@ def test_cloture_evenement_auto_fin_suivi_si_derniere_structure_ac(
     page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
     page.get_by_role("button", name="Actions").click()
     page.get_by_role("link", name="Clôturer l'événement").click()
+    expect(page.get_by_text(f"Confirmez-vous la clôture de l’événement {evenement.numero}")).to_be_visible()
     page.get_by_role("button", name="Clôturer").click()
 
     expect(page.get_by_text(f"L'événement n°{evenement.numero} a bien été clôturé.")).to_be_visible()

--- a/sv/tests/test_evenement_performance_details.py
+++ b/sv/tests/test_evenement_performance_details.py
@@ -10,7 +10,7 @@ from sv.factories import (
     LieuFactory,
 )
 
-BASE_NUM_QUERIES = 20  # Please note a first call is made without assertion to warm up any possible cache
+BASE_NUM_QUERIES = 21  # Please note a first call is made without assertion to warm up any possible cache
 
 
 @pytest.mark.django_db

--- a/sv/view_mixins.py
+++ b/sv/view_mixins.py
@@ -116,6 +116,11 @@ class WithClotureContextMixin:
         context = super().get_context_data(**kwargs)
         evenement = self.get_object()
         user = self.request.user
-        context["contacts_not_in_fin_suivi"] = evenement.get_contacts_structures_not_in_fin_suivi()
+        context["contacts_not_in_fin_suivi"] = contacts_structures_not_in_fin_suivi = (
+            evenement.get_contacts_structures_not_in_fin_suivi()
+        )
         context["is_evenement_can_be_cloturer"], _ = evenement.can_be_cloturer(user)
+        context["is_the_only_remaining_structure"] = evenement.is_the_only_remaining_structure(
+            user, contacts_structures_not_in_fin_suivi
+        )
         return context


### PR DESCRIPTION
- modification du titre (ajout du numéro de l'évènement),
- modification du wording si la structure MUS (ou BSV) est la seule qui n’est pas en fin de suivi.