### PR TITLE
Ajouter un tri sur les labels des listes d'évènements

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -12,7 +12,7 @@ fileignoreconfig:
 - filename: bin/fetch_contacts_agricoll_and_key.sh
   checksum: 8d190b28dc273aa32259925161d1b26e0749cc1a560a8c75949e03f932db4214
 - filename: sv/views.py
-  checksum: 62b3a8a26bcb7a4ee9f8c73e92241093690212cfce216acf640079bfb36dcdfc
+  checksum: 4ceb0a98828aa09751d33b14f8183c8ac6872bd6bc6e32bc0c605533286e55e6
 - filename: ssa/static/ssa/_rappel_conso_form.js
   checksum: eaddd88cdb839b7592fb59aad23f27f727999f50f90a073e0ec7bc4673c411d0
 - filename: core/views.py
@@ -23,3 +23,11 @@ fileignoreconfig:
   checksum: 3f44e693b99c4888008d386912072ab74f14ca5010791b1a957b71a6f99bdc46
 - filename: ssa/tests/pages.py
   checksum: 13f50c16e3e5b6b187725c13c7d814a526fc4d6242dbb42a383ef00095a8ca09
+- filename: sv/templates/sv/_evenement_sort_link.html
+  checksum: 2d2d55ba063f2c815925d845ef860354398ad2830f36e0e5429163fd0131c101
+- filename: sv/tests/test_evenement_list_order.py
+  checksum: 8f9ff88f349a3e8be0d00903d6a9ccaa81db3c8c825a4feaccbb45042b641542
+- filename: core/mixins.py
+  checksum: 9717807f321037aee25f9711e052e85b2b9e2df83bcce796d1931e04ab2f53fb
+- filename: conftest.py
+  checksum: a17ce992990a59928baab025a092e3d561dd5f5bdee013ec86ceafcb21d07359

--- a/core/templates/core/_evenement_sort_link.html
+++ b/core/templates/core/_evenement_sort_link.html
@@ -1,0 +1,6 @@
+<a href="?order_by={{ field }}{% if field == current_order_by and current_order_dir == 'asc' %}&order_dir=desc{% else %}&order_dir=asc{% endif %}{% for key, value in request.GET.items %}{% if key != 'order_by' and key != 'order_dir' and key != 'page' %}&{{ key }}={{ value }}{% endif %}{% endfor %}" class="evenements__sort-link">
+    {{ display_name }}
+    {% if field == current_order_by %}
+        <span class="fr-icon--sm {% if current_order_dir == 'asc' %}fr-icon-arrow-up-line{% else %}fr-icon-arrow-down-line{% endif %}" aria-hidden="true"></span>
+    {% endif %}
+</a>

--- a/ssa/templates/ssa/evenementproduit_list.html
+++ b/ssa/templates/ssa/evenementproduit_list.html
@@ -29,19 +29,19 @@
             <table>
                 <thead>
                     <tr>
-                        <th class="fr-col-1" scope="col">N°</th>
-                        <th class="fr-col-1" scope="col">Création</th>
-                        <th class="fr-col-3" scope="col">Description de l'événement</th>
+                        <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='numero_evenement' display_name='N°' %}</th>
+                        <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='creation' display_name='Création' %}</th>
+                        <th class="fr-col-3" scope="col">{% include 'core/_evenement_sort_link.html' with field='description' display_name="Description de l'événement" %}</th>
                         <th class="fr-col-2" scope="col">Catégorie de produit</th>
                         <th class="fr-col-2" scope="col">Catégorie de danger</th>
-                        <th class="fr-col-1" scope="col">Créateur</th>
-                        <th class="fr-col-1" scope="col">État</th>
-                        <th class="fr-col-1" scope="col">Liens</th>
+                        <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='createur' display_name='Créateur' %}</th>
+                        <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='etat' display_name='État' %}</th>
+                        <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='liens' display_name='Liens' %}</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for evenement in evenementproduit_list %}
-                        <tr>
+                        <tr class="evenements__list-row">
                             <td><a href="{{ evenement.get_absolute_url }}" class="fr-link">{{ evenement.numero }}</a></td>
                             <td>{{ evenement.date_creation|date:"d/m/Y" }}</td>
                             <td class="ellipsis">{{ evenement.product_description }}</td>

