### PR TITLE
Afficher les erreurs de mise à jour d'un document

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -16,7 +16,7 @@ fileignoreconfig:
 - filename: ssa/static/ssa/_rappel_conso_form.js
   checksum: eaddd88cdb839b7592fb59aad23f27f727999f50f90a073e0ec7bc4673c411d0
 - filename: core/views.py
-  checksum: e55806f08fc497ac39c0f6e585fa53977678756e4213c117118b75fac2a70c66
+  checksum: 8769185324b5056204e84c1a72696094abeebd374a4ae70f0b273d56dc308c71
 - filename: sv/static/sv/fichedetection_lieux_form.js
   checksum: dd7abfcb004df5833e92c64806dc6436672d4ceb9727ca495ac3f7431c6d776f
 - filename: core/templates/core/_tableau_fil_de_suivi.html

--- a/core/views.py
+++ b/core/views.py
@@ -26,6 +26,7 @@ from .mixins import (
     WithPublishMixin,
     WithACNotificationMixin,
     MessageHandlingMixin,
+    WithFormErrorsAsMessagesMixin,
 )
 from .models import Document, Message, Contact, user_is_referent_national
 from .notifications import notify_contact_agent
@@ -99,7 +100,9 @@ class DocumentDeleteView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTest
         return safe_redirect(request.POST.get("next") + "#tabpanel-documents-panel")
 
 
-class DocumentUpdateView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTestMixin, UpdateView):
+class DocumentUpdateView(
+    PreventActionIfVisibiliteBrouillonMixin, UserPassesTestMixin, WithFormErrorsAsMessagesMixin, UpdateView
+):
     model = Document
     form_class = DocumentEditForm
     http_method_names = ["post"]
@@ -120,6 +123,10 @@ class DocumentUpdateView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTest
         response = super().form_valid(form)
         messages.success(self.request, "Le document a bien été mis à jour.", extra_tags="core documents")
         return response
+
+    def form_invalid(self, form):
+        super().form_invalid(form)
+        return safe_redirect(self.get_success_url())
 
 
 class ContactDeleteView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTestMixin, View):


### PR DESCRIPTION
En cas d'erreur de mise à jour d'un document afficher les erreurs sous forme de message.
- Permet d'éviter l'erreur django.template.exceptions.TemplateDoesNotExist: core/document_form.html
- Permet de débugger le test test_can_edit_document_on_evenement quand cela se produira a nouveau sur la CI