### PR TITLE
Améliorer la gestions des établissements

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -37,4 +37,5 @@ fileignoreconfig:
   checksum: 51c1b202eb0400ca7694cf33aba8576e0e86e75238b25a1fd5b21125dea83580
 - filename: sv/tests/test_evenement_message.py
   checksum: 1314596f364b4ad7da911e291af1d6224cf310254b567e31066fb48837474dfe
-- filename: core/templates/core/_tableau_fil_de_suivi.html
+- filename: ssa/forms.py
+  checksum: 81cfbcafe674609598356abbfee6ea13464258219b2c38a0088a6de0985c7a3a

--- a/ssa/forms.py
+++ b/ssa/forms.py
@@ -11,6 +11,7 @@ from ssa.fields import SelectWithAttributeField
 from ssa.form_mixins import WithEvenementProduitFreeLinksMixin
 from ssa.models import Etablissement, TypeExploitant, PositionDossier, CategorieDanger
 from ssa.models import EvenementProduit, TypeEvenement, Source, TemperatureConservation, ActionEngagees
+from ssa.models.departements import Departement
 from ssa.models.evenement_produit import PretAManger, QuantificationUnite, CategorieProduit
 from ssa.widgets import PositionDossierWidget
 
@@ -108,10 +109,24 @@ class EtablissementForm(DSFRForm, forms.ModelForm):
     position_dossier = SEVESChoiceField(
         choices=PositionDossier.choices, label="Position dossier", required=False, widget=PositionDossierWidget
     )
+    departement = SEVESChoiceField(
+        choices=sorted(Departement.choices, key=lambda c: c[1]), required=False, label="Département"
+    )
 
     class Meta:
         model = Etablissement
-        exclude = []
+        fields = [
+            "siret",
+            "numero_agrement",
+            "raison_sociale",
+            "adresse_lieu_dit",
+            "commune",
+            "code_insee",
+            "departement",
+            "pays",
+            "type_exploitant",
+            "position_dossier",
+        ]
 
 
 class MessageForm(BaseMessageForm):