--- a/sv/managers.py
+++ b/sv/managers.py
@@ -110,7 +110,7 @@ class EvenementQueryset(models.QuerySet):
     def order_by_numero(self):
         return self.order_by("-numero_annee", "-numero_evenement")
 
-    def with_date_derniere_mise_a_jour_and_order(self):
+    def with_date_derniere_mise_a_jour(self):
         """
         Calcule la date la plus récente de modification parmi l'événement,
         ses détections et sa fiche zone délimitée, puis trie le queryset par cette date.
@@ -128,7 +128,7 @@ class EvenementQueryset(models.QuerySet):
                 "date_derniere_mise_a_jour_zone",
                 output_field=models.DateTimeField(),
             ),
-        ).order_by("-date_derniere_mise_a_jour_globale")
+        )
 
     def get_user_can_view(self, user):
         from sv.models import Evenement

--- a/sv/templates/sv/evenement_list.html
+++ b/sv/templates/sv/evenement_list.html
@@ -48,17 +48,17 @@
                 <table class="evenements__list-table">
                     <thead>
                         <tr class="evenements__table-header">
-                            <th scope="col" class="fr-col-1">Notifié AC</th>
-                            <th scope="col" class="fr-col-1">Évènement</th>
-                            <th scope="col" class="fr-col-3">Organisme nuisible</th>
-                            <th scope="col" class="fr-col-1">Création</th>
-                            <th scope="col" class="fr-col-1">Dernière MAJ descripteurs</th>
-                            <th scope="col">Créateur</th>
+                            <th scope="col" class="fr-col-1">{% include 'core/_evenement_sort_link.html' with field='ac_notified' display_name='Notifié AC' %}</th>
+                            <th scope="col" class="fr-col-1">{% include 'core/_evenement_sort_link.html' with field='numero_evenement' display_name='Évènement' %}</th>
+                            <th scope="col" class="fr-col-3">{% include 'core/_evenement_sort_link.html' with field='organisme' display_name='Organisme nuisible' %}</th>
+                            <th scope="col" class="fr-col-1">{% include 'core/_evenement_sort_link.html' with field='creation' display_name='Création' %}</th>
+                            <th scope="col" class="fr-col-1">{% include 'core/_evenement_sort_link.html' with field='maj' display_name='Dernière MAJ descripteurs' %}</th>
+                            <th scope="col">{% include 'core/_evenement_sort_link.html' with field='createur' display_name='Créateur' %}</th>
                             <th scope="col">Commune</th>
-                            <th scope="col">État</th>
-                            <th scope="col">Visibilité</th>
-                            <th scope="col">Détections</th>
-                            <th scope="col">Zone</th>
+                            <th scope="col">{% include 'core/_evenement_sort_link.html' with field='etat' display_name='État' %}</th>
+                            <th scope="col">{% include 'core/_evenement_sort_link.html' with field='visibilite' display_name='Visibilité' %}</th>
+                            <th scope="col">{% include 'core/_evenement_sort_link.html' with field='detections' display_name='Détections' %}</th>
+                            <th scope="col">{% include 'core/_evenement_sort_link.html' with field='zone' display_name='Zone' %}</th>
                         </tr>
                     </thead>
                     <tbody>

--- a/sv/tests/test_evenement_list_order.py
+++ b/sv/tests/test_evenement_list_order.py
@@ -1,0 +1,245 @@
+from datetime import datetime
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from playwright.sync_api import Page
+
+from core.factories import StructureFactory
+from core.models import Visibilite
+from sv.factories import FicheDetectionFactory, EvenementFactory, FicheZoneFactory
+from sv.models import Evenement, Etat
+
+
+@pytest.mark.parametrize(
+    "direction,expected_order",
+    [
+        ("asc", ["evenement_2", "evenement_1", "evenement_3"]),
+        ("desc", ["evenement_1", "evenement_3", "evenement_2"]),
+    ],
+    ids=["asc", "desc"],
+)
+def test_order_by_ac_notified(
+    live_server, page: Page, url_builder_for_list_ordering, assert_events_order, direction, expected_order
+):
+    evenements = {
+        "evenement_1": EvenementFactory(is_ac_notified=True),
+        "evenement_2": EvenementFactory(is_ac_notified=False),
+        "evenement_3": EvenementFactory(is_ac_notified=True),
+    }
+    page.goto(url_builder_for_list_ordering("ac_notified", direction, "sv:evenement-liste"))
+    page.get_by_role("link", name="Notifié AC").click()
+    assert_events_order(page, evenements, expected_order)
+
+
+@pytest.mark.parametrize(
+    "direction,expected_order",
+    [
+        ("asc", ["evenement_3", "evenement_1", "evenement_2"]),
+        ("desc", ["evenement_2", "evenement_1", "evenement_3"]),
+    ],
+    ids=["asc", "desc"],
+)
+def test_order_by_numero_evenement(
+    live_server, page: Page, url_builder_for_list_ordering, assert_events_order, direction, expected_order
+):
+    evenements = {
+        "evenement_1": EvenementFactory(numero_annee=2025, numero_evenement=2),
+        "evenement_2": EvenementFactory(numero_annee=2025, numero_evenement=3),
+        "evenement_3": EvenementFactory(numero_annee=2025, numero_evenement=1),
+    }
+    page.goto(url_builder_for_list_ordering("numero_evenement", direction, "sv:evenement-liste"))
+    page.get_by_role("link", name="Évènement", exact=True).click()
+    assert_events_order(page, evenements, expected_order)
+
+
+@pytest.mark.parametrize(
+    "direction,expected_order",
+    [
+        ("asc", ["evenement_1", "evenement_3", "evenement_2"]),
+        ("desc", ["evenement_2", "evenement_3", "evenement_1"]),
+    ],
+    ids=["asc", "desc"],
+)
+def test_order_by_organisme_nuisible(
+    live_server, page: Page, url_builder_for_list_ordering, assert_events_order, direction, expected_order
+):
+    evenements = {
+        "evenement_1": EvenementFactory(organisme_nuisible__libelle_court="A"),
+        "evenement_2": EvenementFactory(organisme_nuisible__libelle_court="C"),
+        "evenement_3": EvenementFactory(organisme_nuisible__libelle_court="B"),
+    }
+    page.goto(url_builder_for_list_ordering("organisme", direction, "sv:evenement-liste"))
+    page.get_by_role("link", name="Organisme nuisible").click()
+    assert_events_order(page, evenements, expected_order)
+
+
+@pytest.mark.parametrize(
+    "direction,expected_order",
+    [
+        ("asc", ["evenement_1", "evenement_3", "evenement_2"]),
+        ("desc", ["evenement_2", "evenement_3", "evenement_1"]),
+    ],
+    ids=["asc", "desc"],
+)
+def test_order_by_date_creation(
+    live_server, page: Page, url_builder_for_list_ordering, assert_events_order, direction, expected_order
+):
+    evenements = {
+        "evenement_1": EvenementFactory(date_creation=timezone.make_aware(datetime(2023, 1, 1))),
+        "evenement_2": EvenementFactory(date_creation=timezone.make_aware(datetime(2023, 3, 1))),
+        "evenement_3": EvenementFactory(date_creation=timezone.make_aware(datetime(2023, 2, 1))),
+    }
+    page.goto(url_builder_for_list_ordering("creation", direction, "sv:evenement-liste"))
+    page.get_by_role("link", name="Création").click()
+    assert_events_order(page, evenements, expected_order)
+
+
+@pytest.mark.parametrize(
+    "direction,expected_order",
+    [
+        ("asc", ["evenement_1", "evenement_3", "evenement_2"]),
+        ("desc", ["evenement_2", "evenement_3", "evenement_1"]),
+    ],
+    ids=["asc", "desc"],
+)
+def test_order_by_date_derniere_mise_a_jour(
+    live_server, page: Page, url_builder_for_list_ordering, assert_events_order, direction, expected_order
+):
+    Evenement._meta.get_field("date_derniere_mise_a_jour").auto_now = False
+    evenements = {
+        "evenement_1": EvenementFactory(date_derniere_mise_a_jour=timezone.make_aware(datetime(2025, 1, 1))),
+        "evenement_2": EvenementFactory(date_derniere_mise_a_jour=timezone.make_aware(datetime(2025, 3, 1))),
+        "evenement_3": EvenementFactory(date_derniere_mise_a_jour=timezone.make_aware(datetime(2025, 2, 1))),
+    }
+    page.goto(url_builder_for_list_ordering("maj", direction, "sv:evenement-liste"))
+    page.get_by_role("link", name="Dernière MAJ descripteurs").click()
+    assert_events_order(page, evenements, expected_order)
+
+
+@pytest.mark.parametrize(
+    "direction,expected_order",
+    [
+        ("asc", ["evenement_1", "evenement_3", "evenement_2"]),
+        ("desc", ["evenement_2", "evenement_3", "evenement_1"]),
+    ],
+    ids=["asc", "desc"],
+)
+def test_order_by_createur(
+    live_server, page: Page, url_builder_for_list_ordering, assert_events_order, direction, expected_order
+):
+    evenements = {
+        "evenement_1": EvenementFactory(createur=StructureFactory(libelle="A"), visibilite=Visibilite.NATIONALE),
+        "evenement_2": EvenementFactory(createur=StructureFactory(libelle="C"), visibilite=Visibilite.NATIONALE),
+        "evenement_3": EvenementFactory(createur=StructureFactory(libelle="B"), visibilite=Visibilite.NATIONALE),
+    }
+    page.goto(url_builder_for_list_ordering("createur", direction, "sv:evenement-liste"))
+    page.get_by_role("link", name="Créateur").click()
+    assert_events_order(page, evenements, expected_order)
+
+
+@pytest.mark.parametrize(
+    "direction,expected_order",
+    [
+        ("asc", ["evenement_2", "evenement_3", "evenement_1"]),
+        ("desc", ["evenement_1", "evenement_3", "evenement_2"]),
+    ],
+    ids=["asc", "desc"],
+)
+def test_order_by_etat(
+    live_server, page: Page, url_builder_for_list_ordering, assert_events_order, direction, expected_order
+):
+    evenements = {
+        "evenement_1": EvenementFactory(etat=Etat.NOUVEAU),
+        "evenement_2": EvenementFactory(etat=Etat.CLOTURE),
+        "evenement_3": EvenementFactory(etat=Etat.EN_COURS),
+    }
+    page.goto(url_builder_for_list_ordering("etat", direction, "sv:evenement-liste"))
+    page.get_by_role("link", name="État").click()
+    assert_events_order(page, evenements, expected_order)
+
+
+@pytest.mark.parametrize(
+    "direction,expected_order",
+    [
+        ("asc", ["evenement_1", "evenement_3", "evenement_2"]),
+        ("desc", ["evenement_2", "evenement_3", "evenement_1"]),
+    ],
+    ids=["asc", "desc"],
+)
+def test_order_by_visibilite(
+    live_server, page: Page, url_builder_for_list_ordering, assert_events_order, direction, expected_order
+):
+    evenement_1 = EvenementFactory()
+    structure = StructureFactory()
+    evenement_1.allowed_structures.add(structure)
+    evenement_1.visibilite = Visibilite.LIMITEE
+    evenement_1.save()
+    evenements = {
+        "evenement_1": evenement_1,
+        "evenement_2": EvenementFactory(visibilite=Visibilite.NATIONALE),
+        "evenement_3": EvenementFactory(visibilite=Visibilite.LOCALE),
+    }
+    page.goto(url_builder_for_list_ordering("visibilite", direction, "sv:evenement-liste"))
+    page.get_by_role("link", name="Visibilité").click()
+    assert_events_order(page, evenements, expected_order)
+
+
+@pytest.mark.parametrize(
+    "direction,expected_order",
+    [
+        ("asc", ["evenement_3", "evenement_1", "evenement_2"]),
+        ("desc", ["evenement_2", "evenement_1", "evenement_3"]),
+    ],
+    ids=["asc", "desc"],
+)
+def test_order_by_detections(
+    live_server, page: Page, url_builder_for_list_ordering, assert_events_order, direction, expected_order
+):
+    evenements = {
+        "evenement_1": EvenementFactory(),
+        "evenement_2": EvenementFactory(),
+        "evenement_3": EvenementFactory(),
+    }
+    FicheDetectionFactory.create_batch(2, evenement=evenements["evenement_1"])
+    FicheDetectionFactory.create_batch(3, evenement=evenements["evenement_2"])
+    FicheDetectionFactory.create_batch(1, evenement=evenements["evenement_3"])
+    page.goto(url_builder_for_list_ordering("detections", direction, "sv:evenement-liste"))
+    page.get_by_role("link", name="Détections").click()
+    assert_events_order(page, evenements, expected_order)
+
+
+@pytest.mark.parametrize(
+    "direction,expected_order",
+    [
+        ("asc", ["evenement_2", "evenement_1"]),
+        ("desc", ["evenement_1", "evenement_2"]),
+    ],
+    ids=["asc", "desc"],
+)
+def test_order_by_zone(
+    live_server, page: Page, url_builder_for_list_ordering, assert_events_order, direction, expected_order
+):
+    evenements = {
+        "evenement_1": EvenementFactory(),
+        "evenement_2": EvenementFactory(fiche_zone_delimitee=FicheZoneFactory()),
+    }
+    page.goto(url_builder_for_list_ordering("zone", direction, "sv:evenement-liste"))
+    page.get_by_role("link", name="Zone").click()
+    assert_events_order(page, evenements, expected_order)
+
+
+def test_order_by_with_bad_parameters_order_by_date_derniere_mise_a_jour_desc(
+    live_server, page: Page, assert_events_order
+):
+    Evenement._meta.get_field("date_derniere_mise_a_jour").auto_now = False
+    evenements = {
+        "evenement_1": EvenementFactory(date_derniere_mise_a_jour=timezone.make_aware(datetime(2025, 2, 1))),
+        "evenement_2": EvenementFactory(date_derniere_mise_a_jour=timezone.make_aware(datetime(2025, 3, 1))),
+        "evenement_3": EvenementFactory(date_derniere_mise_a_jour=timezone.make_aware(datetime(2025, 1, 1))),
+    }
+    expected_order = ["evenement_2", "evenement_1", "evenement_3"]
+    page.goto(
+        f"{live_server.url}{reverse('sv:evenement-liste')}?order_by=bad_order_by_value&order_dir=bad_order_dir_value"
+    )
+    assert_events_order(page, evenements, expected_order)


### PR DESCRIPTION
Cette PR ajoute la possibilité de pouvoir effectuer un tri (asc ou desc) pour chaque colonne des tableaux de liste d'évènements sauf pour : 
- commune (SV)
- Catégorie de produit (SSA)
- Catégorie de danger (SSA) 

J'ai factorisé la logique dans un nouveau mixin `WithOrderingMixin` (cf. app `core`).
J'ai utilisé un dictionnaire pour faire correspondre les valeurs des paramètres GET autorisés aux champs des modèles. Cela évite d'avoir le nom des champs directement dans les paramètres GET et d'avoir une liste des paramètres GET autorisés.
Ajout de tests pour SV et SSA.