### PR TITLE
Corriger l'ajout d'agent et de structures

### DIFF
--- a/core/pages.py
+++ b/core/pages.py
@@ -143,3 +143,23 @@ class WithDocumentsPage:
 
     def document_edit_save(self, id):
         self.page.get_by_test_id(f"documents-edit-{id}").click()
+
+
+class WithContactsPage:
+    def __init__(self, page: Page):
+        self.page = page
+        self.go_to_contact_tab()
+
+    def go_to_contact_tab(self):
+        self.page.get_by_role("tab", name="Contacts").click()
+        self.page.get_by_role("tab", name="Contacts").evaluate("el => el.scrollIntoView()")
+
+    def add_agent(self, choice_js_fill, contact):
+        choice_js_fill(
+            self.page, "#add-contact-agent-form .choices", contact.agent.nom, contact.display_with_agent_unit
+        )
+        self.page.locator("#add-contact-agent-form").get_by_role("button", name="Ajouter").click()
+
+    def add_structure(self, choice_js_fill, contact):
+        choice_js_fill(self.page, "#add-contact-structure-form .choices", str(contact), str(contact))
+        self.page.locator("#add-contact-structure-form").get_by_role("button", name="Ajouter").click()

--- a/core/tests/generic_tests/contacts.py
+++ b/core/tests/generic_tests/contacts.py
@@ -1,0 +1,33 @@
+from playwright.sync_api import expect
+
+from core.factories import ContactStructureFactory, ContactAgentFactory
+from core.pages import WithContactsPage
+
+
+def generic_test_add_contact_agent_to_an_evenement(live_server, page, choice_js_fill, object):
+    contact_structure = ContactStructureFactory()
+    contact = ContactAgentFactory(with_active_agent=True, agent__structure=contact_structure.structure)
+
+    page.goto(f"{live_server.url}{object.get_absolute_url()}")
+    contact_page = WithContactsPage(page)
+    contact_page.add_agent(choice_js_fill, contact)
+
+    contact_page.go_to_contact_tab()
+    expect(page.get_by_text("L'agent a été ajouté avec succès.")).to_be_visible()
+    expect(page.get_by_test_id("contacts-agents")).to_be_visible()
+    assert page.get_by_test_id("contacts-agents").count() == 1
+    assert object.__class__.objects.filter(pk=object.pk, contacts=contact).exists()
+
+
+def generic_test_add_contact_structure_to_an_evenement(live_server, page, choice_js_fill, object):
+    contact_structure = ContactStructureFactory(with_one_active_agent=True)
+
+    page.goto(f"{live_server.url}{object.get_absolute_url()}")
+    contact_page = WithContactsPage(page)
+    contact_page.add_structure(choice_js_fill, contact_structure)
+
+    contact_page.go_to_contact_tab()
+    expect(page.get_by_text("La structure a été ajoutée avec succès.")).to_be_visible()
+    expect(page.get_by_test_id("contacts-structures")).to_be_visible()
+    assert page.get_by_test_id("contacts-structures").count() == 1
+    assert object.__class__.objects.filter(pk=object.pk, contacts=contact_structure).exists()

--- a/core/views.py
+++ b/core/views.py
@@ -312,23 +312,24 @@ class StructureAddView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTestMi
 
     def post(self, request, *args, **kwargs):
         form = StructureAddForm(request.POST)
-        if form.is_valid():
-            self.obj = self.get_fiche_object()
-            contacts_structures = form.cleaned_data["contacts_structures"]
-            with transaction.atomic():
-                for contact_structure in contacts_structures:
-                    self.obj.contacts.add(contact_structure)
-                self.obj.update_allowed_structures_and_visibility(contacts_structures)
-
-            message = ngettext(
-                "La structure a été ajoutée avec succès.",
-                "Les %(count)d structures ont été ajoutées avec succès.",
-                len(contacts_structures),
-            ) % {"count": len(contacts_structures)}
-            messages.success(request, message, extra_tags="core contacts")
+        if not form.is_valid():
+            messages.error(request, "Erreur lors de l'ajout de la structure.")
             return safe_redirect(self.obj.get_absolute_url() + "#tabpanel-contacts-panel")
 
