### PR TITLE
feat(tests): Permet de configurer le timeout global de Playwright avec une variable d'env

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 from unittest.mock import patch
 
@@ -17,6 +18,8 @@ User = get_user_model()
 @pytest.fixture
 def page(page):
     timeout = 4_000
+    with contextlib.suppress(TypeError, ValueError):
+        timeout = int(os.getenv("PLAYWRIGHT_TIMEOUT"))
     page.set_default_navigation_timeout(timeout)
     page.set_default_timeout(timeout)
     yield page


### PR DESCRIPTION
Pour une raison que j'ignore encore le mode debug rend le démarrage d'un serveur Django extrêmement lent ici. Du coup Playwright timeout avant même que Django ai eu le temps de recevoir la moindre requête HTTP. Cette fonctionnalité me rend beaucoup plus simple de debugger ces tests.