### PR TITLE
Améliorer le comportement du bloc siret sur SSA

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -89,6 +89,7 @@ def choice_js_cant_pick(db, page):
         page.query_selector(locator).click()
         page.wait_for_selector("input:focus", state="visible", timeout=2_000)
         page.locator("*:focus").fill(fill_content)
+        page.wait_for_timeout(1000)
         expect(page.get_by_role("option", name=exact_name, exact=True)).not_to_be_visible()
 
     return _choice_js_cant_pick

--- a/ssa/forms.py
+++ b/ssa/forms.py
@@ -93,14 +93,7 @@ class EtablissementForm(DSFRForm, forms.ModelForm):
     siret = forms.CharField(
         required=False,
         max_length=14,
-        label="N° SIRET",
-        widget=forms.TextInput(
-            attrs={
-                "pattern": "[0-9]{14}",
-                "placeholder": "110 070 018 00012",
-                "title": "Le Siret doit contenir exactement 14 chiffres",
-            }
-        ),
+        widget=forms.HiddenInput,
     )
     code_insee = forms.CharField(widget=forms.HiddenInput(), required=False)
     adresse_lieu_dit = forms.CharField(widget=forms.Select(), required=False)

--- a/ssa/static/ssa/_etablissement_form.js
+++ b/ssa/static/ssa/_etablissement_form.js
@@ -33,9 +33,13 @@ document.addEventListener('DOMContentLoaded', () => {
             field.closest("dialog").querySelector('[id$=raison_sociale]').value = event.detail.customProperties.raison
             field.closest("dialog").querySelector('[id$=commune]').value = event.detail.customProperties.commune
             field.closest("dialog").querySelector('[id$=code_insee]').value = event.detail.customProperties.code_commune
-            let result = [{"value": event.detail.customProperties.streetData, "label": event.detail.customProperties.streetData, selected:true }]
-            addressChoices.setChoices(result, 'value', 'label', true)
             field.closest("dialog").querySelector('[id$=pays]').value = "FR"
+
+            if (!!event.detail.customProperties.streetData){
+                let result = [{"value": event.detail.customProperties.streetData, "label": event.detail.customProperties.streetData, selected:true }]
+                addressChoices.setChoices(result, 'value', 'label', true)
+            }
+
             fetch(`/ssa/api/find-numero-agrement/?siret=${event.detail.customProperties.siret}`)
                 .then(response => response.json())
                 .then(data => {
@@ -43,29 +47,16 @@ document.addEventListener('DOMContentLoaded', () => {
                         field.closest("dialog").querySelector('[id$=agrement]').value = data["numero_agrement"]
                     }
                 });
-
-            field.closest("dialog").querySelector('[id$=sirene-btn]').classList.remove("fr-hidden")
-            field.closest("dialog").querySelector('.fr-search-bar').classList.add("fr-hidden")
-            field.closest("dialog").querySelector('.fr-search-bar select').innerHTML = ""
-            choicesSIRET.destroy()
         })
     }
 
     function setupSiretBlock(modal, addressChoices){
-        const siretLookupBtn = modal.querySelector("#sirene-btn")
-        const siretInput = modal.querySelector("#search-siret-input")
-        if (!siretInput.dataset.token){
-            siretLookupBtn.classList.add("fr-hidden")
+        const siretSelect = modal.querySelector("[id^=search-siret-input-]")
+        if (!siretSelect.dataset.token){
             return
         }
 
-        siretLookupBtn.addEventListener("click", event =>{
-            event.preventDefault()
-            siretLookupBtn.classList.add("fr-hidden")
-            configureSiretField(siretInput, addressChoices)
-            siretLookupBtn.nextElementSibling.classList.remove("fr-hidden")
-        })
-
+        configureSiretField(siretSelect, addressChoices)
     }
 
     function showEtablissementModal() {

--- a/ssa/static/ssa/evenement_produit_form.css
+++ b/ssa/static/ssa/evenement_produit_form.css
@@ -66,9 +66,6 @@
 .fr-search-bar .choices{
     flex: 1.25;
 }
-.etablissement-fields--lookup {
-    text-align: center;
-}
 
 .treeselect-list__item-checkbox-container {
     border-radius: 40px !important;

--- a/ssa/templates/ssa/_etablissement_block.html
+++ b/ssa/templates/ssa/_etablissement_block.html
@@ -18,17 +18,10 @@
                         </div>
                         <div class="fr-modal__content">
                             <h1 id="fr-modal-title-modal--etablissement__prefix__" class="fr-modal__title"><span class="fr-icon-arrow-right-line fr-icon--lg"></span>Ajouter un établissement</h1>
-
-                            <div class="etablissement-fields--lookup">
-                                <button id="sirene-btn" class="fr-btn fr-btn--secondary fr-mx-auto fr-my-4v">
-                                    Rechercher dans la base Sirene (France)
-                                </button>
-                                <div class="fr-search-bar fr-hidden fr-my-4v" id="header-search" role="search">
-                                    <select class="fr-input" type="search" id="search-siret-input" name="search-{{ id }}-input" data-token="{{ sirene_token }}"></select>
-                                    <button class="fr-btn" title="Rechercher">Rechercher</button>
-                                </div>
+                            <div class="fr-fieldset__element">
+                                <label for="search-siret-input-{{ id }}">N° SIRET</label>
+                                <select class="fr-input" type="search" id="search-siret-input-{{ id }}" name="search-{{ id }}-input" data-token="{{ sirene_token }}"></select>
                             </div>
-
                             {{ empty_form.as_dsfr_div }}
                         </div>
                         <div class="fr-modal__footer">


### PR DESCRIPTION
Ce commit mélange des améliorations propres à SSA et des améliorations communes:

- Permet de passer un siret complet (ou un str de plus de 9 caractères) et de tout de même faire la recherche sur le SIREN.
- Le cas échéant ne montrer que le / les SIRET qui correspondent au terme recherché
- Permettre de forcer la valeur si la valeur saisi est complète

- Simplification de l'interface pour SSA (plus besoin de faire plusieurs clics).
- Afin que le champ choices JS avec la recherche soit toujours disponible sur la page de création d'événement produit on force un faux token via le JS dans la méthode navigate (pour éviter de devoir mocker cette partie à chaque fois).