### PR TITLE
Modification du wording du toggle “détail/synthèse”

### DIFF
--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -40,7 +40,7 @@
                             <div class="fr-segmented__elements">
                                 <div class="fr-segmented__element">
                                     <input value="detail" checked type="radio" id="detail-btn" name="segmented-2215">
-                                    <label class="fr-label" for="detail-btn"><i class="ri-expand-vertical-fill fr-mr-1w"></i>Détail</label>
+                                    <label class="fr-label" for="detail-btn"><i class="ri-expand-vertical-fill fr-mr-1w"></i>Affichage détaillé</label>
                                 </div>
                                 <div class="fr-segmented__element">
                                     <input value="synthese" type="radio" id="synthese-btn" name="segmented-2215">


### PR DESCRIPTION
Modification du wording du toggle sur SV par “Affichage détaillé/Synthèse” au lieu de “Détail/Synthèse”