### PR TITLE
Ajouter un ordre par défaut en cas d'égalité

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -652,7 +652,7 @@ class WithOrderingMixin:
         ordering = self.get_ordering()
         if isinstance(ordering, str):
             ordering = (ordering,)
-        return queryset.order_by(*ordering)
+        return queryset.order_by(*ordering, "-pk")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/ssa/tests/test_evenement_produit_list_order.py
+++ b/ssa/tests/test_evenement_produit_list_order.py
@@ -1,16 +1,13 @@
 from datetime import datetime
 
 import pytest
-from django.contrib.contenttypes.models import ContentType
-
-from playwright.sync_api import Page
 from django.utils import timezone
+from playwright.sync_api import Page
 
 from core.factories import StructureFactory
 from core.mixins import WithEtatMixin
 from core.models import LienLibre
 from ssa.factories import EvenementProduitFactory
-from ssa.models import EvenementProduit
 
 
 @pytest.mark.parametrize(
@@ -120,19 +117,8 @@ def test_order_by_liens(
         "evenement_3": EvenementProduitFactory(),
         "evenement_4": EvenementProduitFactory(),
     }
-    content_type = ContentType.objects.get_for_model(EvenementProduit)
-    LienLibre.objects.create(
-        content_type_1=content_type,
-        object_id_1=evenements["evenement_2"].id,
-        content_type_2=content_type,
-        object_id_2=evenements["evenement_1"].id,
-    )
-    LienLibre.objects.create(
-        content_type_1=content_type,
-        object_id_1=evenements["evenement_2"].id,
-        content_type_2=content_type,
-        object_id_2=evenements["evenement_3"].id,
-    )
+    LienLibre.objects.create(related_object_1=evenements["evenement_2"], related_object_2=evenements["evenement_1"])
+    LienLibre.objects.create(related_object_1=evenements["evenement_2"], related_object_2=evenements["evenement_3"])
     page.goto(url_builder_for_list_ordering("liens", direction, "ssa:evenement-produit-liste"))
     page.get_by_role("link", name="Liens").click()
     assert_events_order(page, evenements, expected_order, 1)

--- a/sv/tests/test_evenement_list_order.py
+++ b/sv/tests/test_evenement_list_order.py
@@ -14,8 +14,8 @@ from sv.models import Evenement, Etat
 @pytest.mark.parametrize(
     "direction,expected_order",
     [
-        ("asc", ["evenement_2", "evenement_1", "evenement_3"]),
-        ("desc", ["evenement_1", "evenement_3", "evenement_2"]),
+        ("asc", ["evenement_2", "evenement_3", "evenement_1"]),
+        ("desc", ["evenement_3", "evenement_1", "evenement_2"]),
     ],
     ids=["asc", "desc"],
 )


### PR DESCRIPTION
En cas d'égalité dans un tri (même nombre, même mot, etc.) trier par pk, surtout afin de rendre le code plus facilement testable.