### PR TITLE
Corriger l'envoi de message sur SSA

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -31,3 +31,5 @@ fileignoreconfig:
   checksum: 9717807f321037aee25f9711e052e85b2b9e2df83bcce796d1931e04ab2f53fb
 - filename: conftest.py
   checksum: a17ce992990a59928baab025a092e3d561dd5f5bdee013ec86ceafcb21d07359
+- filename: core/pages.py
+  checksum: 292dc4f6a239dfc2068d4144f0dd2617271f6d42aa5f3b878877722907751204

--- a/core/pages.py
+++ b/core/pages.py
@@ -1,0 +1,57 @@
+from playwright.sync_api import Page
+
+
+class WithMessagePage:
+    def __init__(self, page: Page):
+        self.page = page
+
+    def new_message(self):
+        self.page.get_by_test_id("element-actions").click()
+        self.page.get_by_role("link", name="Message").click()
+
+    def pick_recipient(self, contact, choice_js_fill):
+        choice_js_fill(
+            self.page,
+            'label[for="id_recipients"] ~ div.choices',
+            contact.nom,
+            contact.contact_set.get().display_with_agent_unit,
+            use_locator_as_parent_element=True,
+        )
+
+    @property
+    def message_form_title(self):
+        return self.page.locator("#message-type-title")
+
+    @property
+    def message_title(self):
+        return self.page.locator("#id_title")
+
+    @property
+    def message_content(self):
+        return self.page.locator("#id_content")
+
+    def submit_message(self):
+        self.page.get_by_test_id("fildesuivi-add-submit").click()
+
+    def message_sender_in_table(self, index=1):
+        return self.page.text_content(f"#table-sm-row-key-{index} td:nth-child(2) a")
+
+    def message_recipient_in_table(self, index=1):
+        return self.page.text_content(f"#table-sm-row-key-{index} td:nth-child(3) a")
+
+    def message_title_in_table(self, index=1):
+        return self.page.text_content(f"#table-sm-row-key-{index} td:nth-child(4) a")
+
+    def message_type_in_table(self, index=1):
+        return self.page.text_content(f"#table-sm-row-key-{index} td:nth-child(6) a")
+
+    def open_message(self, index=1):
+        self.page.locator(f"#table-sm-row-key-{index} td:nth-child(6) a").click()
+
+    @property
+    def message_title_in_sidebar(self):
+        return self.page.locator(".sidebar.open h5")
+
+    @property
+    def message_content_in_sidebar(self):
+        return self.page.locator(".sidebar.open").get_by_test_id("message-content")

--- a/core/static/core/message_form.js
+++ b/core/static/core/message_form.js
@@ -89,8 +89,10 @@ function getMessageConfig(){
     const copieStructuresElement = document.querySelector('label[for="id_recipients_copy_structures_only"]').parentNode
 
     let limitedRecipientsElement = null
+    let limitedRecipientsInput = null
     if (isLimitedRecipientsASelect()) {
         limitedRecipientsElement = document.getElementById("id_recipients_limited_recipients").parentNode.parentNode.parentNode
+        limitedRecipientsInput =  document.getElementById("id_recipients_limited_recipients")
     } else {
         limitedRecipientsElement = document.getElementById("id_recipients_limited_recipients").parentNode
     }
@@ -113,6 +115,9 @@ function getMessageConfig(){
             toShow: [helpElement],
             required: []
         }
+    }
+    if (isLimitedRecipientsASelect()) {
+        configuration["compte rendu sur demande d'intervention"].required = [limitedRecipientsInput]
     }
     return [configuration, allElements, allRequiredInputs]
 }

--- a/core/tests/generic_tests/messages.py
+++ b/core/tests/generic_tests/messages.py
@@ -1,0 +1,31 @@
+from playwright.sync_api import Page, expect
+
+from core.factories import ContactAgentFactory
+from core.models import Message
+from core.pages import WithMessagePage
+
+
+def generic_test_can_add_and_see_message_without_document(live_server, page: Page, choice_js_fill, object):
+    active_contact = ContactAgentFactory(with_active_agent=True).agent
+
+    page.goto(f"{live_server.url}{object.get_absolute_url()}")
+    message_page = WithMessagePage(page)
+    message_page.new_message()
+    message_page.pick_recipient(active_contact, choice_js_fill)
+    expect(message_page.message_form_title).to_have_text("message")
+
+    message_page.message_title.fill("Title of the message")
+    message_page.message_content.fill("My content \n with a line return")
+    message_page.submit_message()
+
+    page.wait_for_url(f"**{object.get_absolute_url()}#tabpanel-messages-panel")
+
+    assert message_page.message_sender_in_table() == "Structure Test"
+    assert message_page.message_recipient_in_table() == str(active_contact)
+    assert message_page.message_title_in_table() == "Title of the message"
+    assert message_page.message_type_in_table() == "Message"
+    message_page.open_message()
+
+    expect(message_page.message_title_in_sidebar).to_be_visible()
+    assert "My content <br> with a line return" in message_page.message_content_in_sidebar.inner_html()
+    assert object.messages.get().status == Message.Status.FINALISE