-        messages.error(request, "Erreur lors de l'ajout de la structure.")
+        self.obj = self.get_fiche_object()
+        contacts_structures = form.cleaned_data["contacts_structures"]
+        with transaction.atomic():
+            for contact_structure in contacts_structures:
+                self.obj.contacts.add(contact_structure)
+            if hasattr(self.obj, "update_allowed_structures_and_visibility"):
+                self.obj.update_allowed_structures_and_visibility(contacts_structures)
+
+        message = ngettext(
+            "La structure a été ajoutée avec succès.",
+            "Les %(count)d structures ont été ajoutées avec succès.",
+            len(contacts_structures),
+        ) % {"count": len(contacts_structures)}
+        messages.success(request, message, extra_tags="core contacts")
         return safe_redirect(self.obj.get_absolute_url() + "#tabpanel-contacts-panel")
 
 
@@ -347,29 +348,30 @@ class AgentAddView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTestMixin,
 
     def post(self, request, *args, **kwargs):
         form = AgentAddForm(request.POST)
-        if form.is_valid():
-            self.obj = self.get_fiche_object()
-            contacts_agents = form.cleaned_data["contacts_agents"]
-            allowed_contacts_structures_to_add = []
-            with transaction.atomic():
-                for contact_agent in contacts_agents:
-                    self.obj.contacts.add(contact_agent)
-                    if not user_is_referent_national(contact_agent.agent.user):
-                        contact_structure = contact_agent.get_structure_contact()
-                        self.obj.contacts.add(contact_structure)
-                        allowed_contacts_structures_to_add.append(contact_structure)
-                self.obj.update_allowed_structures_and_visibility(allowed_contacts_structures_to_add)
-                notify_contact_agent(contact_agent, self.obj)
-
-            message = ngettext(
-                "L'agent a été ajouté avec succès.",
-                "Les %(count)d agents ont été ajoutés avec succès.",
-                len(contacts_agents),
-            ) % {"count": len(contacts_agents)}
-            messages.success(request, message, extra_tags="core contacts")
+        if not form.is_valid():
+            messages.error(request, "Erreur lors de l'ajout de l'agent.")
             return safe_redirect(self.obj.get_absolute_url() + "#tabpanel-contacts-panel")
 
-        messages.error(request, "Erreur lors de l'ajout de l'agent.")
+        self.obj = self.get_fiche_object()
+        contacts_agents = form.cleaned_data["contacts_agents"]
+        allowed_contacts_structures_to_add = []
+        with transaction.atomic():
+            for contact_agent in contacts_agents:
+                self.obj.contacts.add(contact_agent)
+                if not user_is_referent_national(contact_agent.agent.user):
+                    contact_structure = contact_agent.get_structure_contact()
+                    self.obj.contacts.add(contact_structure)
+                    allowed_contacts_structures_to_add.append(contact_structure)
+            if hasattr(self.obj, "update_allowed_structures_and_visibility"):
+                self.obj.update_allowed_structures_and_visibility(allowed_contacts_structures_to_add)
+            notify_contact_agent(contact_agent, self.obj)
+
+        message = ngettext(
+            "L'agent a été ajouté avec succès.",
+            "Les %(count)d agents ont été ajoutés avec succès.",
+            len(contacts_agents),
+        ) % {"count": len(contacts_agents)}
+        messages.success(request, message, extra_tags="core contacts")
         return safe_redirect(self.obj.get_absolute_url() + "#tabpanel-contacts-panel")
 
 

--- a/ssa/tests/test_evenement_produit_contact_add.py
+++ b/ssa/tests/test_evenement_produit_contact_add.py
@@ -1,0 +1,8 @@
+from core.tests.generic_tests.contacts import generic_test_add_contact_agent_to_an_evenement
+from ssa.factories import EvenementProduitFactory
+from ssa.models import EvenementProduit
+
+
+def test_add_contact_agent_to_an_evenement(live_server, page, choice_js_fill):
+    evenement = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    generic_test_add_contact_agent_to_an_evenement(live_server, page, choice_js_fill, evenement)

--- a/ssa/tests/test_evenement_produit_structure_add.py
+++ b/ssa/tests/test_evenement_produit_structure_add.py
@@ -1,0 +1,8 @@
+from core.tests.generic_tests.contacts import generic_test_add_contact_structure_to_an_evenement
+from ssa.factories import EvenementProduitFactory
+from ssa.models import EvenementProduit
+
+
+def test_add_contact_structure_to_an_evenement(live_server, page, choice_js_fill):
+    evenement = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    generic_test_add_contact_structure_to_an_evenement(live_server, page, choice_js_fill, evenement)