--- a/ssa/static/ssa/_etablissement_form.js
+++ b/ssa/static/ssa/_etablissement_form.js
@@ -82,8 +82,13 @@ document.addEventListener('DOMContentLoaded', () => {
         setTimeout(() => {
             dsfr(modal).modal.disclose()
             dsfr(modal).modal.node.addEventListener('dsfr.conceal', event => {
+                if (modal.dataset.needsRestoreBackup === "false"){
+                    modal.dataset.needsRestoreBackup = ""
+                    removeRequired(modal)
+                    return
+                }
                 removeRequired(modal)
-                if (!event.target.classList.contains("save-btn") && !!modalEtablissementHTMLContent[nextIdToUse]) {
+                if (!!modalEtablissementHTMLContent[nextIdToUse]) {
                     event.target.querySelector(".fr-modal__content").replaceWith(modalEtablissementHTMLContent[nextIdToUse])
                     modalEtablissementHTMLContent[nextIdToUse] = null
                 }
@@ -98,9 +103,6 @@ document.addEventListener('DOMContentLoaded', () => {
             event.preventDefault()
             submitFormAndAddEtablissementCard(event)
         })
-
-
-
     }
 
     function getSelectedLabel(element) {
@@ -132,8 +134,14 @@ document.addEventListener('DOMContentLoaded', () => {
         const structure = `Département : ${currentModal.querySelector('[id$=departement]').value || 'nc.'}`
         baseCard.querySelector('.structure').textContent = structure
 
-        const numeroAgrement = `N° d'agrément : ${currentModal.querySelector('[id$=numero_agrement]').value || 'nc.'}`
-        baseCard.querySelector('.numero-agrement').textContent = numeroAgrement
+        const numeroAgrementValue = currentModal.querySelector('[id$=numero_agrement]').value
+        if (!!numeroAgrementValue) {
+            baseCard.querySelector('.numero-agrement').textContent = `N° d'agrément : ${numeroAgrementValue}`
+            baseCard.querySelector('.numero-agrement').classList.remove("fr-hidden")
+        } else {
+            baseCard.querySelector('.numero-agrement').classList.add("fr-hidden")
+        }
+
 
         const positionDossierInput = currentModal.querySelector('[id$=position_dossier]')
         const positionDossier = getSelectedLabel(positionDossierInput)
@@ -177,6 +185,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         dsfr(currentModal).modal.conceal()
+        currentModal.dataset.needsRestoreBackup = "false"
         removeRequired(currentModal)
     }
 

--- a/ssa/templates/ssa/_etablissement_block.html
+++ b/ssa/templates/ssa/_etablissement_block.html
@@ -14,7 +14,7 @@
                 <div class="fr-col-12 fr-col-md-8">
                     <div class="fr-modal__body">
                         <div class="fr-modal__header">
-                            <a href="#" class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-etablissement__prefix__" target="_self">Fermer</a>
+                            <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-etablissement__prefix__" type="button">Fermer</button>
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-title-modal--etablissement__prefix__" class="fr-modal__title"><span class="fr-icon-arrow-right-line fr-icon--lg"></span>Ajouter un établissement</h1>
@@ -33,7 +33,7 @@
                         </div>
                         <div class="fr-modal__footer">
                             <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg">
-                                <a href="#" class="fr-btn fr-btn--secondary" aria-controls="fr-modal-etablissement__prefix__">Annuler</a>
+                                <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-etablissement__prefix__" type="button">Annuler</button>
                                 <button type="submit" class="fr-btn save-btn" id="etablissement-save-btn-__prefix__">Enregistrer</button>
                             </div>
                         </div>
@@ -84,7 +84,7 @@
         <p class="type-exploitant fr-tag fr-hidden fr-mb-2v"></p>
         <p class="pays fr-tag fr-hidden fr-mb-2v"></p>
         <div class="structure"></div>
-        <div class="numero-agrement"></div>
+        <div class="numero-agrement fr-hidden"></div>
         <p class="position-dossier fr-badge fr-hidden fr-my-2v"></p>
     </div>
 </template>

--- a/ssa/templates/ssa/_modal_etablissement_details.html
+++ b/ssa/templates/ssa/_modal_etablissement_details.html
@@ -1,3 +1,4 @@
+
 <dialog aria-labelledby="fr-modal-title-modal-etablissement-{{ etablissement.pk }}" role="dialog"
         id="fr-modal-etablissement-{{ etablissement.pk }}" class="fr-modal">
     <div class="fr-container fr-container--fluid fr-container-md">
@@ -16,6 +17,10 @@
                             <div class="fr-grid-row fr-grid-row--gutters">
                                 <div class="fr-col-5 bold">Siret</div>
                                 <div class="fr-col-7">{{ etablissement.siret|default:"nc." }}</div>
+                            </div>
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-col-5 bold">N° agrément</div>
+                                <div class="fr-col-7">{{ etablissement.numero_agrement|default:"nc." }}</div>
                             </div>
                             <div class="fr-grid-row fr-grid-row--gutters">
                                 <div class="fr-col-5 bold">Adresse</div>
@@ -41,10 +46,7 @@
                                 <div class="fr-col-5 bold">Position dossier</div>
                                 <div class="fr-col-7">{% if etablissement.position_dossier %}<p class="position-dossier fr-badge {{ etablissement.position_dossier_css_class }} fr-my-2v">{{ etablissement.get_position_dossier_display }}</p>{% else %}nc.{% endif %}</div>
                             </div>
-                            <div class="fr-grid-row fr-grid-row--gutters">
-                                <div class="fr-col-5 bold">N° agrément</div>
-                                <div class="fr-col-7">{{ etablissement.numero_agrement|default:"nc." }}</div>
-                            </div>
+
                         </div>
                     </div>
                 </div>

--- a/ssa/tests/test_evenement_produit_creation.py
+++ b/ssa/tests/test_evenement_produit_creation.py
@@ -164,6 +164,30 @@ def test_can_add_etablissements(live_server, page: Page, assert_models_are_equal
     assert_models_are_equal(etablissements[2], etablissement_3, to_exclude=FIELD_TO_EXCLUDE_ETABLISSEMENT)
 
 
+def test_can_edit_etablissement_multiple_times(live_server, page: Page, assert_models_are_equal):
+    evenement = EvenementProduitFactory()
+
+    etablissement = EtablissementFactory.build(evenement_produit=evenement)
+
+    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page.navigate()
+    creation_page.fill_required_fields(evenement)
+    creation_page.add_etablissement(etablissement)
+    creation_page.open_edit_etablissement()
+    creation_page.current_modal.locator('[id$="-departement"]').select_option("Ain")
+    creation_page.close_etablissement_modal()
+
+    creation_page.open_edit_etablissement()
+    creation_page.current_modal.locator('[id$="-departement"]').select_option("Aisne")
+    creation_page.close_etablissement_modal()
+
+    creation_page.submit_as_draft()
+    creation_page.page.wait_for_timeout(600)
+
+    etablissement = Etablissement.objects.get()
+    assert etablissement.departement == "Aisne"
+
+
 def test_card_etablissement_content(live_server, page: Page):
     etablissement = EtablissementFactory()
 


### PR DESCRIPTION
- Rendre l'ordre des champs consistants entre la création et la page de détails
- Eviter que la fermeture de la modale ramène en haut de page
- Corrige un bug en cas d'édition multiple de la modale
- Tri les départements par ordre alpha