### PR TITLE
Permettre le clic uniquement sur la croix de rappel conso

### DIFF
--- a/ssa/static/ssa/evenement_produit_form.css
+++ b/ssa/static/ssa/evenement_produit_form.css
@@ -48,6 +48,13 @@
 #rappel-3 {
     width: 8ch;
 }
+#rappel-container .fr-tag{
+    pointer-events: none;
+}
+#rappel-container .fr-tag:after{
+    pointer-events: auto;
+    cursor: pointer;
+}
 .modal-etablissement input, .modal-etablissement select{
     margin-top: 0.5rem;
 }

--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -66,7 +66,9 @@ class EvenementProduitCreationPage:
         self.numero_rappel_submit.click()
 
     def delete_rappel_conso(self, numero):
-        self.page.locator(".fr-tag", has_text=numero).click()
+        tag = self.page.locator(".fr-tag", has_text=numero)
+        box = tag.bounding_box()
+        self.page.mouse.click(box["x"] + box["width"] - 15, box["y"] - 5 + box["height"] / 2)
 
     def add_etablissement_with_required_fields(self, etablissement: Etablissement):
         modal = self.open_etablissement_modal()


### PR DESCRIPTION
Sur les tag de rappel conso, ne faire disparaitre le numéro uniquement au clic sur la croix et pas sur l'ensemble du tag.