### PR TITLE
Modification libellé bouton publier événement si AC

### DIFF
--- a/sv/templates/sv/evenement_detail.html
+++ b/sv/templates/sv/evenement_detail.html
@@ -41,11 +41,15 @@
                 <ul class="fr-btns-group fr-btns-group--inline-md">
                     {% if can_publish %}
                         <li>
-                            <button class="fr-btn fr-btn--secondary fr-mr-1w" data-fr-opened="false" aria-controls="fr-modal-publier-without-notifier-ac">Publier sans déclarer à l'AC</button>
+                            <button class="fr-btn fr-btn--secondary fr-mr-1w" data-fr-opened="false" aria-controls="fr-modal-publier-without-notifier-ac">
+                                {% if request.user.agent.structure.is_ac %}Publier{% else %}Publier sans déclarer à l'AC{% endif %}
+                            </button>
                         </li>
-                        <li>
-                            <button class="fr-btn fr-btn--secondary" data-fr-opened="false" aria-controls="fr-modal-publier-and-notifier-ac">Publier et déclarer à l'AC</button>
-                        </li>
+                        {% if not request.user.agent.structure.is_ac %}
+                            <li>
+                                <button class="fr-btn fr-btn--secondary" data-fr-opened="false" aria-controls="fr-modal-publier-and-notifier-ac">Publier et déclarer à l'AC</button>
+                            </li>
+                        {% endif %}
                     {% endif %}
                     <li>
                         <div class="details-top-row--actions">{% include "sv/_evenement_action_navigation.html" %}</div>

--- a/sv/tests/test_evenement_etats.py
+++ b/sv/tests/test_evenement_etats.py
@@ -470,3 +470,13 @@ def test_cant_publish_and_notifier_ac_evenement_i_cant_see(client, mailoutbox):
     assert evenement.is_draft is True
     assert evenement.is_ac_notified is False
     assert len(mailoutbox) == 0
+
+
+def test_show_only_publish_btn_for_ac_users(live_server, page: Page, mocked_authentification_user, contact_ac):
+    contact_structure_mus = ContactStructureFactory(structure__niveau1=AC_STRUCTURE, structure__niveau2=MUS_STRUCTURE)
+    mocked_authentification_user.agent.structure = contact_structure_mus.structure
+    evenement = EvenementFactory(etat=Evenement.Etat.BROUILLON, createur=contact_structure_mus.structure)
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    expect(page.get_by_role("button", name="Publier", exact=True)).to_be_visible()
+    expect(page.get_by_role("button", name="Publier sans déclarer à l'AC")).not_to_be_visible()
+    expect(page.get_by_role("button", name="Publier et déclarer à l'AC")).not_to_be_visible()


### PR DESCRIPTION
Si l'agent connecté est de l'AC alors afficher qu'un bouton "Publier" pour la publication de l'évènement. 