### PR TITLE
fix: recherche communes — empêche le peuplement de résultats périmés

### DIFF
--- a/sv/static/sv/fichedetection_lieux_form.js
+++ b/sv/static/sv/fichedetection_lieux_form.js
@@ -3,7 +3,7 @@ import {setUpCommuneChoices} from "/static/core/commune.js";
 import {setUpAddressChoices} from "/static/core/ban_autocomplete.js";
 
 document.lieuxCards = []
-modalHTMLContent = {}
+const modalHTMLContent = {}
 document.choicesInstances = {};
 
 function deleteLieu(event) {


### PR DESCRIPTION
Annule les précédentes requêtes HTTP avant d'en relancer une ou de modifier le dropdown afin de ne pas le peupler avec des résultats qui pourraient être rendus obselètes par une interaction utilisateur/utilisatrice.

Cette PR n'ajoute pas de nouveaux tests car ce genre de situations avec évènements concurrents est très difficile à tester de façon fiable pour peu de valeur ajoutée.
