### PR TITLE
Ajouter des filtres dans la liste SSA

### DIFF
--- a/core/templates/core/_dsfr_div.html
+++ b/core/templates/core/_dsfr_div.html
@@ -14,10 +14,10 @@
         {% if field.help_text %}
           <span class="helptext fr-hint-text"{% if field.auto_id %} id="{{ field.auto_id }}_helptext"{% endif %}>{{ field.help_text|safe }}</span>
         {% endif %}
-        {% if forloop.last %}
-          {% for field in hidden_fields %}{{ field }}{% endfor %}
-        {% endif %}
       </div>
+    {% endif %}
+    {% if forloop.last %}
+      {% for field in hidden_fields %}{{ field }}{% endfor %}
     {% endif %}
   {% endfor %}
   {% if not fields and not errors %}

--- a/ssa/static/ssa/_custom_tree_select.css
+++ b/ssa/static/ssa/_custom_tree_select.css
@@ -1,0 +1,60 @@
+.treeselect-list__group-container {
+    background-color: var(--background-contrast-grey);
+
+}
+
+.treeselect-list__item-icon {
+    fill : var(--text-action-high-blue-france);
+}
+
+.treeselect-list__item {
+    height: 40px !important;
+}
+
+.treeselect-list__item-label{
+    font-size: 16px !important;
+}
+
+.treeselect-list__item[level="0"] {
+    color: var(--text-action-high-blue-france);
+}
+
+.treeselect-list__item[level="1"]{
+    border-bottom: 1px solid #BBBBBB;
+    padding-left: 20px !important;
+}
+
+
+.treeselect-list__item[level="2"] {
+    background-color: #DDDDDD;
+    padding-left: 40px !important;
+}
+
+.treeselect-input {
+    background-color: var(--background-contrast-grey) !important;
+    border-radius: 0px !important;
+}
+
+.treeselect-list__group-container .treeselect-list__item--focused {
+    background-color : #FFF !important
+}
+
+
+.treeselect-list__item--checked .treeselect-list__item-checkbox-container {
+    background-color: var(--background-action-high-blue-france) !important;
+}
+
+.treeselect-list__item-icon {
+    width: 100% !important;
+    order: 2
+}
+.treeselect-list__item-icon svg{
+    width: 20px !important;
+    order: 2;
+    margin-left: auto;
+    stroke: var(--background-action-high-blue-france) !important;
+}
+
+.treeselect-list__item-checkbox-container {
+    margin-right: 10px;
+}

--- a/ssa/static/ssa/_custom_tree_select.js
+++ b/ssa/static/ssa/_custom_tree_select.js
@@ -1,0 +1,55 @@
+export function patchItems(element){
+    setTimeout(() => {
+        element.querySelectorAll('.treeselect-list__item').forEach(itemElement => {
+
+      // Show checkbox / radio is the element can be selected
+            if (!itemElement.classList.contains("treeselect-list__item--non-selectable-group")){
+                const checkboxContainer = itemElement.querySelector(".treeselect-list__item-checkbox-container")
+                if (!!checkboxContainer){
+                    checkboxContainer.style.display = "initial"
+                }
+            }
+
+            const iconElement =  itemElement.querySelector(".treeselect-list__item-icon")
+            if (!iconElement) {
+                return
+            }
+
+      // If element has children hide the label (which triggers on click the selection of the element)
+      // and copy the text from the label next to the icon (which triggers on click the opening/closing of the group)
+            const label = itemElement.querySelector(".treeselect-list__item-label")
+            label.style.display = "none"
+            if (iconElement.innerHTML.includes(label.innerText)) return;
+            iconElement.innerHTML += label.innerText
+        });
+    }, 0);
+}
+
+export function findPath(value, options, path = []) {
+    for (const node of options) {
+        if (node.value === value) {
+            return [...path, node];
+        }
+        if (node.children) {
+            const result = findPath(value, node.children, [...path, node]);
+            if (result) return result;
+        }
+    }
+    return null;
+}
+
+export function addLevel2CategoryIfAllChildrenAreSelected(options, selectedOptions){
+    const result = [...selectedOptions]
+
+    options.forEach(level1 => {
+        level1.children.forEach(level2 => {
+            const level3Ids = level2.children .map(c => c.value)
+            if (level3Ids.length && level3Ids.every(value => selectedOptions.includes(value))) {
+                if (!result.includes(level2.value)) {
+                    result.push(level2.value);
+                }
+            }
+        });
+    });
+    return result
+}

