### PR TITLE
Corrige bug d'ajout commune dans un lieu existant

### DIFF
--- a/sv/static/sv/fichedetection_lieux_form.js
+++ b/sv/static/sv/fichedetection_lieux_form.js
@@ -189,12 +189,7 @@ function configureSiretField(field){
 
     document.querySelector("#add-lieu-bouton").addEventListener("click", showLieuModal)
     document.querySelectorAll(".lieu-save-btn").forEach(button => button.addEventListener("click", saveLieu))
-    document.querySelectorAll("[id^=commune-select-]").forEach(communeSelect =>{
-        const communeField = communeSelect.parentNode.parentNode.querySelector('[id$="-commune"]')
-        if (!!communeField.value){
-            setUpCommune(communeSelect)
-        }
-    })
+    document.querySelectorAll("[id^=commune-select-]").forEach(communeSelect => setUpCommune(communeSelect));
     document.getElementById("delete-lieu-confirm-btn").addEventListener("click", deleteLieu)
     document.querySelectorAll("[id^=modal-add-lieu-]").forEach(modal => modal.addEventListener('dsfr.disclose', saveModalWhenOpening))
     document.querySelectorAll("[id^=modal-add-lieu-] .fr-btn--close").forEach(element => element.addEventListener("click", closeDSFRModal))

--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -1194,3 +1194,22 @@ def test_cant_update_detection_if_evenement_is_cloture(client):
     assert response.status_code == 403
     fiche_detection.refresh_from_db()
     assert fiche_detection.commentaire != "AAAA"
+
+
+@pytest.mark.django_db
+def test_can_add_commune_to_existing_lieu(
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    fill_commune,
+):
+    lieu = LieuFactory(commune="")
+    page.goto(f"{live_server.url}{lieu.fiche_detection.get_update_url()}")
+    page.get_by_role("button", name="Modifier le lieu").click()
+    fill_commune(page)
+    lieu_form_elements.save_btn.click()
+    form_elements.save_update_btn.click()
+
+    lieu.refresh_from_db()
+    assert lieu.commune == "Lille"


### PR DESCRIPTION
Problème:
Si je souhaite ajouter une commune sur un lieu existant, le champ Commune ne fonctionne pas. Pour reproduire le bug :
- Créer une fiche détection avec un lieu mais sans commune
- Allez sur le formulaire de modification de la fiche détection
- Ouvrir la modale correspond au lieu
- Le champ commune ne fonctionne pas

![image](https://github.com/user-attachments/assets/7fc2fffc-d953-438c-94f2-be08196a84db)
