### PR TITLE
Ajout filtres pour structures et agents en contact

### DIFF
--- a/core/filters_mixins.py
+++ b/core/filters_mixins.py
@@ -3,6 +3,9 @@ import re
 import django_filters
 from django.forms.widgets import TextInput
 
+from core.models import Contact, Structure
+from seves import settings
+
 
 class WithNumeroFilterMixin(django_filters.FilterSet):
     numero = django_filters.CharFilter(
@@ -48,3 +51,37 @@ class WithNumeroFilterMixin(django_filters.FilterSet):
         if len(parts) == 2:
             return queryset.filter(numero_annee=int(parts[0]), numero_evenement=int(parts[1]))
         return queryset
+
+
+class WithStructureContactFilterMixin(django_filters.FilterSet):
+    structure_contact = django_filters.ModelChoiceFilter(
+        label="Structure en contact",
+        queryset=(
+            Contact.objects.structures_only()
+            .filter(structure__in=Structure.objects.can_be_contacted())
+            .order_by("structure__libelle")
+            .select_related("structure")
+        ),
+        empty_label=settings.SELECT_EMPTY_CHOICE,
+        method="filter_structure_contact",
+    )
+
+    def filter_structure_contact(self, queryset, name, value):
+        return queryset.filter(contacts=value)
+
+
+class WithAgentContactFilterMixin(django_filters.FilterSet):
+    agent_contact = django_filters.ModelChoiceFilter(
+        label="Agent en contact",
+        queryset=(
+            Contact.objects.agents_only()
+            .can_be_emailed()
+            .select_related("agent", "agent__structure")
+            .order_by_structure_and_name()
+        ),
+        empty_label=settings.SELECT_EMPTY_CHOICE,
+        method="filter_agent_contact",
+    )
+
+    def filter_agent_contact(self, queryset, name, value):
+        return queryset.filter(contacts=value)

--- a/sv/filters.py
+++ b/sv/filters.py
@@ -3,12 +3,14 @@ from django.db.models import OuterRef, Exists
 from django.forms.widgets import DateInput
 
 from core.form_mixins import DSFRForm
-from core.filters_mixins import WithNumeroFilterMixin
+from core.filters_mixins import WithNumeroFilterMixin, WithStructureContactFilterMixin, WithAgentContactFilterMixin
 from seves import settings
 from .models import FicheDetection, Region, OrganismeNuisible, Evenement
 
 
-class EvenementFilter(WithNumeroFilterMixin, django_filters.FilterSet):
+class EvenementFilter(
+    WithNumeroFilterMixin, WithStructureContactFilterMixin, WithAgentContactFilterMixin, django_filters.FilterSet
+):
     region = django_filters.ModelChoiceFilter(
         label="Région", queryset=Region.objects.all(), empty_label=settings.SELECT_EMPTY_CHOICE, method="filter_region"
     )
@@ -40,6 +42,10 @@ class EvenementFilter(WithNumeroFilterMixin, django_filters.FilterSet):
             "etat",
         ]
         form = DSFRForm
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.form.manual_render_fields = ["structure_contact", "agent_contact"]
 
     def filter_organisme_nuisible(self, queryset, name, value):
         return queryset.filter(organisme_nuisible__libelle_court__startswith=value).distinct()

--- a/sv/static/sv/evenement_list.js
+++ b/sv/static/sv/evenement_list.js
@@ -1,5 +1,12 @@
 document.addEventListener('DOMContentLoaded', function() {
-    const choices = new Choices(document.getElementById('id_organisme_nuisible'), {
+    const choicesOrganismeNuisible = new Choices(document.getElementById('id_organisme_nuisible'), {
+        classNames: {
+            containerInner: 'fr-select',
+        },
+        itemSelectText: ''
+    });
+
+    const choicesAgentContact = new Choices(document.getElementById('id_agent_contact'), {
         classNames: {
             containerInner: 'fr-select',
         },
@@ -14,7 +21,9 @@ document.addEventListener('DOMContentLoaded', function() {
         this.elements['start_date'].value = '';
         this.elements['end_date'].value = '';
         this.elements['etat'].value = '';
-        choices.setChoiceByValue('');
+        choicesOrganismeNuisible.setChoiceByValue('');
+        this.elements['structure_contact'].value = '';
+        choicesAgentContact.setChoiceByValue('');
         e.target.closest("form").submit();
     });
 

--- a/sv/templates/sv/evenement_list.html
+++ b/sv/templates/sv/evenement_list.html
@@ -1,6 +1,7 @@
 {% extends 'sv/base.html' %}
 {% load static %}
 {% load etat_tags %}
+{% load render_field %}
 
 {% block extrahead %}
     <link rel="stylesheet" href="{% static 'sv/evenement_list.css' %}">
@@ -19,6 +20,14 @@
             <h2 class="fr-h3">Rechercher un évènement</h2>
             <div class="evenements__search-form">
                 {{ filter.form.as_dsfr_div }}
+            </div>
+            <div class="evenements__search-form">
+                <div class="fr-fieldset__element">
+                    {% render_field filter.form.structure_contact %}
+                </div>
+                <div class="fr-fieldset__element">
+                    {% render_field filter.form.agent_contact %}
+                </div>
             </div>
             <div class="fr-fieldset__element evenement__header--actions">
                 <button type="reset" class="fr-btn fr-btn--tertiary-no-outline fr-mr-2w">Effacer</button>

--- a/sv/tests/test_fiche_list_performances.py
+++ b/sv/tests/test_fiche_list_performances.py
@@ -9,13 +9,13 @@ def test_list_detection_performance(client, django_assert_num_queries, mocked_au
     FicheDetectionFactory()
     client.get(reverse("sv:evenement-liste"))
 
-    with django_assert_num_queries(8):
+    with django_assert_num_queries(10):
         client.get(reverse("sv:evenement-liste"))
 
     for _ in range(0, 5):
         FicheDetectionFactory()
 
-    with django_assert_num_queries(8):
+    with django_assert_num_queries(10):
         client.get(reverse("sv:evenement-liste"))
 
 
@@ -25,11 +25,11 @@ def test_list_zone_performance(client, django_assert_num_queries, mocked_authent
     url = reverse("sv:evenement-liste")
     client.get(url)
 
-    with django_assert_num_queries(7):
+    with django_assert_num_queries(9):
         client.get(url)
 
     for _ in range(0, 5):
         EvenementFactory(fiche_zone_delimitee=FicheZoneFactory())
 
-    with django_assert_num_queries(7):
+    with django_assert_num_queries(9):
         client.get(url)


### PR DESCRIPTION
Ajout de deux filtres supplémentaire dans le formulaire de recherche d'évènements :
- Structure en contact : récupère les évènements dont dans la structure sélectionnée est dans la liste des contacts
- Agent en contact : récupère les évènements dont dans l'agent sélectionné est dans la liste des contacts