### PR TITLE
Améliorer la sortie de la page de permissions

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -6,7 +6,7 @@ fileignoreconfig:
 - filename: ssa/views/produit.py
   checksum: eadd0e65dfa86ad93c0666ab7abafa1f6a0ed07908892e5852324b17ab35797a
 - filename: seves/settings.py
-  checksum: 65c7cfe88aa40072834b2aa1735924bc7e414baf09932cd687526c5f7f4c2866
+  checksum: e1570ab4d3ada7c6372ea53cf7e998d894b74f2278853a7c74f5e0bb8d730a73
 - filename: ssa/static/ssa/_etablissement_form.js
   checksum: d94c97728a3f7afe71f035d1cb6b6c3155fc74c694d7d24251274b76cb897a1e
 - filename: bin/fetch_contacts_agricoll_and_key.sh

--- a/account/static/account/permissions.js
+++ b/account/static/account/permissions.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', function() {
+    document.getElementById("cancel-link").addEventListener("click", (event) => {
+        event.preventDefault();
+        window.location = document.referrer;
+    });
+});

--- a/account/templates/user_permissions.html
+++ b/account/templates/user_permissions.html
@@ -4,7 +4,9 @@
 {% block extrahead %}
     <link rel="stylesheet" href="{% static 'account/base.css' %}">
 {% endblock %}
-
+{% block scripts %}
+    <script type="text/javascript" src="{% static 'account/permissions.js' %}"></script>
+{% endblock %}
 
 {% block content %}
     <div class="fr-container fr-pt-4w">
@@ -20,6 +22,8 @@
                 </div>
                 {% csrf_token %}
                 <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-mt-2w">
+                    <input type="hidden" name="next" value="{{ request.META.HTTP_REFERER }}">
+                    <button id="cancel-link" class="fr-btn fr-btn--secondary">Annuler</button>
                     <button class="fr-btn" type="submit">Enregistrer les modifications</button>
                 </div>
             </form>

--- a/account/views.py
+++ b/account/views.py
@@ -1,21 +1,19 @@
+from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
-from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import PermissionDenied
-from django.urls import reverse_lazy
 from django.views.generic import FormView
 
 from account.forms import UserPermissionForm
+from core.redirect import safe_redirect
 from seves import settings
 
 User = get_user_model()
 
 
-class HandlePermissionsView(SuccessMessageMixin, FormView):
+class HandlePermissionsView(FormView):
     form_class = UserPermissionForm
     template_name = "user_permissions.html"
-    success_url = reverse_lazy("handle-permissions")
-    success_message = "Modification de droits enregistrées sur Sèves Santé des végétaux"
 
     def dispatch(self, request, *args, **kwargs):
         user_groups = request.user.groups.values_list("name", flat=True)
@@ -60,4 +58,5 @@ class HandlePermissionsView(SuccessMessageMixin, FormView):
             user.is_active = value
             user.save()
             user.groups.add(sv_group)
-        return super().form_valid(form)
+        messages.success(self.request, "Modification de droits enregistrées sur Sèves Santé des végétaux")
+        return safe_redirect(self.request.POST.get("next"))

--- a/core/redirect.py
+++ b/core/redirect.py
@@ -1,9 +1,10 @@
+from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.utils.http import url_has_allowed_host_and_scheme
 
 
 def safe_redirect(url):
-    if not url_has_allowed_host_and_scheme(url, allowed_hosts=None):
+    if not url_has_allowed_host_and_scheme(url, allowed_hosts=settings.ALLOWED_HOSTS):
         url = reverse("index")
     return HttpResponseRedirect(url)

--- a/core/templates/core/base.html
+++ b/core/templates/core/base.html
@@ -50,30 +50,32 @@
                             </div>
                             <div class="product-switch">
                                 {% block product %}
-                                    {% if other_domains|length == 0 %}
-                                        <a href="{{ current_domain.url }}" class="fr-tag {{ current_domain.icon }} fr-tag--icon-left">
-                                            {{ current_domain.nom }}
-                                        </a>
-                                    {% else %}
-                                        <nav role="navigation" class="fr-translate fr-nav">
-                                            <div class="fr-nav__item">
-                                                <button class="fr-translate__btn fr-btn fr-btn--tertiary fr-tag fr-tag--icon-left"
-                                                        aria-controls="domain-picker" aria-expanded="false"
-                                                        title="Sélectionner un produit">
-                                                    <span class="{{ current_domain.icon }} fr-icon--sm fr-pr-1w" ></span>
-                                                    {{ current_domain.nom }}</button>
-                                                <div class="fr-collapse fr-translate__menu fr-menu" id="domain-picker">
-                                                    <ul class="fr-menu__list">
-                                                        {% for domain in other_domains %}
-                                                            <li class="fr-mt-1w">
-                                                                <a class="fr-translate__language fr-nav__link fr-tag" href="{{ domain.url }}" >
-                                                                    <span class="{{ domain.icon }} fr-icon--sm fr-pr-1w" ></span>
-                                                                    {{ domain.nom }}</a></li>
-                                                        {% endfor %}
-                                                    </ul>
+                                    {% if current_domain %}
+                                        {% if other_domains|length == 0 %}
+                                            <a href="{{ current_domain.url }}" class="fr-tag {{ current_domain.icon }} fr-tag--icon-left">
+                                                {{ current_domain.nom }}
+                                            </a>
+                                        {% else %}
+                                            <nav role="navigation" class="fr-translate fr-nav">
+                                                <div class="fr-nav__item">
+                                                    <button class="fr-translate__btn fr-btn fr-btn--tertiary fr-tag fr-tag--icon-left"
+                                                            aria-controls="domain-picker" aria-expanded="false"
+                                                            title="Sélectionner un produit">
+                                                        <span class="{{ current_domain.icon }} fr-icon--sm fr-pr-1w" ></span>
+                                                        {{ current_domain.nom }}</button>
+                                                    <div class="fr-collapse fr-translate__menu fr-menu" id="domain-picker">
+                                                        <ul class="fr-menu__list">
+                                                            {% for domain in other_domains %}
+                                                                <li class="fr-mt-1w">
+                                                                    <a class="fr-translate__language fr-nav__link fr-tag" href="{{ domain.url }}" >
+                                                                        <span class="{{ domain.icon }} fr-icon--sm fr-pr-1w" ></span>
+                                                                        {{ domain.nom }}</a></li>
+                                                            {% endfor %}
+                                                        </ul>
+                                                    </div>
                                                 </div>
-                                            </div>
-                                        </nav>
+                                            </nav>
+                                        {% endif %}
                                     {% endif %}
 
 

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -44,7 +44,7 @@ SECRET_KEY = env("SECRET_KEY")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env("DEBUG")
 
-ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["127.0.0.1", "localhost"])
+ALLOWED_HOSTS = env.list("ALLOWED_HOSTS", default=["127.0.0.1", "127.0.0.1:8000", "localhost"])
 
 # Django admin URL
 ADMIN_ENABLED = env("DJANGO_ADMIN_ENABLED")


### PR DESCRIPTION
Permet de sortir proprement de la page de permission:
- A l'aide d'un bouton annuler qui redirige vers la page précédente
- Lors de la validation du formulaire ramener sur la page précédente a condition que celle-ci fasse parti de SEVES

Dans la fonction `safe_redirect` on ne passait que des URLs relatives, nous n'avions donc pas besoin d'autoriser des domaines, avec une URL complète le changement de `allowed_hosts` est nécessaire.