--- a/ssa/forms.py
+++ b/ssa/forms.py
@@ -116,7 +116,7 @@ class EtablissementForm(DSFRForm, forms.ModelForm):
 
 class MessageForm(BaseMessageForm):
     recipients_limited_recipients = ContactModelMultipleChoiceField(
-        queryset=Contact.objects.get_ssa_structures(), label="Destinataires"
+        queryset=Contact.objects.get_ssa_structures(), label="Destinataires", required=False
     )
     manual_render_fields = [
         "recipients_structures_only",

--- a/ssa/tests/test_evenement_produit_message.py
+++ b/ssa/tests/test_evenement_produit_message.py
@@ -2,6 +2,7 @@ from playwright.sync_api import Page, expect
 
 from core.constants import MUS_STRUCTURE
 from core.factories import ContactStructureFactory
+from core.tests.generic_tests.messages import generic_test_can_add_and_see_message_without_document
 from ssa.factories import EvenementProduitFactory
 from ssa.models import EvenementProduit
 from ssa.tests.pages import EvenementProduitDetailsPage
@@ -26,3 +27,8 @@ def test_can_add_and_see_compte_rendu(live_server, page: Page, choice_js_fill):
     assert details_page.fil_de_suivi_recipients == "MUS"
     assert details_page.fil_de_suivi_title == "Title of the message"
     assert details_page.fil_de_suivi_type == "Compte rendu sur demande d'intervention"
+
+
+def test_can_add_and_see_message_without_document(live_server, page: Page, choice_js_fill):
+    evenement = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    generic_test_can_add_and_see_message_without_document(live_server, page, choice_js_fill, evenement)

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -11,6 +11,7 @@ from playwright.sync_api import Page, expect
 
 from core.factories import ContactAgentFactory, ContactStructureFactory, StructureFactory, DocumentFactory
 from core.models import Message, Contact, Structure, Visibilite, Document, FinSuiviContact
+from core.tests.generic_tests.messages import generic_test_can_add_and_see_message_without_document
 from seves import settings
 from sv.factories import EvenementFactory
 from sv.models import Evenement
@@ -19,45 +20,8 @@ User = get_user_model()
 
 
 def test_can_add_and_see_message_without_document(live_server, page: Page, choice_js_fill):
-    active_contact = ContactAgentFactory(with_active_agent=True).agent
     evenement = EvenementFactory()
-
-    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
-    page.get_by_test_id("element-actions").click()
-    page.get_by_role("link", name="Message").click()
-
-    choice_js_fill(
-        page,
-        'label[for="id_recipients"] ~ div.choices',
-        active_contact.nom,
-        active_contact.contact_set.get().display_with_agent_unit,
-        use_locator_as_parent_element=True,
-    )
-    expect(page.locator("#message-type-title")).to_have_text("message")
-    page.locator("#id_title").fill("Title of the message")
-    page.locator("#id_content").fill("My content \n with a line return")
-    page.get_by_test_id("fildesuivi-add-submit").click()
-
-    page.wait_for_url(f"**{evenement.get_absolute_url()}#tabpanel-messages-panel")
-
-    cell_selector = f"#table-sm-row-key-1 td:nth-child({2}) a"
-    assert page.text_content(cell_selector) == "Structure Test"
-
-    cell_selector = f"#table-sm-row-key-1 td:nth-child({3}) a"
-    assert page.text_content(cell_selector).strip() == str(active_contact)
-
-    cell_selector = f"#table-sm-row-key-1 td:nth-child({4}) a"
-    assert page.text_content(cell_selector) == "Title of the message"
-
-    cell_selector = f"#table-sm-row-key-1 td:nth-child({6}) a"
-    assert page.text_content(cell_selector) == "Message"
-
-    page.locator(cell_selector).click()
-
-    expect(page.get_by_role("heading", name="Title of the message")).to_be_visible()
-    assert "My content <br> with a line return" in page.get_by_test_id("message-content").inner_html()
-
-    assert evenement.messages.get().status == Message.Status.FINALISE
+    generic_test_can_add_and_see_message_without_document(live_server, page, choice_js_fill, evenement)
 
 
 def test_can_add_and_see_demande_intervention(live_server, page: Page, choice_js_fill):


### PR DESCRIPTION
Suite au changement de form sur les destinataires l'envoi de message ne fonctionnait plus sur SSA.

- Correction du problème (champ requis / non requis en fonction du type de message)
- Introduction d'un comportement de test générique pour les test qui sont 100% similaires entre plusieurs domaines