### PR TITLE
Améliorer les tests sur la dernière date de mise à jour

### DIFF
--- a/sv/tests/test_evenement_details.py
+++ b/sv/tests/test_evenement_details.py
@@ -36,9 +36,13 @@ def assert_fiche_zone_derniere_mise_a_jour_is_visible_and_updated(page: Page):
 
     def _assert_fiche_zone_derniere_mise_a_jour_visible(fiche_zone_delimitee: FicheZoneDelimitee):
         last_update_text = (
-            f"Dernière mise à jour le {get_date_formated(fiche_zone_delimitee.date_derniere_mise_a_jour)}"
+            f"Dernière mise à jour le {get_date_formated(fiche_zone_delimitee.evenement.date_derniere_mise_a_jour)}"
         )
         expect(page.get_by_test_id("evenement-header").get_by_text(last_update_text)).to_be_visible()
+
+        last_update_text = (
+            f"Dernière mise à jour le {get_date_formated(fiche_zone_delimitee.date_derniere_mise_a_jour)}"
+        )
         page.get_by_role("tab", name="Zone").click()
         expect(page.get_by_label("Zone", exact=True).get_by_text(last_update_text)).to_be_visible()
 
@@ -50,10 +54,14 @@ def assert_fiche_detection_derniere_mise_a_jour_is_visible_and_updated(page: Pag
     """Fixture pour vérifier que la date de dernière mise à jour de la fiche détection est correctement affichée."""
 
     def _assert_fiche_detection_derniere_mise_a_jour_visible(fiche_detection: FicheDetection):
-        last_update_text = f"Dernière mise à jour le {get_date_formated(fiche_detection.date_derniere_mise_a_jour)}"
+        last_update_text = (
+            f"Dernière mise à jour le {get_date_formated(fiche_detection.evenement.date_derniere_mise_a_jour)}"
+        )
         expect(page.get_by_test_id("evenement-header").get_by_text(last_update_text)).to_be_visible()
+
         page.get_by_role("tab", name="Détection").click()
         page.get_by_role("tab", name=fiche_detection.numero_detection).click()
+        last_update_text = f"Dernière mise à jour le {get_date_formated(fiche_detection.date_derniere_mise_a_jour)}"
         expect(page.locator("#tabpanel-detection-panel").get_by_text(last_update_text)).to_be_visible()
 
     return _assert_fiche_detection_derniere_mise_a_jour_visible


### PR DESCRIPTION
Extrait d'un message explicatif:

On a eu un fail random sur _assert_fiche_zone_derniere_mise_a_jour_visible (via test_date_derniere_mise_a_jour_after_delete_detection_in_zone_infestee). Dans le helper, on vérifie que la date de dernière mise à jour de l'événement soit A et que la date de mise à jour de la zone soit aussi A (A = last_update_text dans le code). Pour autant on a la mise à jour de l'événement qui se a un endroit/moment dans le code et la mise à jour de la zone à un autre endroit/moment.

Il n'y a pas de garantie que cela soit la même valeur (la valeur n'est pas "passée") donc on peut avoir 13:39 dans un champ et 13:40 dans un autre.