### PR TITLE
S'assurer que les structures soient triés

### DIFF
--- a/core/filters.py
+++ b/core/filters.py
@@ -15,7 +15,7 @@ class DocumentFilter(django_filters.FilterSet):
         label="Type de Document",
     )
     created_by_structure = django_filters.ModelChoiceFilter(
-        queryset=Structure.objects.all(),
+        queryset=Structure.objects.none(),
         field_name="created_by_structure",
         label="Structure",
     )
@@ -35,7 +35,6 @@ class DocumentFilter(django_filters.FilterSet):
             (k, v) for (k, v) in Document.TypeDocument.choices if k in actual_document_types
         ]
 
-        structure_queryset = Structure.objects.filter(
-            id__in=self.queryset.values_list("created_by_structure", flat=True).distinct()
-        )
+        ids = self.queryset.values_list("created_by_structure", flat=True).distinct()
+        structure_queryset = Structure.objects.filter(id__in=ids).order_by("libelle")
         self.filters["created_by_structure"].queryset = structure_queryset

--- a/sv/tests/test_evenement_documents.py
+++ b/sv/tests/test_evenement_documents.py
@@ -188,7 +188,7 @@ def test_can_filter_documents_by_unit_on_evenement(live_server, page: Page, chec
     expect(page.get_by_text("Test document", exact=True)).to_be_visible()
     expect(page.get_by_text("Ma carto", exact=True)).to_be_visible()
 
-    check_select_options(page, "id_created_by_structure", ["Structure Test", "Other structure"])
+    check_select_options(page, "id_created_by_structure", ["Other structure", "Structure Test"])
     page.locator(".documents__filters #id_created_by_structure").select_option("Structure Test")
     page.get_by_test_id("documents-filter").click()
 


### PR DESCRIPTION
Dans l'interface de filtre des documents, mettre en place un tri par ordre alpha.