### PR TITLE
Permettre de chercher un établissement via SIREN

### DIFF
--- a/core/static/core/siret.js
+++ b/core/static/core/siret.js
@@ -21,8 +21,9 @@ export function fetchSiret(value, token) {
             }
             data["etablissements"].forEach((etablissement) => {
                 let address = etablissement["adresseEtablissement"]
-                let streetData = `${address["numeroVoieEtablissement"]} ${address["typeVoieEtablissement"]} ${address["libelleVoieEtablissement"]} - ${address["codePostalEtablissement"]} ${address["libelleCommuneEtablissement"]}`
-                let resultEtablissement = `${etablissement["siret"]} - ${streetData}`
+                let streetData = `${address["numeroVoieEtablissement"]} ${address["typeVoieEtablissement"]} ${address["libelleVoieEtablissement"]}`
+                let fullStreetData = `${streetData} - ${address["codePostalEtablissement"]} ${address["libelleCommuneEtablissement"]}`
+                let resultEtablissement = `${etablissement["siret"]} - ${fullStreetData}`
                 const uniteLegale = etablissement["uniteLegale"]
                 let resultUnite = `${uniteLegale["denominationUniteLegale"]?? ""} ${uniteLegale["denominationUniteLegale"]?? ""} ${uniteLegale["prenom1UniteLegale"]?? ""} ${uniteLegale["nomUniteLegale"]?? ""}`
                 results.push({
@@ -30,8 +31,11 @@ export function fetchSiret(value, token) {
                     label: resultUnite + " " + resultEtablissement ,
                     customProperties: {
                         "streetData": streetData,
+                        "fullStreetData": fullStreetData,
                         "siret": etablissement["siret"],
-                        "raison": uniteLegale["denominationUniteLegale"]
+                        "raison": uniteLegale["denominationUniteLegale"],
+                        "commune": address["libelleCommuneEtablissement"],
+                        "code_commune": address["codeCommuneEtablissement"],
                     }
                 })
             });
@@ -39,7 +43,7 @@ export function fetchSiret(value, token) {
         });
 }
 