--- a/ssa/static/ssa/evenement_produit_form.css
+++ b/ssa/static/ssa/evenement_produit_form.css
@@ -70,62 +70,7 @@
     text-align: center;
 }
 
-.treeselect-list__group-container {
-    background-color: var(--background-contrast-grey);
-
-}
-
-.treeselect-list__item-icon {
-    fill : var(--text-action-high-blue-france);
-}
-
-.treeselect-list__item {
-    height: 40px !important;
-}
-
-.treeselect-list__item-label{
-    font-size: 16px !important;
-}
-
-.treeselect-list__item[level="0"] {
-    color: var(--text-action-high-blue-france);
-}
-
-.treeselect-list__item[level="1"]{
-    border-bottom: 1px solid #BBBBBB;
-    padding-left: 20px !important;
-}
-
-
-.treeselect-list__item[level="2"] {
-    background-color: #DDDDDD;
-    padding-left: 40px !important;
-}
-
-.treeselect-input {
-    background-color: var(--background-contrast-grey) !important;
-}
-
-.treeselect-list__group-container .treeselect-list__item--focused {
-    background-color : #FFF !important
-}
-
 .treeselect-list__item-checkbox-container {
     border-radius: 40px !important;
     margin-right: 10px;
-}
-
-.treeselect-list__item--checked .treeselect-list__item-checkbox-container {
-    background-color: var(--background-action-high-blue-france) !important;
-}
-
-.treeselect-list__item-icon {
-    width: 100% !important;
-    order: 2
-}
-.treeselect-list__item-icon svg{
-    width: 20px !important;
-    order: 2;
-    margin-left: auto;
-    stroke: var(--background-action-high-blue-france) !important;
 }

--- a/ssa/static/ssa/evenement_produit_form.js
+++ b/ssa/static/ssa/evenement_produit_form.js
@@ -1,18 +1,5 @@
 import {setUpFreeLinks} from "/static/core/free_links.js";
