### PR TITLE
Corrige le bug d'envoi de message si on quitte la modale confirmation

### DIFF
--- a/core/static/core/message_form.js
+++ b/core/static/core/message_form.js
@@ -184,6 +184,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const typeInput = document.getElementById('id_document_type');
     const inputDestination = document.getElementById("inputs-for-upload")
     const extensionsInfoSpan = document.getElementById("allowed-extensions-list");
+    const submitButton = document.getElementById("message-send-btn");
 
     typeInput.addEventListener("change", () => onDocumentTypeChange(typeInput, fileInput, messageAddDocumentButton, extensionsInfoSpan));
     fileInput.addEventListener("change", () => onFileInputChange(fileInput, typeInput, messageAddDocumentButton));
@@ -212,7 +213,7 @@ document.addEventListener('DOMContentLoaded', function () {
         })
     })
 
-    document.getElementById("message-send-btn").addEventListener("click", event =>{
+    submitButton.addEventListener("click", event =>{
         event.preventDefault()
         const messageForm = document.getElementById("message-form")
 
@@ -241,5 +242,8 @@ document.addEventListener('DOMContentLoaded', function () {
         document.getElementById("message-add-document").click()
         document.getElementById("message-form").submit()
     })
+    document.getElementById("fr-modal-document-confirmation").addEventListener("dsfr.disclose", event => {
+        submitButton.disabled = false;
+    });
 
 });


### PR DESCRIPTION
Problème:
Si je quitte la modale de confirmation d'envoi de message (car ajout de document non validé), le bouton d'envoi de message est disabled.

Ce qui a été fait:
- Ajout d'un listener sur la fermeture de la modale sans envoi du message pour réactiver le bouton d'envoi du message,
- Ajout d'un test.