### PR TITLE
Fait correspondre le padding des `<input>` treeselect avec celui des `<input>` du DSFR

### DIFF
--- a/ssa/static/ssa/_custom_tree_select.css
+++ b/ssa/static/ssa/_custom_tree_select.css
@@ -62,3 +62,7 @@
 .treeselect-list__item-checkbox-container {
     margin-right: 10px;
 }
+
+.treeselect-input__edit {
+    padding: .5rem 1rem !important;
+}


### PR DESCRIPTION
![](https://github.com/user-attachments/assets/06d17a0d-1d54-4463-854e-2256420c1074)