### PR TITLE
Fiabiliser le test d'edit des documents

### DIFF
--- a/core/factories.py
+++ b/core/factories.py
@@ -2,6 +2,7 @@ import random
 
 import factory
 from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice
 
@@ -103,7 +104,6 @@ class DocumentFactory(DjangoModelFactory):
 
     nom = factory.Faker("sentence", nb_words=2)
     description = factory.Faker("paragraph")
-    file = factory.django.FileField(filename="test.csv")
     document_type = FuzzyChoice([choice[0] for choice in Document.TypeDocument.choices])
 
     @factory.lazy_attribute
@@ -113,6 +113,12 @@ class DocumentFactory(DjangoModelFactory):
     @factory.lazy_attribute
     def created_by_structure(self):
         return Structure.objects.get(libelle="Structure Test")
+
+    @factory.lazy_attribute
+    def file(self):
+        ext_by_type = Document.ALLOWED_EXTENSIONS_PER_DOCUMENT_TYPE[self.document_type]
+        ext = random.choice(ext_by_type).value.lower()
+        return SimpleUploadedFile(f"test.{ext}", b"dummy content")
 
 
 class MessageFactory(DjangoModelFactory):


### PR DESCRIPTION
Dans les tests `test_can_edit_document_on_evenement` (et plus généralement dans les tests qui manipulent les documents) on peut se retrouver avec un type de document qui n'autorise que certaines extensions de fichier (par exemple le type Cartographie) tout en essayant d'uploader un fichier CSV.