--- a/sv/tests/test_evenement_contact_add.py
+++ b/sv/tests/test_evenement_contact_add.py
@@ -9,6 +9,9 @@ from django.urls import reverse
 from core.constants import MUS_STRUCTURE
 from core.factories import ContactAgentFactory, ContactStructureFactory, StructureFactory
 from core.models import Contact
+from core.tests.generic_tests.contacts import (
+    generic_test_add_contact_agent_to_an_evenement,
+)
 from seves import settings
 from sv.factories import EvenementFactory
 from sv.models import Evenement
@@ -28,21 +31,9 @@ def contacts(db):
     return ContactAgentFactory.create_batch(2, agent__structure=structure, with_active_agent=True)
 
 
-def test_add_contact_agent_to_an_evenement(live_server, page, choice_js_fill, goto_contacts):
-    contact_structure = ContactStructureFactory()
-    contact = ContactAgentFactory(with_active_agent=True, agent__structure=contact_structure.structure)
+def test_add_contact_agent_to_an_evenement(live_server, page, choice_js_fill):
     evenement = EvenementFactory()
-
-    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
-    goto_contacts(page)
-    choice_js_fill(page, "#add-contact-agent-form .choices", contact.agent.nom, contact.display_with_agent_unit)
-    page.locator("#add-contact-agent-form").get_by_role("button", name="Ajouter").click()
-    goto_contacts(page)
-
-    expect(page.get_by_text("L'agent a été ajouté avec succès.")).to_be_visible()
-    expect(page.get_by_test_id("contacts-agents")).to_be_visible()
-    assert page.get_by_test_id("contacts-agents").count() == 1
-    assert Evenement.objects.filter(pk=evenement.pk, contacts=contact).exists()
+    generic_test_add_contact_agent_to_an_evenement(live_server, page, choice_js_fill, evenement)
 
 
 def test_cant_add_inactive_agent_to_an_evenement(live_server, page, choice_js_cant_pick, goto_contacts):

--- a/sv/tests/test_evenement_structure_add.py
+++ b/sv/tests/test_evenement_structure_add.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from playwright.sync_api import expect, Page
 
 from core.factories import ContactStructureFactory
+from core.tests.generic_tests.contacts import generic_test_add_contact_structure_to_an_evenement
 from sv.factories import EvenementFactory
 from sv.models import Evenement
 
@@ -76,21 +77,9 @@ def test_structure_niveau2_without_emails_are_not_visible(live_server, page):
     expect(page.get_by_label("Ajouter une structure").get_by_role("option", name="Bar")).not_to_be_visible()
 
 
-@pytest.mark.django_db
-def test_add_structure_to_an_evenement(live_server, page, choice_js_fill):
-    contact = ContactStructureFactory(with_one_active_agent=True)
+def test_add_contact_structure_to_an_evenement(live_server, page, choice_js_fill):
     evenement = EvenementFactory()
-
-    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
-    page.get_by_role("tab", name="Contacts").click()
-    choice_js_fill(page, "#add-contact-structure-form .choices", str(contact), str(contact))
-    page.locator("#add-contact-structure-form").get_by_role("button", name="Ajouter").click()
-    page.get_by_role("tab", name="Contacts").click()
-
-    expect(page.get_by_text("La structure a été ajoutée avec succès.")).to_be_visible()
-    expect(page.get_by_test_id("contacts-structures")).to_be_visible()
-    assert page.get_by_test_id("contacts-structures").count() == 1
-    assert Evenement.objects.filter(pk=evenement.pk, contacts=contact).exists()
+    generic_test_add_contact_structure_to_an_evenement(live_server, page, choice_js_fill, evenement)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Depuis d939ed2c31d39ed4bd15e80b8d40f19d79f2edbd l'ajout des structures et des agents ne fonctionne plus dans SSA car le modèle EvenementProduit n'a pas de notion de visilibité et donc n'utilise pas le mixin qui fourni la méthode `update_allowed_structures_and_visibility`.

Mise en commun d'un test minimal, a défaut de migrer tous les tests sous forme de tests génériques.

Fixes SEVES-57