### PR TITLE
Permettre d'éditer un document sur SSA

### DIFF
--- a/core/pages.py
+++ b/core/pages.py
@@ -1,4 +1,4 @@
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 
 class WithMessagePage:
@@ -55,3 +55,27 @@ class WithMessagePage:
     @property
     def message_content_in_sidebar(self):
         return self.page.locator(".sidebar.open").get_by_test_id("message-content")
+
+
+class WithDocumentsPage:
+    def __init__(self, page: Page):
+        self.page = page
+
+    def open_document_tab(self):
+        self.page.get_by_test_id("documents").click()
+
+    def document_title(self, id):
+        return self.page.get_by_test_id(f"document-title-{id}")
+
+    def open_edit_document(self, id):
+        self.page.locator(f'a[aria-controls="fr-modal-edit-{id}"]').click()
+        expect(self.page.locator(f"#fr-modal-edit-{id}")).to_be_visible()
+
+    def document_edit_title(self, id):
+        return self.page.locator(f"#fr-modal-edit-{id} #id_nom")
+
+    def document_edit_description(self, id):
+        return self.page.locator(f"#fr-modal-edit-{id} #id_description")
+
+    def document_edit_save(self, id):
+        self.page.get_by_test_id(f"documents-edit-{id}").click()

--- a/core/templates/core/_carte_resume_document.html
+++ b/core/templates/core/_carte_resume_document.html
@@ -3,7 +3,7 @@
         <div class="fr-card__content document__details {% if document.is_deleted %}document__details--deleted{% endif %}">
             <p class="fr-hint-text fr-mb-0-5v">Ajouté le {{ document.date_creation }}</p>
             <p class="fr-text--sm document__details--structure fr-mb-1v">{{ document.created_by_structure.libelle | default:document.created_by_structure.niveau2 | upper }}</p>
-            <p class="fr-text--sm fr-mb-0-5v fr-text--bold">{{ document.nom }}
+            <p class="fr-text--sm fr-mb-0-5v fr-text--bold" data-testid="document-title-{{ document.pk }}">{{ document.nom }}
                 {% if document.description %}
                     <button class="fr-btn--tooltip fr-btn" type="button" id="button-{{ document.pk }}" aria-describedby="tooltip-{{ document.pk }}">
                         Information contextuelle

--- a/core/templates/core/_modale_edition_document.html
+++ b/core/templates/core/_modale_edition_document.html
@@ -16,10 +16,7 @@
                             <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg">
 
                                 {% csrf_token %}
-                                <input type="hidden" value="{{ document.pk }}" name="pk">
-                                <input type="hidden" value="{{ evenement.get_absolute_url }}" name="next">
                                 <button type="submit" class="fr-btn" data-testid="documents-edit-{{ document.pk }}">Enregistrer les modifications</button>
-
                             </div>
                         </div>
                     </form>

--- a/core/views.py
+++ b/core/views.py
@@ -114,7 +114,7 @@ class DocumentUpdateView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTest
         return self.document.content_object
 
     def get_success_url(self):
-        return self.request.POST.get("next") + "#tabpanel-documents-panel"
+        return self.get_fiche_object().get_absolute_url() + "#tabpanel-documents-panel"
 
     def form_valid(self, form):
         response = super().form_valid(form)


### PR DESCRIPTION
La redirection après l'édition d'un document dans SSA ne fonctionnait pas faute de paramètre next passé dans le template.

J'ai simplifié le code, car a priori on veut toujours ramener à la fiche après l'édition d'un document, nous n'avons donc plus besoin de ce paramètre.
Je commence a ajouter la notion de test "générique" pour les bloc commun, sur la base des pages on pourrait avoir une matrice de test commune pour plusieurs modèles.