-export function setUpSiretChoices(element){
+export function setUpSiretChoices(element, position){
     const choicesSIRET = new Choices(element, {
         removeItemButton: true,
         placeholderValue: 'N° SIRET',
@@ -49,7 +53,7 @@ export function setUpSiretChoices(element){
         searchResultLimit: 20,
         classNames: {containerInner: 'fr-select'},
         itemSelectText: '',
-        position: 'top',
+        position: position,
     });
 
     choicesSIRET.input.element.addEventListener('input', debounce((event) => {

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -304,6 +304,7 @@ CSP_CONNECT_SRC = (
     "api.insee.fr",
     "data.economie.gouv.fr",
     "api-adresse.data.gouv.fr",
+    "fichiers-publics.agriculture.gouv.fr",
 )
 
 SENTRY_REPORT_URL = env("SENTRY_REPORT_URL")

--- a/ssa/static/ssa/evenement_produit_form.css
+++ b/ssa/static/ssa/evenement_produit_form.css
@@ -62,3 +62,10 @@
 #liens-libre input {
     margin-bottom: 0rem;
 }
+
+.fr-search-bar .choices{
+    flex: 1.25;
+}
+.etablissement-fields--lookup {
+    text-align: center;
+}

--- a/ssa/templates/ssa/_etablissement_block.html
+++ b/ssa/templates/ssa/_etablissement_block.html
@@ -18,6 +18,17 @@
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-title-modal--etablissement__prefix__" class="fr-modal__title"><span class="fr-icon-arrow-right-line fr-icon--lg"></span>Ajouter un établissement</h1>
+
+                            <div class="etablissement-fields--lookup">
+                                <button id="sirene-btn" class="fr-btn fr-btn--secondary fr-mx-auto fr-my-4v">
+                                    Rechercher dans la base Sirene (France)
+                                </button>
+                                <div class="fr-search-bar fr-hidden fr-my-4v" id="header-search" role="search">
+                                    <select class="fr-input" type="search" id="search-siret-input" name="search-{{ id }}-input" data-token="{{ sirene_token }}"></select>
+                                    <button class="fr-btn" title="Rechercher">Rechercher</button>
+                                </div>
+                            </div>
+
                             {{ empty_form.as_dsfr_div }}
                         </div>
                         <div class="fr-modal__footer">

--- a/ssa/templates/ssa/evenement_produit_form.html
+++ b/ssa/templates/ssa/evenement_produit_form.html
@@ -7,6 +7,7 @@
 {% endblock %}
 {% block scripts %}
     <script type="text/javascript" src="{% static 'core/forms.js' %}"></script>
+    <script type="text/javascript" src="{% static 'ssa/_numero_agrement.js' %}"></script>
     <script type="text/javascript" src="{% static 'ssa/_rappel_conso_form.js' %}"></script>
     <script type="module" src="{% static 'ssa/evenement_produit_form.js' %}"></script>
     <script type="module" src="{% static 'ssa/_etablissement_form.js' %}"></script>

--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -90,6 +90,10 @@ class EvenementProduitCreationPage:
         self.page.locator("#add-etablissement").click()
         return self.current_modal
 
+    def add_etablissement_siren(self, value, full_value, choice_js_fill):
+        self.current_modal.locator("#sirene-btn").click()
+        choice_js_fill(self.page, "#header-search .choices", value, full_value)
+
     @property
     def current_modal(self):
         return self.page.locator(".fr-modal__body").locator("visible=true")

--- a/ssa/tests/test_api_views.py
+++ b/ssa/tests/test_api_views.py
@@ -1,0 +1,38 @@
+from django.urls import reverse
+from unittest.mock import patch
+
+
+@patch("ssa.views.api.requests.get")
+@patch("ssa.views.api.csv.reader")
+def test_api_view_siret_found(mock_csv_reader, mock_requests_get, client):
+    mock_requests_get.return_value.text = "mocked content"
+    mock_csv_reader.return_value = iter(
+        [
+            ["Numero de département", "Numéro agrément/Approval number", "SIRET", "Other columns"],
+            ["1", "03.223.432", "12345", "Other data"],
+        ]
+    )
+
+    response = client.get(reverse("ssa:find-numero-agrement") + "?siret=12345")
+
+    assert response.status_code == 200
+    assert response.json() == {"numero_agrement": "03.223.432"}
+    assert mock_requests_get.call_count == 1
+
+
+@patch("ssa.views.api.requests.get")
+@patch("ssa.views.api.csv.reader")
+def test_api_view_siret_not_found(mock_csv_reader, mock_requests_get, client):
+    mock_requests_get.return_value.text = "mocked content"
+    mock_csv_reader.return_value = iter(
+        [
+            ["Numero de département", "Numéro agrément/Approval number", "SIRET", "Other columns"],
+            ["1", "03.223.432", "12345", "Other data"],
+        ]
+    )
+
+    response = client.get(reverse("ssa:find-numero-agrement") + "?siret=5555555")
+
+    assert response.status_code == 404
+    assert response.json() == {"error": "SIRET non trouvé"}
+    assert mock_requests_get.call_count == 18

--- a/ssa/urls.py
+++ b/ssa/urls.py
@@ -1,6 +1,11 @@
 from django.urls import path
 
-from .views.produit import EvenementProduitDetailView, EvenementProduitCreateView, EvenementProduitListView
+from .views import (
+    EvenementProduitDetailView,
+    EvenementProduitCreateView,
+    EvenementProduitListView,
+    FindNumeroAgrementView,
+)
 
 app_name = "ssa"
 urlpatterns = [
@@ -18,5 +23,10 @@ urlpatterns = [
         "evenement-produit/",
         EvenementProduitListView.as_view(),
         name="evenement-produit-liste",
+    ),
+    path(
+        "api/find-numero-agrement/",
+        FindNumeroAgrementView.as_view(),
+        name="find-numero-agrement",
     ),
 ]

--- a/ssa/views/__init__.py
+++ b/ssa/views/__init__.py
@@ -1,3 +1,4 @@
 from .produit import EvenementProduitCreateView as EvenementProduitCreateView
 from .produit import EvenementProduitDetailView as EvenementProduitDetailView
 from .produit import EvenementProduitListView as EvenementProduitListView
+from .api import FindNumeroAgrementView as FindNumeroAgrementView

--- a/ssa/views/api.py
+++ b/ssa/views/api.py
@@ -1,0 +1,38 @@
+import csv
+import requests
+from django.http import JsonResponse
+from django.views import View
+from io import StringIO
+
+CSV_URLS = [
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA1_ACTIV_GEN.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA1_VIAN_ONG_DOM.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA1_VIAN_COL_LAGO.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA1_VIAN_GIB_ELEV.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA1_VIAN_GIB_SAUV.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA1_VIAND_HACHE_VSM.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA4_AGSANPROBASEVDE_PRV.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA4B_AS_CE_PRODCOQUI_COV.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA4B_AS_CE_PRODPECHE_COV.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA1_LAIT.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA1_OEUF.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA1_GREN_ESCARG.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA4_AGSANGREXPR_PRV.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA4_AGR_ESVEBO_PRV.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA4_AGSANGELAT_PRV.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA4_AGSANCOLL_PRV.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA_PROD_RAFF.txt",
+    "https://fichiers-publics.agriculture.gouv.fr/dgal/ListesOfficielles/SSA4_ASCCC_PRV.txt",
+]
+
+
+class FindNumeroAgrementView(View):
+    def get(self, request):
+        for url in CSV_URLS:
+            csv_data = csv.reader(StringIO(requests.get(url).text))
+            next(csv_data, None)
+
+            for row in csv_data:
+                if len(row) >= 3 and row[2] == self.request.GET.get("siret"):
+                    return JsonResponse({"numero_agrement": row[1]})
+        return JsonResponse({"error": "SIRET non trouvé"}, status=404)

--- a/ssa/views/produit.py
+++ b/ssa/views/produit.py
@@ -16,6 +16,7 @@ from core.mixins import (
     WithContactFormsInContextMixin,
     WithBlocCommunPermission,
     WithAddUserContactsMixin,
+    WithSireneTokenMixin,
 )
 from ssa.filters import EvenementProduitFilter
 from ssa.forms import EvenementProduitForm
@@ -23,7 +24,9 @@ from ssa.formsets import EtablissementFormSet
 from ssa.models import EvenementProduit
 
 
-class EvenementProduitCreateView(WithFormErrorsAsMessagesMixin, WithAddUserContactsMixin, CreateView):
+class EvenementProduitCreateView(
+    WithFormErrorsAsMessagesMixin, WithAddUserContactsMixin, WithSireneTokenMixin, CreateView
+):
     form_class = EvenementProduitForm
     template_name = "ssa/evenement_produit_form.html"
 

--- a/sv/static/sv/fichedetection_lieux_form.js
+++ b/sv/static/sv/fichedetection_lieux_form.js
@@ -163,12 +163,12 @@ function setupCharacterCounter(element) {
 
 
 function configureSiretField(field){
-    const choicesSIRET = setUpSiretChoices(field)
+    const choicesSIRET = setUpSiretChoices(field, 'top')
     choicesSIRET.passedElement.element.addEventListener("choice", (event)=> {
         field.closest("dialog").querySelector('[id$=siret_etablissement]').value = event.detail.customProperties.siret
         field.closest("dialog").querySelector('[id$=raison_sociale_etablissement]').value = event.detail.customProperties.raison
-        field.closest("dialog").querySelector('[id$=adresse_lieu_dit]').value = event.detail.customProperties.streetData
-        field.closest("dialog").querySelector('[id$=adresse_etablissement]').value = event.detail.customProperties.streetData
+        field.closest("dialog").querySelector('[id$=adresse_lieu_dit]').value = event.detail.customProperties.fullStreetData
+        field.closest("dialog").querySelector('[id$=adresse_etablissement]').value = event.detail.customProperties.fullStreetData
         field.closest("dialog").querySelector('[id$=pays_etablissement]').value = "FR"
 
         field.closest("dialog").querySelector('[id$=sirene-btn]').classList.remove("fr-hidden")


### PR DESCRIPTION
Dans SSA permettre de rechercher un établissement via son SIREN et de compléter le formulaire en utilisant les informations renvoyées par l'API.

Ajout d'une vue qui permet en plus d'obtenir le numéro d'agrément depuis le siret:

- Obligation de le faire côté back à cause de la politique CORS de l'hébergement des fichiers
- Version "naive" pour le moment, il est possible que la vue timeout et/ou que le champ mette du temps à se compléter au niveau frontend. Cette implémentation évite de devoir écrire un script de synchronisation des données des numéros d'agréement.
- J'ai réalisé des tests avec des numéros qui sont dans les derniers fichiers et c'est tout de même assez rapide.

Amélioration envisageable:
- Ajouter un retour UI pour indiquer que le numéro d'agrément est en train de se charger.
- Utiliser du code async pour le téléchargement / lecture des fichiers
- Stocker les infos en base avec un script de recopie et de gestion des suppressions
- Héberger les CSV ailleurs (simple copie) et réaliser l'opération côté front.