### PR TITLE
Améliorer la recherche par SIRET/SIREN

### DIFF
--- a/core/static/core/siret.js
+++ b/core/static/core/siret.js
@@ -31,7 +31,7 @@ function improveResults(value, results) {
 export function fetchSiret(value, token) {
     const cleanedValue =  value.replaceAll(" ", "")
     const siren =  cleanedValue.substring(0, 9);
-    const url = 'https://api.insee.fr/entreprises/sirene/siret?q=siren%3A' + siren + '* AND -periode(etatAdministratifEtablissement:F)';
+    const url = `https://api.insee.fr/entreprises/sirene/siret?nombre=100&q=siren%3A${siren}* AND -periode(etatAdministratifEtablissement:F)`;
     const headers = {
         'Authorization': `Bearer ${token}`,
         'Content-Type': 'application/json',

--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -169,7 +169,7 @@ class EvenementProduitCreationPage(WithTreeSelect):
             call_count["count"] += 1
 
         self.page.route(
-            f"https://api.insee.fr/entreprises/sirene/siret?q=siren%3A{siret[:9]}*%20AND%20-periode(etatAdministratifEtablissement:F)",
+            f"https://api.insee.fr/entreprises/sirene/siret?nombre=100&q=siren%3A{siret[:9]}*%20AND%20-periode(etatAdministratifEtablissement:F)",
             handle,
         )
 

--- a/ssa/tests/test_evenement_produit_creation.py
+++ b/ssa/tests/test_evenement_produit_creation.py
@@ -460,7 +460,7 @@ def test_can_create_etablissement_with_sirene_autocomplete(
         call_count["count"] += 1
 
     page.route(
-        "https://api.insee.fr/entreprises/sirene/siret?q=siren%3A120079017*%20AND%20-periode(etatAdministratifEtablissement:F)",
+        "https://api.insee.fr/entreprises/sirene/siret?nombre=100&q=siren%3A120079017*%20AND%20-periode(etatAdministratifEtablissement:F)",
         handle,
     )
 
@@ -519,7 +519,7 @@ def test_can_create_etablissement_with_force_siret_value(
         call_count["count"] += 1
 
     page.route(
-        "https://api.insee.fr/entreprises/sirene/siret?q=siren%3A123123123*%20AND%20-periode(etatAdministratifEtablissement:F)",
+        "https://api.insee.fr/entreprises/sirene/siret?nombre=100&q=siren%3A123123123*%20AND%20-periode(etatAdministratifEtablissement:F)",
         handle,
     )
 
@@ -601,7 +601,7 @@ def test_can_create_etablissement_with_full_siren_will_filter_results(
         call_count["count"] += 1
 
     page.route(
-        "https://api.insee.fr/entreprises/sirene/siret?q=siren%3A123123123*%20AND%20-periode(etatAdministratifEtablissement:F)",
+        "https://api.insee.fr/entreprises/sirene/siret?nombre=100&q=siren%3A123123123*%20AND%20-periode(etatAdministratifEtablissement:F)",
         handle,
     )
 

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -646,7 +646,7 @@ def test_create_fiche_detection_with_lieu_using_siret(
     )
 
     page.route(
-        "https://api.insee.fr/entreprises/sirene/siret?q=siren%3A120079017*%20AND%20-periode(etatAdministratifEtablissement:F)",
+        "https://api.insee.fr/entreprises/sirene/siret?nombre=100&q=siren%3A120079017*%20AND%20-periode(etatAdministratifEtablissement:F)",
         handle,
     )
 


### PR DESCRIPTION
L'API utilisée ne renvoit par défaut que les 20 premiers résultats, ce commit augmente le seuil à 100 pour les cas où l'on tape un SIREN qui a plus de 20 établissements.

Exemple : en tapant 37861070300480 on recherche 378610703* qui contient 84 établissements.