### PR TITLE
Améliorer le reset du formulaire de recherche sur SSA

### DIFF
--- a/ssa/static/ssa/evenement_produit_list.js
+++ b/ssa/static/ssa/evenement_produit_list.js
@@ -1,0 +1,8 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const searchForm = document.getElementById('search-form')
+    searchForm.addEventListener('reset', function (e) {
+        e.preventDefault()
+        resetForm(searchForm)
+        searchForm.submit()
+    });
+});

--- a/ssa/templates/ssa/evenementproduit_list.html
+++ b/ssa/templates/ssa/evenementproduit_list.html
@@ -4,6 +4,10 @@
 {% block extrahead %}
     <link rel="stylesheet" href="{% static 'ssa/evenement_produit_list.css' %}">
 {% endblock %}
+{% block scripts %}
+    <script type="text/javascript" src="{% static 'core/forms.js' %}"></script>
+    <script type="text/javascript" src="{% static 'ssa/evenement_produit_list.js' %}"></script>
+{% endblock %}
 {% block content %}
     <form id="search-form" method="get" >
         <div class="fr-p-4v evenements_liste__header">

--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -230,3 +230,6 @@ class EvenementProduitListPage:
 
     def submit_search(self):
         return self.page.locator("#search-form").get_by_text("Rechercher", exact=True).click()
+
+    def reset_search(self):
+        return self.page.locator("#search-form").get_by_text("Effacer", exact=True).click()

--- a/ssa/tests/test_evenement_produit_list.py
+++ b/ssa/tests/test_evenement_produit_list.py
@@ -107,3 +107,18 @@ def test_list_can_filter_by_date(live_server, mocked_authentification_user, page
     assert search_page.numero_cell().text_content() == "2025.2"
     expect(search_page.page.get_by_text("2025.1")).not_to_be_visible()
     expect(search_page.page.get_by_text("2025.3")).not_to_be_visible()
+
+
+def test_list_can_reset_form_after_search(live_server, mocked_authentification_user, page: Page):
+    EvenementProduitFactory(numero_annee=2024, numero_evenement=22)
+    search_page = EvenementProduitListPage(page, live_server.url)
+    search_page.navigate()
+
+    search_page.numero_field.fill("2025")
+    search_page.submit_search()
+    expect(search_page.page.get_by_text("2024.22")).not_to_be_visible()
+
+    search_page.reset_search()
+    search_page.page.wait_for_timeout(600)
+    expect(search_page.page.get_by_text("2024.22")).to_be_visible()
+    expect(search_page.numero_field).to_have_value("")


### PR DESCRIPTION
Faire fonctionner le bouton de reset aussi quand les champs sont déjà remplis au chargement de la page (par exemple quand une recherche a déjà été faite). On copie le comportement que l'on a sur SV.