### PR TITLE
Permettre de gérer les documents dans les brouillons

### DIFF
--- a/core/pages.py
+++ b/core/pages.py
@@ -98,6 +98,15 @@ class BaseMessagePage(ABC):
     def open_message(self, index=1):
         self.page.locator(f"#table-sm-row-key-{index} td:nth-child(6) a").click()
 
+    def add_document(self):
+        self.page.locator(f"{self.container_id}").get_by_role("button", name="Ajouter un document").click()
+        self.page.locator(f"{self.container_id} .document-form #id_document_type").select_option("Autre document")
+        self.page.locator(f"{self.container_id} .document-form #id_file").set_input_files("static/images/login.jpeg")
+        self.page.locator(f"{self.container_id} #message-add-document").click()
+
+    def remove_document(self, index):
+        self.page.locator(f"{self.container_id} #document_remove_{index}").click()
+
     @property
     def message_title_in_sidebar(self):
         return self.page.locator(".sidebar.open h5")
@@ -113,6 +122,12 @@ class BaseMessagePage(ABC):
     @property
     def document_type_input(self):
         return self.page.locator(".sidebar #id_document_type")
+
+    @property
+    def get_existing_documents_title(self):
+        cards = self.page.locator(self.container_id).locator("[id^='document_card_'] span")
+        texts = [cards.nth(i).inner_text() for i in range(cards.count())]
+        return [t for t in texts if t]
 
 
 class CreateMessagePage(BaseMessagePage):

--- a/core/templates/core/_sidebar_message_form.html
+++ b/core/templates/core/_sidebar_message_form.html
@@ -36,7 +36,14 @@
                     <button class="fr-btn fr-btn--tertiary btn-full" id="message-add-document" disabled>Valider l'ajout du document</button>
                 </div>
             </div>
-
+        </div>
+        <div class="fr-hidden">
+            {% for existing_document_form in message_form.documents_forms %}
+                <div class="existing-document-form">
+                    {{ existing_document_form }}
+                    <input type="hidden" name="existing_document_name_{{ existing_document_form.instance.pk }}" data-pk="{{ existing_document_form.instance.pk }}" value="{{ existing_document_form.instance.file.name}}">
+                </div>
+            {% endfor %}
         </div>
         <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--center">
             <li>

--- a/ssa/tests/test_evenement_produit_message.py
+++ b/ssa/tests/test_evenement_produit_message.py
@@ -13,6 +13,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_finaliser_draft_note,
     generic_test_can_send_draft_fin_suivi,
     generic_test_can_only_see_own_document_types_in_message_form,
+    generic_test_can_see_and_delete_documents_from_draft_message,
 )
 from ssa.factories import EvenementProduitFactory
 from ssa.models import EvenementProduit
@@ -137,4 +138,16 @@ def test_can_only_see_own_document_types_in_message_form(live_server, page: Page
         page,
         check_select_options_from_element,
         EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS),
+    )
+
+
+def test_can_see_and_delete_documents_from_draft_message(
+    live_server, page: Page, mocked_authentification_user, mailoutbox
+):
+    generic_test_can_see_and_delete_documents_from_draft_message(
+        live_server,
+        page,
+        EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS),
+        mocked_authentification_user,
+        mailoutbox,
     )

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -32,6 +32,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_finaliser_draft_note,
     generic_test_can_send_draft_fin_suivi,
     generic_test_can_only_see_own_document_types_in_message_form,
+    generic_test_can_see_and_delete_documents_from_draft_message,
 )
 from seves import settings
 from sv.factories import EvenementFactory
@@ -1551,4 +1552,16 @@ def test_can_send_draft_fin_suivi(live_server, page: Page, mocked_authentificati
 def test_can_only_see_own_document_types_in_message_form(live_server, page: Page, check_select_options_from_element):
     generic_test_can_only_see_own_document_types_in_message_form(
         live_server, page, check_select_options_from_element, EvenementFactory()
+    )
+
+
+def test_can_see_and_delete_documents_from_draft_message(
+    live_server, page: Page, mocked_authentification_user, mailoutbox
+):
+    generic_test_can_see_and_delete_documents_from_draft_message(
+        live_server,
+        page,
+        EvenementFactory(),
+        mocked_authentification_user,
+        mailoutbox,
     )


### PR DESCRIPTION
Depuis l'introduction des brouillons les documents n'étaient pas géres:
- Affichage de la "carte" des documents existants si il y en a
- Permettre de supprimer un document précédement ajouté au brouillon
- Gestion de l'interface