### PR TITLE
Améliorer le comportement post-login des domaines

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -6,7 +6,7 @@ fileignoreconfig:
 - filename: ssa/views/produit.py
   checksum: eadd0e65dfa86ad93c0666ab7abafa1f6a0ed07908892e5852324b17ab35797a
 - filename: seves/settings.py
-  checksum: 22c9a6b9a273361223a5c2a18fe48240719ead29479cbbc027066504ff92e67f
+  checksum: f1ae9c53f63a76423b0cfdd093b725c0bd2ffd5da5ea60c5a2f13a07287d6608
 - filename: ssa/static/ssa/_etablissement_form.js
   checksum: d94c97728a3f7afe71f035d1cb6b6c3155fc74c694d7d24251274b76cb897a1e
 - filename: bin/fetch_contacts_agricoll_and_key.sh

--- a/seves/middlewares.py
+++ b/seves/middlewares.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied
+from django.shortcuts import redirect
 from django.urls import resolve
 
 
@@ -33,7 +34,28 @@ class LoginAndGroupRequiredMiddleware:
         if needed_group:
             request.domain = match.app_name
             if needed_group in user.groups.values_list("name", flat=True):
-                return self.get_response(request)
+                response = self.get_response(request)
+                response.set_cookie("preferred_domain", match.app_name)
+                return response
             raise PermissionDenied()
 
+        return self.get_response(request)
+
+
+class HomeRedirectMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.user.is_authenticated and request.path == "/":
+            groups = request.user.groups.values_list("name", flat=True)
+            preferred_domain = request.COOKIES.get("preferred_domain")
+            if preferred_domain == "ssa" and settings.SSA_GROUP in groups:
+                return redirect("ssa:evenement-produit-liste")
+            if preferred_domain == "sv" and settings.SV_GROUP in groups:
+                return redirect("sv:evenement-liste")
+            if settings.SSA_GROUP in groups:
+                return redirect("ssa:evenement-produit-liste")
+            if settings.SV_GROUP in groups:
+                return redirect("sv:evenement-liste")
         return self.get_response(request)

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -86,6 +86,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "seves.middlewares.LoginAndGroupRequiredMiddleware",
+    "seves.middlewares.HomeRedirectMiddleware",
     "reversion.middleware.RevisionMiddleware",
     "csp.middleware.CSPMiddleware",
 ]

--- a/sv/tests/test_access.py
+++ b/sv/tests/test_access.py
@@ -1,13 +1,14 @@
 import pytest
 from django.contrib.auth.models import Group
 from django.core.exceptions import PermissionDenied
+from django.http import HttpResponse
 from django.urls import reverse
 from unittest.mock import MagicMock
 from core.factories import UserFactory
 from django.test import RequestFactory
 
 from seves import settings
-from seves.middlewares import LoginAndGroupRequiredMiddleware
+from seves.middlewares import LoginAndGroupRequiredMiddleware, HomeRedirectMiddleware
 
 
 @pytest.mark.django_db
@@ -41,3 +42,34 @@ def test_ok_sv_pages_needs_to_be_in_sv_group_to_be_accessed():
     get_response = MagicMock()
     middleware = LoginAndGroupRequiredMiddleware(get_response)
     middleware.__call__(request)
+
+
+@pytest.mark.django_db
+def test_redirect_to_sv_if_preferred_domain_when_user_in_both_groups():
+    user = UserFactory()
+    sv_group, _ = Group.objects.get_or_create(name=settings.SV_GROUP)
+    ssa_group, _ = Group.objects.get_or_create(name=settings.SSA_GROUP)
+    user.groups.add(ssa_group, sv_group)
+
+    request = RequestFactory().get("/")
+    request.user = user
+    request.COOKIES["preferred_domain"] = "sv"
+
+    response = HomeRedirectMiddleware(lambda request: HttpResponse("OK"))(request)
+    assert response.status_code == 302
+    assert response.url == reverse("sv:evenement-liste")
+
+
+@pytest.mark.django_db
+def test_redirect_to_ssa_per_default():
+    user = UserFactory()
+    sv_group, _ = Group.objects.get_or_create(name=settings.SV_GROUP)
+    ssa_group, _ = Group.objects.get_or_create(name=settings.SSA_GROUP)
+    user.groups.add(ssa_group, sv_group)
+
+    request = RequestFactory().get("/")
+    request.user = user
+
+    response = HomeRedirectMiddleware(lambda request: HttpResponse("OK"))(request)
+    assert response.status_code == 302
+    assert response.url == reverse("ssa:evenement-produit-liste")


### PR DESCRIPTION
- Si un utilisateur peut voir les deux domaines, le rediriger en priorité vers SSA (plus d'activité que sur SV).
- Si un utilisateur consulte un domaine, le ramener post login sur ce prochain domaine par défaut (ne concerne que les utilisateurs qui peuvent voir plusieurs domaines).