-
-function findPath(value, options, path = []) {
-  for (const node of options) {
-    if (node.value === value) {
-      return [...path, node];
-    }
-    if (node.children) {
-      const result = findPath(value, node.children, [...path, node]);
-      if (result) return result;
-    }
-  }
-  return null;
-}
-
+import {patchItems, findPath} from "/static/ssa/_custom_tree_select.js"
 
 document.addEventListener('DOMContentLoaded', () => {
   function disableSourceOptions(typeEvenementInput, sourceInput) {
@@ -27,33 +14,6 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
     sourceInput.selectedIndex = 0;
-  }
-
-  function patchItems(element){
-    setTimeout(() => {
-      element.querySelectorAll('.treeselect-list__item').forEach(itemElement => {
-
-      // Show checkbox / radio is the element can be selected
-        if (!itemElement.classList.contains("treeselect-list__item--non-selectable-group")){
-          const checkboxContainer = itemElement.querySelector(".treeselect-list__item-checkbox-container")
-          if (!!checkboxContainer){
-            checkboxContainer.style.display = "initial"
-          }
-        }
-
-        const iconElement =  itemElement.querySelector(".treeselect-list__item-icon")
-        if (!iconElement) {
-          return
-        }
-
-      // If element has children hide the label (which triggers on click the selection of the element)
-      // and copy the text from the label next to the icon (which triggers on click the opening/closing of the group)
-        const label = itemElement.querySelector(".treeselect-list__item-label")
-        label.style.display = "none"
-        if (iconElement.innerHTML.includes(label.innerText)) return;
-        iconElement.innerHTML += label.innerText
-      });
-    }, 0);
   }
 
   function setupCategorieProduit(){

--- a/ssa/static/ssa/evenement_produit_list.css
+++ b/ssa/static/ssa/evenement_produit_list.css
@@ -12,6 +12,8 @@
 .evenements_liste__header--actions {
     display: flex;
     justify-content: flex-end;
+    margin-top: auto;
+    margin-bottom: auto;
 }
 .more-filters-title {
     display: flex;
@@ -28,8 +30,12 @@
     align-items: flex-end;
     gap: 0.5rem;
 }
+.fr-fieldset__element:has([id=id_categorie_produit]), .fr-fieldset__element:has([id=id_categorie_danger]) {
+    display: None;
+}
+
 .evenements_liste__search-form .fr-fieldset__element{
-    flex: 1 1 200px;
+    flex: 1 1 250px;
     max-width: 300px;
 }
 .ellipsis {

--- a/ssa/static/ssa/evenement_produit_list.js
+++ b/ssa/static/ssa/evenement_produit_list.js
@@ -1,21 +1,76 @@
+import {patchItems, addLevel2CategoryIfAllChildrenAreSelected} from "/static/ssa/_custom_tree_select.js"
+
 document.addEventListener('DOMContentLoaded', function() {
-    const searchForm = document.getElementById('search-form')
-    searchForm.addEventListener('reset', function (e) {
-        e.preventDefault()
+    function resetAndSubmit(event){
+        const searchForm = document.getElementById('search-form')
+        event.preventDefault()
         resetForm(searchForm)
         searchForm.submit()
-    });
+    }
 
-    document.querySelector(".clear-btn").addEventListener("click", (event)=>{
+    function clearSidebarFilters(event) {
         event.preventDefault()
         resetForm(document.getElementById("sidebar"))
-    })
+    }
 
-    document.querySelector(".add-btn").addEventListener("click", (event)=>{
+    function addSidebarFilters(event) {
         event.preventDefault()
         event.target.closest(".sidebar").classList.toggle('open');
         document.querySelector('.main-container').classList.toggle('open')
-    })
+    }
+    function setupCategorieProduit(){
+        const options = JSON.parse(document.getElementById("categorie-produit-data").textContent)
+        const parentContainer = document.getElementById("categorie-produit")
+        const selectedValues = parentContainer.dataset.selected.split("||").map(v => v.trim())
+        const treeselect = new Treeselect({
+            parentHtmlContainer: parentContainer,
+            value: selectedValues,
+            options: options,
+            showTags: false,
+            placeholder: "Choisir",
+            openCallback() {
+                patchItems(treeselect.srcElement)
+            },
+        })
+        document.querySelector("#categorie-produit .treeselect-input").classList.add("fr-input")
+        patchItems(treeselect.srcElement)
+        treeselect.srcElement.addEventListener("update-dom", ()=>{patchItems(treeselect.srcElement)})
+
+        treeselect.srcElement.addEventListener('input', (e) => {
+            const values = addLevel2CategoryIfAllChildrenAreSelected(options, e.detail)
+            document.getElementById("id_categorie_produit").value = values.join("||")
+        })
+    }
+
+    function setupCategorieDanger(){
+        const options = JSON.parse(document.getElementById("categorie-danger-data").textContent)
+        const parentContainer = document.getElementById("categorie-danger")
+        const selectedValues = parentContainer.dataset.selected.split("||").map(v => v.trim())
+        const treeselect = new Treeselect({
+            parentHtmlContainer: parentContainer,
+            value: selectedValues,
+            options: options,
+            showTags: false,
+            placeholder: "Choisir",
+            openCallback() {
+                patchItems(treeselect.srcElement)
+            },
+        })
+        document.querySelector("#categorie-danger .treeselect-input").classList.add("fr-input")
+        patchItems(treeselect.srcElement)
+        treeselect.srcElement.addEventListener("update-dom", ()=>{patchItems(treeselect.srcElement)})
+
+        treeselect.srcElement.addEventListener('input', (e) => {
+            const values = addLevel2CategoryIfAllChildrenAreSelected(options, e.detail)
+            document.getElementById("id_categorie_danger").value = values.join("||")
+        })
+    }
+
+    document.getElementById('search-form').addEventListener('reset', resetAndSubmit)
+    document.querySelector(".clear-btn").addEventListener("click", clearSidebarFilters)
+    document.querySelector(".add-btn").addEventListener("click", addSidebarFilters)
+    setupCategorieProduit()
+    setupCategorieDanger()
 
     const sidebarClosingObserver = new MutationObserver((mutations) => {
         mutations.forEach(mutation => {

--- a/ssa/templates/ssa/evenement_produit_form.html
+++ b/ssa/templates/ssa/evenement_produit_form.html
@@ -4,6 +4,7 @@
 {% block extrahead %}
     <link rel="stylesheet" href="{% static 'ssa/_etablissement_card.css' %}">
     <link rel="stylesheet" href="{% static 'ssa/evenement_produit_form.css' %}">
+    <link rel="stylesheet" href="{% static 'ssa/_custom_tree_select.css' %}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/treeselectjs@0.13.1/dist/treeselectjs.css" />
 {% endblock %}
 {% block scripts %}

--- a/ssa/templates/ssa/evenementproduit_list.html
+++ b/ssa/templates/ssa/evenementproduit_list.html
@@ -3,12 +3,15 @@
 {% load etat_tags %}
 {% block extrahead %}
     <link rel="stylesheet" href="{% static 'ssa/evenement_produit_list.css' %}">
+    <link rel="stylesheet" href="{% static 'ssa/_custom_tree_select.css' %}">
     <link rel="stylesheet" href="{% static 'core/has_sidebar.css' %}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/treeselectjs@0.13.1/dist/treeselectjs.css" />
 {% endblock %}
 {% block scripts %}
+    <script type="module" src="{% static 'ssa/treeselectjs.umd.js' %}"></script>
     <script type="text/javascript" src="{% static 'core/forms.js' %}"></script>
     <script type="text/javascript" src="{% static 'core/sidebar.js' %}"></script>
-    <script type="text/javascript" src="{% static 'ssa/evenement_produit_list.js' %}"></script>
+    <script type="module" src="{% static 'ssa/evenement_produit_list.js' %}"></script>
 {% endblock %}
 {% block highlight_menu_evenements %}menu__item--active{% endblock %}
 {% block content %}
@@ -24,49 +27,58 @@
             </div>
             <div class="evenements_liste__search-form">
                 {{ filter.form.as_dsfr_div }}
+                <div class=" fr-fieldset__element">
+                    <label for="categorie-produit">Catégorie de produit</label>
+                    <div id="categorie-produit-data" class="fr-hidden">{{ categorie_produit_data|safe }}</div>
+                    <div id="categorie-produit" data-selected="{{ request.GET.categorie_produit }}"></div>
+                </div>
+                <div class=" fr-fieldset__element">
+                    <label for="categorie-danger">Catégorie de danger</label>
+                    <div id="categorie-danger-data" class="fr-hidden">{{ categorie_danger_data|safe }}</div>
+                    <div id="categorie-danger" data-selected="{{ request.GET.categorie_danger }}"></div>
+                </div>
+                <div class="fr-fieldset__element evenements_liste__header--actions">
+                    <button type="reset" class="fr-btn fr-btn--tertiary-no-outline fr-mr-2w" id="reset-btn">Effacer</button>
+                    <button type="submit" class="fr-btn">Rechercher</button>
+                </div>
             </div>
-            <div class="fr-fieldset__element evenements_liste__header--actions">
-                <button type="reset" class="fr-btn fr-btn--tertiary-no-outline fr-mr-2w" id="reset-btn">Effacer</button>
-                <button type="submit" class="fr-btn">Rechercher</button>
-            </div>
-        </div>
-    </form>
-    <main class="main-container">
+        </form>
+        <main class="main-container">
 
-        <div>{{ object_list.count }} sur un total de {{ page_obj.paginator.count }}</div>
-        {% if object_list.count %}
-            <div class="fr-table fr-table--no-caption fr-table--layout-fixed">
-                <table>
-                    <thead>
-                        <tr>
-                            <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='numero_evenement' display_name='N°' %}</th>
-                            <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='creation' display_name='Création' %}</th>
-                            <th class="fr-col-3" scope="col">Description de l'événement</th>
-                            <th class="fr-col-2" scope="col">Catégorie de produit</th>
-                            <th class="fr-col-2" scope="col">Catégorie de danger</th>
-                            <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='createur' display_name='Créateur' %}</th>
-                            <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='etat' display_name='État' %}</th>
-                            <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='liens' display_name='Liens' %}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for evenement in evenementproduit_list %}
-                            <tr class="evenements__list-row">
-                                <td><a href="{{ evenement.get_absolute_url }}" class="fr-link">{{ evenement.numero }}</a></td>
-                                <td>{{ evenement.date_creation|date:"d/m/Y" }}</td>
-                                <td class="ellipsis">{{ evenement.product_description }}</td>
-                                <td>{{ evenement.get_categorie_produit_display }}</td>
-                                <td>{{ evenement.get_categorie_danger_display }}</td>
-                                <td>{{ evenement.createur }}</td>
-                                <td><span class="fr-badge fr-badge--{{evenement.etat|etat_color}} fr-badge--no-icon">{{ evenement.readable_etat }}</span></td>
-                                <td>{{ evenement.nb_liens_libre }}</td>
+            <div>{{ object_list.count }} sur un total de {{ page_obj.paginator.count }}</div>
+            {% if object_list.count %}
+                <div class="fr-table fr-table--no-caption fr-table--layout-fixed">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='numero_evenement' display_name='N°' %}</th>
+                                <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='creation' display_name='Création' %}</th>
+                                <th class="fr-col-3" scope="col">Description de l'événement</th>
+                                <th class="fr-col-2" scope="col">Catégorie de produit</th>
+                                <th class="fr-col-2" scope="col">Catégorie de danger</th>
+                                <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='createur' display_name='Créateur' %}</th>
+                                <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='etat' display_name='État' %}</th>
+                                <th class="fr-col-1" scope="col">{% include 'core/_evenement_sort_link.html' with field='liens' display_name='Liens' %}</th>
                             </tr>
