### PR TITLE
Corrige bug modification document enregistré via un élement de suivi

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -109,6 +109,8 @@ class DocumentUpdateView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTest
 
     def get_fiche_object(self):
         self.document = get_object_or_404(Document, pk=self.kwargs.get("pk"))
+        if isinstance(self.document.content_object, Message):
+            return self.document.content_object.content_object
         return self.document.content_object
 
     def get_success_url(self):


### PR DESCRIPTION
Si j'ajoute un élément de suivi avec un document, et que j'essaie de modifier une information du document (nom du fichier, commentaire) via son formulaire de modification, une erreur 500 est générée (cf. erreur Sentry SEVES-4Q) : 
```python
AttributeError
'Message' object has no attribute 'is_draft'
```
Cela vient de la méthode `get_fiche_object` dans la view `DocumentUpdateView`. 
Cette méthode est censé renvoyer l'objet correspondant à l'évènement (`Evenement`) alors que l'objet renvoyé est de type `Message`.