### PR TITLE
Corriger les modales d'établissement dans SSA

### DIFF
--- a/ssa/static/ssa/_etablissement_form.js
+++ b/ssa/static/ssa/_etablissement_form.js
@@ -1,5 +1,7 @@
 import {setUpAddressChoices} from "/static/core/ban_autocomplete.js";
 
+let modalEtablissementHTMLContent = {}
+
 document.addEventListener('DOMContentLoaded', () => {
     function getNextIdToUse() {
         let num = 0
@@ -24,9 +26,9 @@ document.addEventListener('DOMContentLoaded', () => {
             dsfr(modal).modal.disclose()
             dsfr(modal).modal.node.addEventListener('dsfr.conceal', event => {
                 removeRequired(modal)
-                const originalTarget = event.explicitOriginalTarget
-                if (!originalTarget.classList.contains("save-btn")) {
-                    resetForm(modal)
+                if (!event.target.classList.contains("save-btn") && !!modalEtablissementHTMLContent[nextIdToUse]) {
+                    event.target.querySelector(".fr-modal__content").replaceWith(modalEtablissementHTMLContent[nextIdToUse])
+                    modalEtablissementHTMLContent[nextIdToUse] = null
                 }
             });
         }, 10)
@@ -112,6 +114,9 @@ document.addEventListener('DOMContentLoaded', () => {
             const card = getEtablissementCard(clone, currentModal, etablissementId)
             card.querySelector('.etablissement-delete-btn').addEventListener("click", () => {deleteEtablissement(etablissementId)})
             card.querySelector('.etablissement-edit-btn').setAttribute("aria-controls", `fr-modal-etablissement${etablissementId}`)
+            card.querySelector('.etablissement-edit-btn').addEventListener("click", () => {
+                modalEtablissementHTMLContent[etablissementId] = document.querySelector(`#fr-modal-etablissement${etablissementId} .fr-modal__content`).cloneNode(true)
+            })
             document.getElementById("etablissement-card-container").appendChild(card);
         } else {
             existingCard.replaceWith(getEtablissementCard(existingCard, currentModal, etablissementId))

--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -137,6 +137,9 @@ class EvenementProduitCreationPage:
 
         self.close_etablissement_modal()
 
+    def open_edit_etablissement(self):
+        self.page.locator(".etablissement-edit-btn").click()
+
     def etablissement_card(self, index=0):
         return self.page.locator(".etablissement-card").nth(index)
 

--- a/ssa/tests/test_evenement_produit_creation.py
+++ b/ssa/tests/test_evenement_produit_creation.py
@@ -1,5 +1,4 @@
 import json
-
 from playwright.sync_api import Page, expect
 
 from core.constants import AC_STRUCTURE
@@ -397,3 +396,20 @@ def test_add_contacts_on_creation(live_server, mocked_authentification_user, pag
 
     user_contact_structure = Contact.objects.get(structure=mocked_authentification_user.agent.structure)
     assert user_contact_structure in evenement_produit.contacts.all()
+
+
+def test_can_add_etablissement_and_quit_modal(live_server, page: Page, assert_models_are_equal):
+    evenement = EvenementProduitFactory()
+
+    etablissement = EtablissementFactory(evenement_produit=evenement)
+
+    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page.navigate()
+    creation_page.fill_required_fields(evenement)
+    creation_page.add_etablissement(etablissement)
+    creation_page.open_edit_etablissement()
+    expect(creation_page.current_modal_raison_sociale_field).to_have_value(etablissement.raison_sociale)
+
+    page.keyboard.press("Escape")
+    creation_page.open_edit_etablissement()
+    expect(creation_page.current_modal_raison_sociale_field).to_have_value(etablissement.raison_sociale)


### PR DESCRIPTION
Corrige le scénario suivant:

- Créer un établissement
- Remplir le champ obligatoire
- Enregistrer la modale
- Editer
- Cliquer en dehors de la modale
- Editer à nouveau --> **Le formulaire est vide alors qu'on devrait avoir nos infos**

- explicitOriginalTarget ne fonctionne que sur firefox pas sur chrome
- sauvegarde du form pour pouvoir le réinitialiser si le changement est fait sans sauvegarde de la modale