### PR TITLE
Permettre de personaliser le MessageForm

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -19,3 +19,7 @@ fileignoreconfig:
   checksum: b54379a22a0229e85ae27aeaf50d2b6931289fb8dbe521b0d3b68e88fc21b2b2
 - filename: sv/static/sv/fichedetection_lieux_form.js
   checksum: dd7abfcb004df5833e92c64806dc6436672d4ceb9727ca495ac3f7431c6d776f
+- filename: core/templates/core/_tableau_fil_de_suivi.html
+  checksum: 3f44e693b99c4888008d386912072ab74f14ca5010791b1a957b71a6f99bdc46
+- filename: ssa/tests/pages.py
+  checksum: 13f50c16e3e5b6b187725c13c7d814a526fc4d6242dbb42a383ef00095a8ca09

--- a/core/constants.py
+++ b/core/constants.py
@@ -4,3 +4,14 @@ BSV_STRUCTURE = "SAS/SDSPV/BSV"
 SERVICE_ACCOUNT_NAME = "service_account"
 SV_DOMAIN = "Santé des végétaux"
 SSA_DOMAIN = "Sécurité sanitaire des aliments"
+SSA_STRUCTURES = [
+    MUS_STRUCTURE,
+    "BEAD",
+    "BETD",
+    "BPMED",
+    "BAMRA",
+    "BEPIAS",
+    "BIB",
+    "SIVEP",
+    "BICMA",
+]

--- a/core/managers.py
+++ b/core/managers.py
@@ -1,7 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Case, When, Value, IntegerField, QuerySet, Q, Manager
 
-from core.constants import MUS_STRUCTURE, BSV_STRUCTURE, SERVICE_ACCOUNT_NAME
+from core.constants import MUS_STRUCTURE, BSV_STRUCTURE, SERVICE_ACCOUNT_NAME, SSA_STRUCTURES
 
 
 class DocumentManager(Manager):
@@ -51,6 +51,9 @@ class ContactQueryset(QuerySet):
 
     def exclude_empty_emails(self):
         return self.exclude(email="")
+
+    def get_ssa_structures(self):
+        return self.filter(structure__libelle__in=SSA_STRUCTURES).prefetch_related("structure")
 
     def can_be_emailed(self):
         return self.exclude_empty_emails().with_active_agent() | self.exclude_empty_emails().structures_only()

