### PR TITLE
Pouvoir ajouter tous les contacts d'un événement dans les destinaires d'un message

### DIFF
--- a/core/static/core/message.css
+++ b/core/static/core/message.css
@@ -32,11 +32,6 @@ label[for=id_recipients]::after, label[for=id_recipients_structures_only]::after
     display: flex;
     justify-content: end;
 }
-label[for=id_recipients], label[for=id_recipients_copy], label[for=id_recipients_structures_only], label[for=id_recipients_copy_structures_only]
-{
-    display: flex;
-    justify-content: space-between;
-}
 .message-draft, .message-draft .fr-tag {
     font-style: italic;
     color: var(--text-disabled-grey);

--- a/core/static/core/message_form.js
+++ b/core/static/core/message_form.js
@@ -63,15 +63,15 @@ function onFileInputChange(fileInput, typeInput, messageAddDocumentButton) {
     }
 }
 
-function addStructuresToRecipients(event, choiceElements){
+function addStructuresToRecipients(event, choiceElements, dataAttribute){
     event.preventDefault()
-    choiceElements.forEach(element =>{element.setChoiceByValue(event.target.getAttribute("data-structures").split(","))})
+    choiceElements.forEach(element =>{element.setChoiceByValue(event.target.getAttribute(dataAttribute).split(","))})
 }
 
-function addShortcut(classToWatch, elements){
+function addShortcut(classToWatch, elements, dataAttribute){
     const destinatairesShortcutElement = document.querySelectorAll(classToWatch)
     destinatairesShortcutElement.forEach(shortcut => {
-        shortcut.addEventListener("click", event => addStructuresToRecipients(event, elements))
+        shortcut.addEventListener("click", event => addStructuresToRecipients(event, elements, dataAttribute))
     })
 }
 
@@ -247,8 +247,10 @@ document.addEventListener('DOMContentLoaded', function () {
         initializeChoices(document.getElementById("id_recipients_limited_recipients"))
     }
 
-    addShortcut(".destinataires-shortcut", [choicesRecipients, choicesStructuresRecipients]);
-    addShortcut(".copie-shortcut", [choicesCopy, choicesStructuresCopy]);
+    addShortcut(".destinataires-shortcut", [choicesRecipients, choicesStructuresRecipients], "data-structures");
+    addShortcut(".copie-shortcut", [choicesCopy, choicesStructuresCopy], "data-structures");
+    addShortcut(".destinataires-contacts-shortcut", [choicesRecipients], "data-contacts");
+    addShortcut(".copie-contacts-shortcut", [choicesCopy], "data-contacts");
     document.querySelectorAll(".open-sidebar").forEach(element =>{
         element.addEventListener("click", event =>{
             changeFormBasedOnMessageType(event.target.dataset.messageType)

--- a/sv/tests/test_evenement_performance_details.py
+++ b/sv/tests/test_evenement_performance_details.py
@@ -120,7 +120,7 @@ def test_evenement_performances_when_adding_structure(client, django_assert_num_
     for structure in ContactStructureFactory.create_batch(10):
         evenement.contacts.add(structure)
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 1):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 2):
         client.get(evenement.get_absolute_url())
 
 


### PR DESCRIPTION
Ajout d'un lien permettant d'ajouter tous les contacts d'un événement lors de la rédaction d'un élément de suivi dans les destinataires ou copie.