### PR TITLE
Corrige problème affichage onglet documents

### DIFF
--- a/core/templates/core/_documents.html
+++ b/core/templates/core/_documents.html
@@ -1,13 +1,13 @@
 <div class="fr-container--fluid fr-mb-4w" id="documents">
     <div class="fr-grid-row">
-        <div class="fr-col-8 fr-col-xl-4">
+        <div class="fr-col-8 fr-col-xl-5">
             <form method="get" action="#tabpanel-documents-panel" class="documents__filters">
                 {{ document_filter.form.as_dsfr_div }}
                 <p class="fr-my-2w fr-ml-2w"> <button type="submit" class="fr-btn" data-testid="documents-filter">Filtrer</button></p>
             </form>
 
         </div>
-        <div class="fr-col-1 fr-col-xl-5"></div>
+        <div class="fr-col-1 fr-col-xl-4"></div>
         {% if can_add_document %}
             <div class="fr-col-3">
                 <div class="fr-btns-group--right fr-mt-3w">


### PR DESCRIPTION
Corrige un problème d'affichage dans l'onglet document (champs type de document et structure) lorsque le formulaire d'ajout de message est affiché.

Avant :
![image](https://github.com/user-attachments/assets/c46eafc0-56a2-4f36-ae10-c32bdbd50e6f)

Après :
![image](https://github.com/user-attachments/assets/48f64794-71ae-4ddc-8266-8b73d94c2427)
