### PR TITLE
Corriger un test sur SSA

### DIFF
--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -221,7 +221,7 @@ def test_create_fiche_detection_with_lieu(
     fill_commune(page)
     lieu_form_elements.coord_gps_wgs84_latitude_input.fill(str(lieu.wgs84_latitude))
     lieu_form_elements.coord_gps_wgs84_longitude_input.fill(str(lieu.wgs84_longitude))
-    lieu_form_elements.is_etablissement_checkbox.click(force=True)
+    lieu_form_elements.is_etablissement_checkbox.click()
     lieu_form_elements.activite_etablissement_input.fill(lieu.activite_etablissement)
     lieu_form_elements.pays_etablissement_input.select_option(lieu.pays_etablissement.code)
     lieu_form_elements.raison_sociale_etablissement_input.fill(lieu.raison_sociale_etablissement)

--- a/sv/tests/test_utils.py
+++ b/sv/tests/test_utils.py
@@ -237,7 +237,7 @@ class LieuFormDomElements:
 
     @property
     def is_etablissement_checkbox(self) -> Locator:
-        return self.page.locator('[id^="id_lieux-"][id$="is_etablissement"]').locator("visible=true")
+        return self.page.locator(".fr-modal__content").locator("visible=true").locator('[for$="is_etablissement"]')
 
     @property
     def is_etablissement_checkbox_checked(self) -> bool:


### PR DESCRIPTION
Avec l'agrandissement du contenu de la modale la case "est établissement" n'était plus trouvé. L'erreur ne remonte pas sur cette ligne à cause du force=True.

- Retrait du force=True pour avoir la vraie source du problème
- Utilisation du label pour le clic : évite d'essayer de cliquer sur la case et que l'événement soit intercepté.