### PR TITLE
Améliorer l'affichage de la position dans le dossier

### DIFF
--- a/ssa/models/etablissement.py
+++ b/ssa/models/etablissement.py
@@ -95,12 +95,12 @@ class Etablissement(models.Model):
 
     @classmethod
     def get_position_dossier_css_class(self, value):
-        RED_CASES = [
+        IMPORTANT_CASES = [
             PositionDossier.SURVENUE_NON_CONFORMITE,
             PositionDossier.DETECTION_NON_CONFORMITE,
             PositionDossier.DETECTION_ET_SURVENUE_NON_CONFORMITE,
         ]
-        return "fr-badge--error" if value in RED_CASES else "fr-badge--info"
+        return "fr-badge--info" if value in IMPORTANT_CASES else ""
 
     @property
     def position_dossier_css_class(self):

--- a/ssa/static/ssa/_etablissement_card.css
+++ b/ssa/static/ssa/_etablissement_card.css
@@ -15,3 +15,6 @@
 .raison-sociale {
     font-weight: bold;
 }
+.position-dossier::before {
+    content: none;
+}

--- a/ssa/static/ssa/_etablissement_form.js
+++ b/ssa/static/ssa/_etablissement_form.js
@@ -141,7 +141,9 @@ document.addEventListener('DOMContentLoaded', () => {
             baseCard.querySelector('.position-dossier').innerText = positionDossier
             baseCard.querySelector('.position-dossier').classList.remove("fr-hidden")
             const extraClass = positionDossierInput.options[positionDossierInput.selectedIndex].dataset.extraClass
-            baseCard.querySelector('.position-dossier').classList.add(extraClass)
+            if (!!extraClass){
+                baseCard.querySelector('.position-dossier').classList.add(extraClass)
+            }
         }
         return baseCard
     }


### PR DESCRIPTION
- Retirer l'icone pour être conforme à la maquette
- Changement de couleur pour éviter d'utiliser le rouge qui pourrait être synonyme de problème alors que c'est plutôt de l'ordre de l'information importante