### PR TITLE
Modification actions de publication d'un évènement

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -15,3 +15,5 @@ fileignoreconfig:
   checksum: 62b3a8a26bcb7a4ee9f8c73e92241093690212cfce216acf640079bfb36dcdfc
 - filename: ssa/static/ssa/_rappel_conso_form.js
   checksum: eaddd88cdb839b7592fb59aad23f27f727999f50f90a073e0ec7bc4673c411d0
+- filename: core/views.py
+  checksum: b54379a22a0229e85ae27aeaf50d2b6931289fb8dbe521b0d3b68e88fc21b2b2

--- a/core/static/core/base.css
+++ b/core/static/core/base.css
@@ -190,8 +190,6 @@ label:has(+ .choices select[data-required="true"])::after,
     flex-wrap: wrap;
 }
 .details-top-row--actions {
-    display: flex;
-    justify-content: space-between;
     max-height: 2.5rem;
 }
 .details-top-row--actions .fr-translate__btn::before {

--- a/core/templates/core/_publier_and_notifier_ac_modal.html
+++ b/core/templates/core/_publier_and_notifier_ac_modal.html
@@ -1,0 +1,32 @@
+<dialog aria-labelledby="fr-modal-publier-and-notifier-ac-title" id="fr-modal-publier-and-notifier-ac" class="fr-modal" role="dialog" >
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button class="fr-btn--close fr-btn" aria-controls="fr-modal-publier-and-notifier-ac">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 id="fr-modal-publier-and-notifier-ac-title" class="fr-modal__title">
+                            <span class="fr-icon-arrow-right-line fr-icon--lg"></span>
+                            Notifier à l'AC l'événement
+                        </h1>
+                        <p>Un message automatique va être envoyé à l'administration centrale pour l'informer de cette notification. Confirmez-vous la déclaration de cet événement ?</p>
+                    </div>
+                    <div class="fr-modal__footer">
+                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg">
+                            <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-publier-and-notifier-ac">Annuler</button>
+                            <form action="{% url 'publish-and-ac-notification' %}" method="post">
+                                {% csrf_token %}
+                                <input type="hidden" value="{{ evenement.get_absolute_url }}" name="next">
+                                <input type="hidden" value="{{ content_type.id }}" name="content_type_id">
+                                <input type="hidden" value="{{ evenement.pk }}" name="content_id">
+                                <input type="submit" class="fr-btn" value="Publier et déclarer à l'AC"/>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/core/templates/core/_publier_without_notifier_ac_modal.html
+++ b/core/templates/core/_publier_without_notifier_ac_modal.html
@@ -1,0 +1,32 @@
+<dialog aria-labelledby="fr-modal-publier-without-notifier-ac-title" id="fr-modal-publier-without-notifier-ac" class="fr-modal" role="dialog" >
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button class="fr-btn--close fr-btn" aria-controls="fr-modal-publier-without-notifier-ac">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 id="fr-modal-publier-without-notifier-ac-title" class="fr-modal__title">
+                            <span class="fr-icon-arrow-right-line fr-icon--lg"></span>
+                            Publier sans déclarer à l'AC
+                        </h1>
+                        <p>L'administration centrale ne sera pas notifiée de la publication de cet événement. Vous pourrez le faire plus tard avec le bouton "Déclarer à l'AC" dans le menu Actions.</p>
+                    </div>
+                    <div class="fr-modal__footer">
+                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg">
+                            <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-publier-without-notifier-ac">Annuler</button>
+                            <form action="{% url 'publish' %}" method="post">
+                                {% csrf_token %}
+                                <input type="hidden" value="{{ evenement.get_absolute_url }}" name="next">
+                                <input type="hidden" value="{{ content_type.id }}" name="content_type_id">
+                                <input type="hidden" value="{{ evenement.pk }}" name="content_id">
+                                <input type="submit" class="fr-btn" value="Publier l'événement"/>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/core/urls.py
+++ b/core/urls.py
@@ -12,6 +12,7 @@ from .views import (
     StructureAddView,
     AgentAddView,
     CloturerView,
+    PublishAndACNotificationView,
     EvenementOuvrirView,
 )
 
@@ -60,6 +61,11 @@ urlpatterns = [
         "publication/",
         PublishView.as_view(),
         name="publish",
+    ),
+    path(
+        "publier-notifier-ac/",
+        PublishAndACNotificationView.as_view(),
+        name="publish-and-ac-notification",
     ),
     path(
         "notify-ac/",

--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -51,23 +51,23 @@
                     </div>
                 {% endif %}
 
-                <div class="details-top-row--actions">
+                <ul class="fr-btns-group fr-btns-group--inline-md">
                     {% if can_publish %}
-                        <form action="{% url 'publish' %}" method="post">
-                            {% csrf_token %}
-                            <input type="hidden" value="{{ evenement.get_absolute_url }}" name="next">
-                            <input type="hidden" value="{{ content_type.id }}" name="content_type_id">
-                            <input type="hidden" value="{{ evenement.pk }}" name="content_id">
-                            <button class="fr-btn fr-btn--secondary fr-mr-2w">
-                                Publier l'événement</button>
-                        </form>
+                        <li>
+                            <button class="fr-btn fr-btn--secondary fr-mr-1w" data-fr-opened="false" aria-controls="fr-modal-publier-without-notifier-ac">Publier sans déclarer à l'AC</button>
+                        </li>
+                        <li>
+                            <button class="fr-btn fr-btn--secondary" data-fr-opened="false" aria-controls="fr-modal-publier-and-notifier-ac">Publier et déclarer à l'AC</button>
+                        </li>
                     {% endif %}
-                    {% if can_ouvrir %}
-                        <button class="fr-btn" data-fr-opened="false" aria-controls="fr-annuler-cloture-modal">Ouvrir l'évènement</button>
-                        {% include "core/_ouvrir_evenement_modal.html" %}
-                    {% endif %}
-                    {% include "sv/_evenement_action_navigation.html" %}
-                </div>
+                    <li>
+                        <div class="details-top-row--actions">{% include "sv/_evenement_action_navigation.html" %}</div>
+                    </li>
+                </ul>
+                {% if can_ouvrir %}
+                    <button class="fr-btn" data-fr-opened="false" aria-controls="fr-annuler-cloture-modal">Ouvrir l'évènement</button>
+                    {% include "core/_ouvrir_evenement_modal.html" %}
+                {% endif %}
             </div>
             {% include "sv/_evenement_badges.html" %}
             {% include "core/_latest_revision.html" with date_derniere_mise_a_jour=evenement.date_derniere_mise_a_jour %}
@@ -189,5 +189,10 @@
         {% endif %}
 
     </main>
+
+    {% if can_publish %}
+        {% include "core/_publier_without_notifier_ac_modal.html" %}
+        {% include "core/_publier_and_notifier_ac_modal.html" %}
+    {% endif %}
 
 {% endblock %}

--- a/sv/tests/test_evenement_details.py
+++ b/sv/tests/test_evenement_details.py
@@ -74,38 +74,6 @@ def test_cant_add_zone_if_already_one(live_server, page: Page):
     expect(page.get_by_text("Ajouter une zone", exact=True)).not_to_be_visible()
 
 
-def test_can_publish_evenement(live_server, page: Page):
-    evenement = EvenementFactory(etat=Evenement.Etat.BROUILLON)
-    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
-
-    publish_btn = page.get_by_text("Publier l'événement", exact=True)
-    expect(publish_btn).to_be_enabled()
-    publish_btn.click()
-    expect(page.get_by_text(f"Événement {evenement.numero} publié avec succès")).to_be_visible()
-
-    publish_btn = page.get_by_text("Publier l'événement", exact=True)
-    expect(publish_btn).not_to_be_visible()
-
-
-def test_cant_forge_publication_of_evenement_we_are_not_owner(client, mocked_authentification_user):
-    evenement = EvenementFactory(
-        createur=Structure.objects.create(libelle="A new structure"), etat=Evenement.Etat.BROUILLON
-    )
-    response = client.get(evenement.get_absolute_url())
-
-    assert response.status_code == 403
-
-    payload = {
-        "content_type_id": ContentType.objects.get_for_model(evenement).id,
-        "content_id": evenement.pk,
-    }
-    response = client.post(reverse("publish"), data=payload)
-
-    assert response.status_code == 302
-    evenement.refresh_from_db()
-    assert evenement.is_draft is True
-
-
 def test_detail_synthese_switch(live_server, page):
     evenement = EvenementFactory()
     FicheDetectionFactory(evenement=evenement)


### PR DESCRIPTION
Cette PR permet de remplacer l'action de publier par deux actions : 
- Publier et déclarer à l’AC,
- Publier sans déclarer à l’AC.

Pour l'action "Publier sans déclarer à l’AC", une modale de confirmation est affichée puis l'événement est publié (passage à l'état `EN_COURS`).

Pour l'action "Publier et déclarer à l’AC" : 
- une modale est affichée,
- l'événement est publié (passage à l'état `EN_COURS`) et la notification à l'AC est envoyée. 

J'ai aussi : 
- ajouté deux mixins `WithPublishMixin` et `WithACNotificationMixin` pour factoriser le code utilisé dans plusieurs views (`PublishView`, `ACNotificationView`, `PublishAndACNotificationView`),
- deplacé les tests `test_can_publish_evenement` et `test_cant_forge_publication_of_evenement_we_are_not_owner` dans `sv/tests/test_evenement_etats.py` car ils sont liés à l'état d'un événement.