### PR TITLE
Stabilisation des tests utilisant `generic_test_can_finaliser_draft_note`

### DIFF
--- a/core/tests/generic_tests/messages.py
+++ b/core/tests/generic_tests/messages.py
@@ -204,6 +204,9 @@ def generic_test_can_send_draft_element_suivi(
     message_page.open_message()
     message_page.submit_message()
 
+    # Wait for the page to confirm message was sent
+    expect(page.locator(".fr-alert.fr-alert--success").get_by_text("Le message a bien été ajouté.")).to_be_visible()
+
     message.refresh_from_db()
     assert message.status == Message.Status.FINALISE
     assert len(mailoutbox) == 1


### PR DESCRIPTION
Les tests utilisant la fonction `generic_test_can_finaliser_draft_note` cassent aléatoirement parce que le test essaie de vérifier l'existence d'un message trop vite après avoir POSTé la requête. Le test a été stabilisé avec une étape d'attente que la page affiche le message de succès avant d'effectuer les assertions du test.