+                        </thead>
+                        <tbody>
+                            {% for evenement in evenementproduit_list %}
+                                <tr class="evenements__list-row">
+                                    <td><a href="{{ evenement.get_absolute_url }}" class="fr-link">{{ evenement.numero }}</a></td>
+                                    <td>{{ evenement.date_creation|date:"d/m/Y" }}</td>
+                                    <td class="ellipsis">{{ evenement.product_description }}</td>
+                                    <td>{{ evenement.get_categorie_produit_display }}</td>
+                                    <td>{{ evenement.get_categorie_danger_display }}</td>
+                                    <td>{{ evenement.createur }}</td>
+                                    <td><span class="fr-badge fr-badge--{{evenement.etat|etat_color}} fr-badge--no-icon">{{ evenement.readable_etat }}</span></td>
+                                    <td>{{ evenement.nb_liens_libre }}</td>
+                                </tr>
 
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        {% endif %}
-        {% include "core/_pagination.html" %}
-    </main>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endif %}
+            {% include "core/_pagination.html" %}
+        </main>
 {% endblock content %}

--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -7,7 +7,19 @@ from playwright.sync_api import Page
 from ssa.models import Etablissement
 
 
-class EvenementProduitCreationPage:
+class WithTreeSelect:
+    def _set_treeselect_option(self, container_id, label):
+        self.page.locator(f"#{container_id} .treeselect-input__edit").click()
+        for part in label.split(">"):
+            if part == label.split(">")[-1]:
+                self.page.get_by_text(part.strip(), exact=True).locator("..").locator(
+                    ".treeselect-list__item-checkbox-icon"
+                ).click(force=True)
+            else:
+                self.page.get_by_title(part.strip(), exact=True).locator(".treeselect-list__item-icon").click()
+
+
+class EvenementProduitCreationPage(WithTreeSelect):
     info_fields = ["numero_rasff", "type_evenement", "source", "description", "numero_rasff"]
     produit_fields = [
         "denomination",
@@ -48,16 +60,6 @@ class EvenementProduitCreationPage:
         self.type_evenement.select_option(evenement_produit.type_evenement)
         self.description.fill(evenement_produit.description)
         self.denomination.fill(evenement_produit.denomination)
-
-    def _set_treeselect_option(self, container_id, label):
-        self.page.locator(f"#{container_id} .treeselect-input__edit").click()
-        for part in label.split(">"):
-            if part == label.split(">")[-1]:
-                self.page.get_by_text(part.strip(), exact=True).locator("..").locator(
-                    ".treeselect-list__item-checkbox-icon"
-                ).click(force=True)
-            else:
-                self.page.get_by_title(part.strip(), exact=True).locator(".treeselect-list__item-icon").click()
 
     def set_categorie_produit(self, evenement_produit):
         label = evenement_produit.get_categorie_produit_display()
@@ -275,7 +277,7 @@ class EvenementProduitDetailsPage:
         return self.page.text_content(f"#table-sm-row-key-{line_number} td:nth-child(6) a")
 
 
-class EvenementProduitListPage:
+class EvenementProduitListPage(WithTreeSelect):
     def __init__(self, page: Page, base_url):
         self.page = page
         self.base_url = base_url
@@ -376,6 +378,12 @@ class EvenementProduitListPage:
     @property
     def pays(self):
         return self.page.locator("#id_pays")
+
+    def set_categorie_produit(self, term):
+        self._set_treeselect_option("categorie-produit", term)
+
+    def set_categorie_danger(self, term):
+        self._set_treeselect_option("categorie-danger", term)
 
     @property
     def full_text_field(self):

--- a/ssa/tests/test_evenement_produit_list.py
+++ b/ssa/tests/test_evenement_produit_list.py
@@ -376,3 +376,48 @@ def test_can_filter_by_pays(live_server, mocked_authentification_user, page: Pag
     expect(page.get_by_text(to_be_found.evenement_produit.numero, exact=True)).to_be_visible()
     expect(page.get_by_text(not_to_be_found_1.evenement_produit.numero, exact=True)).not_to_be_visible()
     expect(page.get_by_text(not_to_be_found_2.evenement_produit.numero, exact=True)).not_to_be_visible()
+
+
+def test_can_filter_by_categorie_produit(live_server, mocked_authentification_user, page: Page):
+    to_be_found = EvenementProduitFactory(categorie_produit="Abat blanc de boucherie")
+    not_to_be_found_1 = EvenementProduitFactory(categorie_produit="Céphalopode cru entier ou coupé")
+    not_to_be_found_2 = EvenementProduitFactory(categorie_produit="Produit d'escargot")
+
+    search_page = EvenementProduitListPage(page, live_server.url)
+    search_page.navigate()
+    search_page.set_categorie_produit("Produit carné > De boucherie > Abat blanc de boucherie")
+    search_page.submit_search()
+
+    expect(page.get_by_text(to_be_found.numero, exact=True)).to_be_visible()
+    expect(page.get_by_text(not_to_be_found_1.numero, exact=True)).not_to_be_visible()
+    expect(page.get_by_text(not_to_be_found_2.numero, exact=True)).not_to_be_visible()
+
+
+def test_can_filter_by_categorie_produit_found_by_parent(live_server, mocked_authentification_user, page: Page):
+    to_be_found = EvenementProduitFactory(categorie_produit="Abat blanc de boucherie")
+    not_to_be_found_1 = EvenementProduitFactory(categorie_produit="Céphalopode cru entier ou coupé")
+    not_to_be_found_2 = EvenementProduitFactory(categorie_produit="Produit d'escargot")
+
+    search_page = EvenementProduitListPage(page, live_server.url)
+    search_page.navigate()
+    search_page.set_categorie_produit("Produit carné > De boucherie")
+    search_page.submit_search()
+
+    expect(page.get_by_text(to_be_found.numero, exact=True)).to_be_visible()
+    expect(page.get_by_text(not_to_be_found_1.numero, exact=True)).not_to_be_visible()
+    expect(page.get_by_text(not_to_be_found_2.numero, exact=True)).not_to_be_visible()
+
+
+def test_can_filter_by_categorie_danger(live_server, mocked_authentification_user, page: Page):
+    to_be_found = EvenementProduitFactory(categorie_danger="Salmonella dublin")
+    not_to_be_found_1 = EvenementProduitFactory(categorie_danger="Listeria")
+    not_to_be_found_2 = EvenementProduitFactory(categorie_danger="Staphylococcus")
+
+    search_page = EvenementProduitListPage(page, live_server.url)
+    search_page.navigate()
+    search_page.set_categorie_danger("Bactérie > Salmonella > Salmonella dublin")
+    search_page.submit_search()
+
+    expect(page.get_by_text(to_be_found.numero, exact=True)).to_be_visible()
+    expect(page.get_by_text(not_to_be_found_1.numero, exact=True)).not_to_be_visible()
+    expect(page.get_by_text(not_to_be_found_2.numero, exact=True)).not_to_be_visible()

--- a/ssa/tests/test_evenement_produit_list_performances.py
+++ b/ssa/tests/test_evenement_produit_list_performances.py
@@ -4,7 +4,7 @@ from playwright.sync_api import Page
 from core.models import LienLibre
 from ssa.factories import EvenementProduitFactory
 
-NB_QUERIES = 5
+NB_QUERIES = 7
 
 
 def test_list_performances(live_server, mocked_authentification_user, page: Page, django_assert_num_queries, client):

--- a/ssa/views/produit.py
+++ b/ssa/views/produit.py
@@ -159,6 +159,8 @@ class EvenementProduitListView(WithOrderingMixin, ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["filter"] = self.filter
+        context["categorie_produit_data"] = json.dumps(CategorieProduit.build_options())
+        context["categorie_danger_data"] = json.dumps(CategorieDanger.build_options())
 
         for evenement in context["object_list"]:
             etat_data = evenement.get_etat_data_from_fin_de_suivi(evenement.has_fin_de_suivi)


### PR DESCRIPTION
Ajouter des filtres pour permettre de filtrer sur les agents / structures en contact (logique déjà existante) et sur les catégories de produit et de danger.
Multualisation du code des catégories de produit et de danger (CSS, JS, mixin de test).

Changement du template de DSFR pour que les champs cachés se rendent correctement, peu importe si le dernier champ est un champ de manual_render_fields.