### PR TITLE
Améliorer les performances de l'authentification

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -6,7 +6,7 @@ fileignoreconfig:
 - filename: ssa/views/produit.py
   checksum: eadd0e65dfa86ad93c0666ab7abafa1f6a0ed07908892e5852324b17ab35797a
 - filename: seves/settings.py
-  checksum: f1ae9c53f63a76423b0cfdd093b725c0bd2ffd5da5ea60c5a2f13a07287d6608
+  checksum: 65c7cfe88aa40072834b2aa1735924bc7e414baf09932cd687526c5f7f4c2866
 - filename: ssa/static/ssa/_etablissement_form.js
   checksum: d94c97728a3f7afe71f035d1cb6b6c3155fc74c694d7d24251274b76cb897a1e
 - filename: bin/fetch_contacts_agricoll_and_key.sh

--- a/seves/auth.py
+++ b/seves/auth.py
@@ -1,0 +1,15 @@
+from mozilla_django_oidc.auth import OIDCAuthenticationBackend
+
+
+class CustomOIDCBackend(OIDCAuthenticationBackend):
+    def get_user(self, user_id):
+        """Return a user based on the id."""
+        try:
+            return (
+                self.UserModel.objects.filter(pk=user_id)
+                .select_related("agent", "agent__structure")
+                .prefetch_related("groups")
+                .first()
+            )
+        except self.UserModel.DoesNotExist:
+            return None

--- a/seves/context_processors.py
+++ b/seves/context_processors.py
@@ -17,7 +17,7 @@ def environment_class(request):
 
 
 def domains(request):
-    user_groups = request.user.groups.values_list("name", flat=True)
+    user_groups = [g.name for g in request.user.groups.all()]
     sv_domain = {"icon": "fr-icon-leaf-line", "nom": "Santé des végétaux", "url": reverse_lazy("sv:evenement-liste")}
     ssa_domain = {
         "icon": "fr-icon-restaurant-line ",

--- a/seves/middlewares.py
+++ b/seves/middlewares.py
@@ -33,7 +33,7 @@ class LoginAndGroupRequiredMiddleware:
         needed_group = self.apps_to_groups.get(match.app_name)
         if needed_group:
             request.domain = match.app_name
-            if needed_group in user.groups.values_list("name", flat=True):
+            if needed_group in [g.name for g in user.groups.all()]:
                 response = self.get_response(request)
                 response.set_cookie("preferred_domain", match.app_name)
                 return response
@@ -48,7 +48,7 @@ class HomeRedirectMiddleware:
 
     def __call__(self, request):
         if request.user.is_authenticated and request.path == "/":
-            groups = request.user.groups.values_list("name", flat=True)
+            groups = [g.name for g in request.user.groups.all()]
             preferred_domain = request.COOKIES.get("preferred_domain")
             if preferred_domain == "ssa" and settings.SSA_GROUP in groups:
                 return redirect("ssa:evenement-produit-liste")

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -210,7 +210,7 @@ if all(
 elif environ.Env(TEMP_STORAGE=(bool, False)):
     STORAGES["default"]["OPTIONS"] = {"location": tempfile.mkdtemp()}
 
-AUTHENTICATION_BACKENDS = ("mozilla_django_oidc.auth.OIDCAuthenticationBackend",)
+AUTHENTICATION_BACKENDS = ("seves.auth.CustomOIDCBackend",)
 LOGIN_URL = reverse_lazy("login")
 OIDC_RP_CLIENT_ID = env("OIDC_RP_CLIENT_ID")
 OIDC_RP_CLIENT_SECRET = env("OIDC_RP_CLIENT_SECRET")


### PR DESCRIPTION
Lors du processus d'authentification / identification récupérer l'agent et la structure de l'agent ainsi que les groupes de l'utilisateur. Cela permet de gagner plusieurs requêtes sur chaque page (agent et structure sont utilisés partout dans le code, les groupes sont utilisés aussi à plusieurs endroits).

Cela ne se reflète pas dans les tests car la partie auth est complétement mocké.
En local sur la vue de liste de SV je passe de 16 requetes à 12 requetes.

⚠️  Les utilisateurs seront déconnecté lors du déploiement de se commit a cause du changement de "nom" du backend.