### PR TITLE
Changer la couleur des tags d'états

### DIFF
--- a/core/templatetags/etat_tags.py
+++ b/core/templatetags/etat_tags.py
@@ -6,8 +6,6 @@ register = template.Library()
 # https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/badge
 ETATS_COLORS = {
     "en_cours": "success",  # Vert
-    "cloture": "error",  # Rouge
-    "fin de suivi": "warning",  # Orange
 }
 
 


### PR DESCRIPTION
L'idée est de ne faire ressortir le tag que quand l'événement est en cours / doit être suivi.