### PR TITLE
Retirer le tri sur la description dans SSA

### DIFF
--- a/ssa/templates/ssa/evenementproduit_list.html
+++ b/ssa/templates/ssa/evenementproduit_list.html
@@ -31,7 +31,7 @@
                     <tr>
                         <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='numero_evenement' display_name='N°' %}</th>
                         <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='creation' display_name='Création' %}</th>
-                        <th class="fr-col-3" scope="col">{% include 'core/_evenement_sort_link.html' with field='description' display_name="Description de l'événement" %}</th>
+                        <th class="fr-col-3" scope="col">Description de l'événement</th>
                         <th class="fr-col-2" scope="col">Catégorie de produit</th>
                         <th class="fr-col-2" scope="col">Catégorie de danger</th>
                         <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='createur' display_name='Créateur' %}</th>

--- a/ssa/tests/test_evenement_produit_list_order.py
+++ b/ssa/tests/test_evenement_produit_list_order.py
@@ -63,27 +63,6 @@ def test_order_by_date_creation(
     ],
     ids=["asc", "desc"],
 )
-def test_order_by_organisme_nuisible(
-    live_server, page: Page, url_builder_for_list_ordering, assert_events_order, direction, expected_order
-):
-    evenements = {
-        "evenement_1": EvenementProduitFactory(description="A"),
-        "evenement_2": EvenementProduitFactory(description="C"),
-        "evenement_3": EvenementProduitFactory(description="B"),
-    }
-    page.goto(url_builder_for_list_ordering("description", direction, "ssa:evenement-produit-liste"))
-    page.get_by_role("link", name="Description de l'événement ").click()
-    assert_events_order(page, evenements, expected_order, 1)
-
-
-@pytest.mark.parametrize(
-    "direction,expected_order",
-    [
-        ("asc", ["evenement_1", "evenement_3", "evenement_2"]),
-        ("desc", ["evenement_2", "evenement_3", "evenement_1"]),
-    ],
-    ids=["asc", "desc"],
-)
 def test_order_by_createur(
     live_server, page: Page, url_builder_for_list_ordering, assert_events_order, direction, expected_order
 ):

--- a/ssa/views/produit.py
+++ b/ssa/views/produit.py
@@ -135,7 +135,6 @@ class EvenementProduitListView(WithOrderingMixin, ListView):
         return {
             "numero_evenement": ("numero_annee", "numero_evenement"),
             "creation": "date_creation",
-            "description": "description",
             "createur": "createur__libelle",
             "etat": "etat",
             "liens": "nb_liens_libre",


### PR DESCRIPTION
- Car cela n'a pas de sens d'un point de vue métier
- Car cela ne fonctionne pas, le filtre est implémenté sur la description alors que la description du tableau est un champ calculé `product_description`

De plus le nom du test est incorrect et parle d'organisme nuisible.