### PR TITLE
Ajouter une validation front sur le numéro d'agrément

### DIFF
--- a/ssa/forms.py
+++ b/ssa/forms.py
@@ -102,6 +102,11 @@ class EtablissementForm(DSFRForm, forms.ModelForm):
             }
         ),
     )
+    numero_agrement = forms.CharField(
+        required=False,
+        label="Numéro d'agrément",
+        widget=forms.TextInput(attrs={"pattern": "^\d{2,3}\.\d{2,3}\.\d{2,3}$", "placeholder": "00(0).00(0).00(0)"}),
+    )
     code_insee = forms.CharField(widget=forms.HiddenInput(), required=False)
     adresse_lieu_dit = forms.CharField(widget=forms.Select(), required=False)
     pays = CountryField(blank=True).formfield()

--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -127,6 +127,10 @@ class EvenementProduitCreationPage(WithTreeSelect):
     def current_modal_raison_sociale_field(self):
         return self.current_modal.locator('[id$="raison_sociale"]')
 
+    @property
+    def current_modal_numero_agrement_field(self):
+        return self.current_modal.locator('[id$="numero_agrement"]')
+
     def close_etablissement_modal(self):
         self.current_modal.locator(".save-btn").click()
         self.current_modal.wait_for(state="hidden", timeout=2_000)

--- a/ssa/tests/test_evenement_produit_creation.py
+++ b/ssa/tests/test_evenement_produit_creation.py
@@ -535,3 +535,17 @@ def test_can_create_evenement_produit_using_shortcut_on_categorie_danger(
 
     evenement_produit = EvenementProduit.objects.get()
     assert evenement_produit.categorie_danger == "Escherichia coli (non STEC - EHEC)"
+
+
+def test_cant_add_etablissement_with_incorrect_numero_agrement(live_server, page: Page):
+    evenement = EvenementProduitFactory()
+
+    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page.navigate()
+    creation_page.fill_required_fields(evenement)
+    creation_page.open_etablissement_modal()
+    creation_page.current_modal_raison_sociale_field.fill("Foo")
+    creation_page.current_modal_numero_agrement_field.fill("11111111")
+    creation_page.current_modal.locator(".save-btn").click()
+
+    assert not creation_page.current_modal_numero_agrement_field.evaluate("el => el.validity.valid")

--- a/ssa/views/produit.py
+++ b/ssa/views/produit.py
@@ -51,6 +51,14 @@ class EvenementProduitCreateView(
             self.request,
             "Erreurs dans le(s) formulaire(s) Etablissement",
         )
+        for i, form in enumerate(self.etablissement_formset):
+            if not form.is_valid():
+                for field, errors in form.errors.items():
+                    for error in errors:
+                        messages.error(
+                            self.request, f"Erreur dans le formulaire établissement #{i + 1} : '{field}': {error}"
+                        )
+
         return self.render_to_response(self.get_context_data())
 
     def post(self, request, *args, **kwargs):


### PR DESCRIPTION
Une validation back / modèle existe déjà, ce qui redirige les utilisateurs sur le formulaire de création avec une erreur générique:

- Ajout de plus d'informations dans le message d'erreur pour faciliter le debug
- Ajout d'une validation front pour qu'il ne soit pas possible de valider la modale si le numéro n'est pas valide.