### PR TITLE
Année courante pour numero_annee dans EvenementFactory

### DIFF
--- a/sv/factories.py
+++ b/sv/factories.py
@@ -347,7 +347,7 @@ class EvenementFactory(DjangoModelFactory):
     statut_reglementaire = factory.SubFactory("sv.factories.StatutReglementaireFactory")
     visibilite = Visibilite.LOCALE
     etat = Evenement.Etat.EN_COURS
-    numero_annee = factory.Faker("year")
+    numero_annee = factory.LazyFunction(lambda: datetime.now().year)
     numero_europhyt = factory.Faker("bothify", text="#?#?#?#?")
     numero_rasff = factory.Faker("bothify", text="#?#?#?#?#")
 


### PR DESCRIPTION
Modification de `numero_annee` dans `EvenementFactory` pour avoir l'année courante au lieu d'une année aléatoire.