--- a/core/mixins.py
+++ b/core/mixins.py
@@ -15,7 +15,6 @@ from django.views.generic import FormView
 from core.forms import (
     DocumentUploadForm,
     DocumentEditForm,
-    MessageForm,
     MessageDocumentForm,
     StructureAddForm,
     AgentAddForm,
@@ -96,10 +95,13 @@ class WithBlocCommunPermission:
 
 
 class WithMessageFormInContextMixin:
+    def get_message_form_class(self):
+        raise NotImplementedError
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         obj = self.get_object()
-        context["message_form"] = MessageForm(
+        context["message_form"] = obj.get_message_form()(
             sender=self.request.user,
             obj=obj,
             next=obj.get_absolute_url(),

--- a/core/model_mixins.py
+++ b/core/model_mixins.py
@@ -17,3 +17,6 @@ class WithBlocCommunFieldsMixin(models.Model):
         contacts_structure = self.contacts.exclude(structure__isnull=True).select_related("structure")
         fin_suivi_contacts_ids = self.fin_suivi.values_list("contact", flat=True)
         return contacts_structure.exclude(id__in=fin_suivi_contacts_ids)
+
+    def get_message_form(self):
+        raise NotImplementedError

--- a/core/static/core/message_form.js
+++ b/core/static/core/message_form.js
@@ -75,6 +75,10 @@ function addShortcut(classToWatch, elements){
     })
 }
 
+function isLimitedRecipientsASelect(){
+    return document.getElementById("id_recipients_limited_recipients").type === "select-multiple"
+}
+
 function getMessageConfig(){
     const helpElement = document.getElementById("point-situation-help")
     const destinatairesElement = document.querySelector('label[for="id_recipients"]').parentNode
@@ -83,7 +87,13 @@ function getMessageConfig(){
     const destinatairesStructureInput = document.getElementById("id_recipients_structures_only")
     const copieElement = document.querySelector('label[for="id_recipients_copy"]').parentNode
     const copieStructuresElement = document.querySelector('label[for="id_recipients_copy_structures_only"]').parentNode
-    const limitedRecipientsElement = document.getElementById("id_recipients_limited_recipients").parentNode
+
+    let limitedRecipientsElement = null
+    if (isLimitedRecipientsASelect()) {
+        limitedRecipientsElement = document.getElementById("id_recipients_limited_recipients").parentNode.parentNode.parentNode
+    } else {
+        limitedRecipientsElement = document.getElementById("id_recipients_limited_recipients").parentNode
+    }
     const allElements = [destinatairesElement, copieElement, destinatairesStructureElement, copieStructuresElement, limitedRecipientsElement, helpElement]
     const allRequiredInputs = [destinatairesInput, destinatairesStructureInput]
     const configuration = {
@@ -183,7 +193,9 @@ function onSubmitBtnClick(event, otherSubmitButton) {
     const messageStatusField = document.getElementById("id_status");
 
     messageStatusField.value = event.target.getAttribute("value");
-    updateLimitedRecipientsValidation();
+    if (!isLimitedRecipientsASelect()) {
+        updateLimitedRecipientsValidation();
+    }
     messageForm.reportValidity()
 
     if (!messageForm.checkValidity()) {
@@ -226,7 +238,9 @@ document.addEventListener('DOMContentLoaded', function () {
     const choicesCopy = initializeChoices(document.getElementById('id_recipients_copy'))
     const choicesStructuresRecipients = initializeChoices(document.getElementById('id_recipients_structures_only'))
     const choicesStructuresCopy = initializeChoices(document.getElementById('id_recipients_copy_structures_only'))
-
+    if (isLimitedRecipientsASelect()) {
+        initializeChoices(document.getElementById("id_recipients_limited_recipients"))
+    }
 
     addShortcut(".destinataires-shortcut", [choicesRecipients, choicesStructuresRecipients]);
     addShortcut(".copie-shortcut", [choicesCopy, choicesStructuresCopy]);

--- a/core/templates/core/_tableau_fil_de_suivi.html
+++ b/core/templates/core/_tableau_fil_de_suivi.html
@@ -23,7 +23,7 @@
     </thead>
     <tbody>
         {% for message in message_list %}
-            <tr id="table-sm-row-key-1" data-row-key="1">
+            <tr id="table-sm-row-key-{{ forloop.counter }}" data-row-key="{{ forloop.counter }}">
                 <td>
                     <a href="#" class="cell-link fil-de-suivi-sidebar" data-message-pk="{{ message.pk }}">{{ message.date_creation }}</a>
                 </td>

--- a/core/views.py
+++ b/core/views.py
@@ -15,7 +15,6 @@ from django.views.generic.edit import FormView, CreateView, UpdateView
 
 from .forms import (
     DocumentUploadForm,
-    MessageForm,
     MessageDocumentForm,
     DocumentEditForm,
     StructureAddForm,
@@ -142,8 +141,10 @@ class MessageCreateView(
     PreventActionIfVisibiliteBrouillonMixin, WithAddUserContactsMixin, UserPassesTestMixin, CreateView
 ):
     model = Message
-    form_class = MessageForm
     http_method_names = ["post"]
+
+    def get_form_class(self):
+        return self.obj.get_message_form()
 
     def dispatch(self, request, *args, **kwargs):
         self.obj_class = ContentType.objects.get(pk=self.kwargs.get("obj_type_pk")).model_class()

--- a/ssa/models/evenement_produit.py
+++ b/ssa/models/evenement_produit.py
@@ -274,6 +274,11 @@ class EvenementProduit(
     def get_cloture_confirm_message(self):
         return f"L'événement n°{self.numero} a bien été clôturé."
 
+    def get_message_form(self):
+        from ssa.forms import MessageForm
+
+        return MessageForm
+
     class Meta:
         constraints = [
             models.CheckConstraint(

--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -217,6 +217,44 @@ class EvenementProduitDetailsPage:
         self.page.get_by_role("link", name="Clôturer l'événement").click()
         self.page.get_by_role("button", name="Clôturer").click()
 
+    def open_compte_rendu_di(self):
+        self.page.get_by_test_id("element-actions").click()
+        self.page.get_by_test_id("fildesuivi-actions-compte-rendu").click()
+
+    @property
+    def message_form_title(self):
+        return self.page.locator("#message-type-title")
+
+    def add_limited_recipient_to_message(self, contact: str, choice_js_fill):
+        choice_js_fill(
+            self.page,
+            ".choices:has(#id_recipients_limited_recipients)",
+            contact,
+            contact,
+            use_locator_as_parent_element=True,
+        )
+
+    def add_message_content_and_send(self):
+        self.page.locator("#id_title").fill("Title of the message")
+        self.page.locator("#id_content").fill("My content \n with a line return")
+        self.page.get_by_test_id("fildesuivi-add-submit").click()
+
+    @property
+    def fil_de_suivi_sender(self, line_number=1):
+        return self.page.text_content(f"#table-sm-row-key-{line_number} td:nth-child(2) a")
+
+    @property
+    def fil_de_suivi_recipients(self, line_number=1):
+        return self.page.text_content(f"#table-sm-row-key-{line_number} td:nth-child(3) a")
+
+    @property
+    def fil_de_suivi_title(self, line_number=1):
+        return self.page.text_content(f"#table-sm-row-key-{line_number} td:nth-child(4) a")
+
+    @property
+    def fil_de_suivi_type(self, line_number=1):
+        return self.page.text_content(f"#table-sm-row-key-{line_number} td:nth-child(6) a")
+
 
 class EvenementProduitListPage:
     def __init__(self, page: Page, base_url):

--- a/ssa/tests/test_evenement_produit_details_performances.py
+++ b/ssa/tests/test_evenement_produit_details_performances.py
@@ -1,7 +1,7 @@
 from core.models import LienLibre
 from ssa.factories import EvenementProduitFactory, EtablissementFactory
 
-NUMBER_BASE_QUERIES = 20
+NUMBER_BASE_QUERIES = 21
 
 
 def test_evenement_produit_performances(client, django_assert_num_queries):

--- a/ssa/tests/test_evenement_produit_message.py
+++ b/ssa/tests/test_evenement_produit_message.py
@@ -1,0 +1,28 @@
+from playwright.sync_api import Page, expect
+
+from core.constants import MUS_STRUCTURE
+from core.factories import ContactStructureFactory
+from ssa.factories import EvenementProduitFactory
+from ssa.models import EvenementProduit
+from ssa.tests.pages import EvenementProduitDetailsPage
+
+
+def test_can_add_and_see_compte_rendu(live_server, page: Page, choice_js_fill):
+    evenement = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    ContactStructureFactory(
+        structure__niveau2=MUS_STRUCTURE, structure__niveau1=MUS_STRUCTURE, structure__libelle=MUS_STRUCTURE
+    )
+
+    details_page = EvenementProduitDetailsPage(page, live_server.url)
+    details_page.navigate(evenement)
+    details_page.open_compte_rendu_di()
+    expect(details_page.message_form_title).to_have_text("compte rendu sur demande d'intervention")
+    details_page.add_limited_recipient_to_message(MUS_STRUCTURE, choice_js_fill)
+    details_page.add_message_content_and_send()
+
+    page.wait_for_url(f"**{evenement.get_absolute_url()}#tabpanel-messages-panel")
+
+    assert details_page.fil_de_suivi_sender == "Structure Test"
+    assert details_page.fil_de_suivi_recipients == "MUS"
+    assert details_page.fil_de_suivi_title == "Title of the message"
+    assert details_page.fil_de_suivi_type == "Compte rendu sur demande d'intervention"

--- a/sv/models/evenements.py
+++ b/sv/models/evenements.py
@@ -212,3 +212,8 @@ class Evenement(
 
     def can_add_fiche_zone_delimitee(self, user):
         return self._user_can_interact(user)
+
+    def get_message_form(self):
+        from ..forms import MessageForm
+
+        return MessageForm


### PR DESCRIPTION
Le but de ce commit est de pouvoir personaliser le comportement du message form en fonction de l'application visée. Au début du projet il était prévu que le comportement soit iso entre toutes les apps, mais il s'avère que non.
L'utilisation de l'héritage permet de personaliser le comportement (case a cocher pour SV, picker ChoiceJs pour SSA) tout en gardant 95% du comportement en commun.

- Changement du template de fil de suivi pour éviter d'avoir plusieurs élements avec le même ID
- Création des sous classes pour la personalisation et implémentation du nouveau comportement dans SSA