### PR TITLE
Améliorer les tests des établissements SSA

### DIFF
--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -1,3 +1,6 @@
+import json
+from urllib.parse import quote
+
 from django.urls import reverse
 from playwright.sync_api import Page
 
@@ -95,7 +98,17 @@ class EvenementProduitCreationPage:
         self.current_modal.locator(".save-btn").click()
         self.current_modal.wait_for(state="hidden", timeout=2_000)
 
-    def force_etablissement_adresse(self, adresse):
+    def force_etablissement_adresse(self, adresse, mock_call=False):
+        if mock_call:
+
+            def handle(route):
+                route.fulfill(status=200, content_type="application/json", body=json.dumps({"features": []}))
+
+            self.page.route(
+                f"https://api-adresse.data.gouv.fr/search/?q={quote(adresse)}&limit=15",
+                handle,
+            )
+
         self.current_modal_address_field.click()
         self.page.wait_for_selector("input:focus", state="visible", timeout=2_000)
         self.page.locator("*:focus").fill(adresse)
@@ -107,7 +120,7 @@ class EvenementProduitCreationPage:
         modal.locator('[id$="siret"]').fill(etablissement.siret)
         modal.locator('[id$="-numero_agrement"]').fill(etablissement.numero_agrement)
         modal.locator('[id$="raison_sociale"]').fill(etablissement.raison_sociale)
-        self.force_etablissement_adresse(etablissement.adresse_lieu_dit)
+        self.force_etablissement_adresse(etablissement.adresse_lieu_dit, mock_call=True)
         modal.locator('[id$="-commune"]').fill(etablissement.commune)
         modal.locator('[id$="-departement"]').select_option(etablissement.departement)
         modal.locator('[id$="-pays"]').select_option(etablissement.pays.code)

--- a/ssa/tests/test_evenement_produit_creation.py
+++ b/ssa/tests/test_evenement_produit_creation.py
@@ -247,6 +247,7 @@ def test_cant_add_free_links_for_etat_brouillon(live_server, page: Page, choice_
 
 def test_can_create_etablissement_with_ban_auto_complete(live_server, page: Page, choice_js_fill_from_element):
     evenement = EvenementProduitFactory.build()
+    call_count = {"count": 0}
 
     def handle(route):
         response = {
@@ -264,12 +265,13 @@ def test_can_create_etablissement_with_ban_auto_complete(live_server, page: Page
             ],
         }
         route.fulfill(status=200, content_type="application/json", body=json.dumps(response))
+        call_count["count"] += 1
 
     creation_page = EvenementProduitCreationPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(evenement)
     creation_page.page.route(
-        "https://api.insee.fr/entreprises/sirene/siret?q=siren%3A120079017*%20AND%20-periode(etatAdministratifEtablissement:F)",
+        "https://api-adresse.data.gouv.fr/search/?q=251%20Rue%20de%20Vaugirard&limit=15",
         handle,
     )
 
@@ -278,6 +280,7 @@ def test_can_create_etablissement_with_ban_auto_complete(live_server, page: Page
     choice_js_fill_from_element(
         page, creation_page.current_modal_address_field, "251 Rue de Vaugirard", "251 Rue de Vaugirard 75015 Paris"
     )
+    assert call_count["count"] == 1
     creation_page.close_etablissement_modal()
     creation_page.submit_as_draft()
     creation_page.page.wait_for_timeout(600)
@@ -292,6 +295,7 @@ def test_can_create_etablissement_with_ban_auto_complete(live_server, page: Page
 
 def test_can_create_etablissement_force_ban_auto_complete(live_server, page: Page, choice_js_fill_from_element):
     evenement = EvenementProduitFactory.build()
+    call_count = {"count": 0}
 
     def handle(route):
         response = {
@@ -309,18 +313,20 @@ def test_can_create_etablissement_force_ban_auto_complete(live_server, page: Pag
             ],
         }
         route.fulfill(status=200, content_type="application/json", body=json.dumps(response))
+        call_count["count"] += 1
 
     creation_page = EvenementProduitCreationPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(evenement)
     creation_page.page.route(
-        "https://api.insee.fr/entreprises/sirene/siret?q=siren%3A120079017*%20AND%20-periode(etatAdministratifEtablissement:F)",
+        "https://api-adresse.data.gouv.fr/search/?q=Mon%20addresse%20qui%20n%27existe%20pas&limit=15",
         handle,
     )
 
     creation_page.open_etablissement_modal()
     creation_page.current_modal_raison_sociale_field.fill("Foo")
     creation_page.force_etablissement_adresse("Mon addresse qui n'existe pas")
+    assert call_count["count"] == 1
     creation_page.close_etablissement_modal()
     creation_page.submit_as_draft()
     creation_page.page.wait_for_timeout(600)


### PR DESCRIPTION
- Corrections des tests existants qui n'utilisaient pas le mock défini et ajout d'une assertion pour plus que cela n'arrive
- Utilisation d'un mock pour tous les autres tests où une adresse fictive est forcée de manière a faire moins d'appels réseau et fiabiliser les tests