### PR TITLE
Retirer le choix par défaut sur les actions engagées

### DIFF
--- a/ssa/forms.py
+++ b/ssa/forms.py
@@ -59,7 +59,7 @@ class EvenementProduitForm(DSFRForm, WithEvenementProduitFreeLinksMixin, forms.M
         label="Produit Prêt à manger (PAM)",
     )
 
-    actions_engagees = forms.ChoiceField(
+    actions_engagees = SEVESChoiceField(
         required=False,
         choices=ActionEngagees.choices,
         help_text="En cas de multiples mesures, indiquer la plus contraigrante ou la dernière en date",


### PR DESCRIPTION
Retour utilisateur : le champ devrait rester vide tant que l’on n’a pas choisi une action