### PR TITLE
Pouvoir rouvrir un événement clôturé

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -22,16 +22,8 @@ from core.forms import (
 )
 from .constants import BSV_STRUCTURE, MUS_STRUCTURE
 from .filters import DocumentFilter
-from core.models import (
-    Document,
-    LienLibre,
-    Contact,
-    Message,
-    Visibilite,
-    Structure,
-    FinSuiviContact,
-    user_is_referent_national,
-)
+from core.models import user_is_referent_national
+from core.models import Document, LienLibre, Contact, Message, Visibilite, Structure, FinSuiviContact, User
 from .notifications import notify_message
 from .redirect import safe_redirect
 from celery.exceptions import OperationalError
@@ -362,6 +354,12 @@ class WithEtatMixin(models.Model):
         if not self.can_be_cloturer_by(user):
             return False, "Vous n'avez pas les droits pour clôturer cet événement."
         return True, ""
+
+    def can_ouvrir(self, user: User):
+        """Vérifie si l'évènement peut être ouvert (repasser dans l'état EN COURS)"""
+        if self.is_cloture:
+            return user.agent.structure.is_ac
+        return False
 
     def get_publish_success_message(self):
         return "Objet publié avec succès"

--- a/core/templates/core/_ouvrir_evenement_modal.html
+++ b/core/templates/core/_ouvrir_evenement_modal.html
@@ -1,0 +1,30 @@
+<dialog aria-labelledby="fr-annuler-cloture-modal-title" id="fr-annuler-cloture-modal" class="fr-modal" role="dialog" >
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button class="fr-btn--close fr-btn" aria-controls="fr-annuler-cloture-modal">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 id="fr-annuler-cloture-modal-title" class="fr-modal__title">
+                            <span class="fr-icon-arrow-right-line fr-icon--lg"></span>
+                            Ouvrir l'évènement
+                        </h1>
+                        <p>L’événement {{ evenement.numero }} est clôturé. Souhaitez-vous ouvrir de nouveau cet événement ?</p>
+                    </div>
+                    <div class="fr-modal__footer">
+                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg">
+                            <button class="fr-btn fr-btn--secondary" aria-controls="fr-annuler-cloture-modal">Annuler</button>
+                            <form method="post" action="{% url 'evenement-ouvrir' evenement.pk %}">
+                                {% csrf_token %}
+                                <input type="hidden" name="content_type_id" value="{{ content_type.pk }}">
+                                <button type="submit" class="fr-btn">Confirmer</button>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/core/urls.py
+++ b/core/urls.py
@@ -12,6 +12,7 @@ from .views import (
     StructureAddView,
     AgentAddView,
     CloturerView,
+    EvenementOuvrirView,
 )
 
 urlpatterns = [
@@ -79,5 +80,10 @@ urlpatterns = [
         "cloturer/<int:pk>",
         CloturerView.as_view(),
         name="cloturer",
+    ),
+    path(
+        "evenement/<int:pk>/ouvrir/",
+        EvenementOuvrirView.as_view(),
+        name="evenement-ouvrir",
     ),
 ]

--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -62,6 +62,10 @@
                                 Publier l'événement</button>
                         </form>
                     {% endif %}
+                    {% if can_ouvrir %}
+                        <button class="fr-btn" data-fr-opened="false" aria-controls="fr-annuler-cloture-modal">Ouvrir l'évènement</button>
+                        {% include "core/_ouvrir_evenement_modal.html" %}
+                    {% endif %}
                     {% include "sv/_evenement_action_navigation.html" %}
                 </div>
             </div>

--- a/sv/views.py
+++ b/sv/views.py
@@ -175,6 +175,7 @@ class EvenementDetailView(
             "can_be_ac_notified": self.get_object().can_notifiy(user),
             "can_be_updated": self.get_object().can_be_updated(user),
             "can_be_deleted": self.get_object().can_be_deleted(user),
+            "can_ouvrir": self.get_object().can_ouvrir(user),
             "can_add_fiche_detection": self.get_object().can_add_fiche_detection(user),
             "can_delete_fiche_detection": self.get_object().can_delete_fiche_detection(),
             "can_update_fiche_detection": self.get_object().can_update_fiche_detection(user),


### PR DESCRIPTION
Ajout d'une action permettant de repasser l'évènement dans l'état EN_COURS. 
Seule l'AC peut effectuer cette action. 
Sa fin de suivi est aussi supprimé.