### PR TITLE
Améliorations sur la CI

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        group: [1, 2, 3, 4, 5, 6, 7, 8]
+        group: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     services:
       postgres:
         image: postgres:latest
@@ -78,15 +78,28 @@ jobs:
           python-version: 3.11.1
           cache: pip
       - name: Install dependencies
-        run: pip install pip-tools && pip-sync && playwright install
+        run: pip install pip-tools && pip-sync
+      - name: Playwright version
+        run: echo "PLAYWRIGHT_VERSION=$(playwright --version | awk '{print $2}')" >> $GITHUB_ENV
+      - name: Cache playwright binaries
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+      - name: Install Playwright dependencies
+        run: playwright install
       - name: Run tests
-        run: pytest --tracing=retain-on-failure --splits 8 --group ${{ matrix.group }}
+        run: >-
+          pytest
+          --tracing=retain-on-failure
+          --splits ${{ strategy.job-total }}
+          --group ${{ matrix.group }}
         env:
           SECRET_KEY: NOT_A_REAL_SECRET
           DATABASE_URL: postgres://postgres:postgres@localhost/github_actions
           DJANGO_ADMIN_URL: mon_url_secrete_admin
       - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+        if: ${{ failure() }}
         with:
-          name: playwright-traces
+          name: playwright-traces-${{ matrix.group }}
           path: test-results/

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -94,6 +94,9 @@ jobs:
           --tracing=retain-on-failure
           --splits ${{ strategy.job-total }}
           --group ${{ matrix.group }}
+          --reruns 1
+          --reruns-delay 5
+          --only-rerun E2ETestNetworkError
         env:
           SECRET_KEY: NOT_A_REAL_SECRET
           DATABASE_URL: postgres://postgres:postgres@localhost/github_actions

--- a/.talismanrc
+++ b/.talismanrc
@@ -30,7 +30,7 @@ fileignoreconfig:
 - filename: core/mixins.py
   checksum: 9717807f321037aee25f9711e052e85b2b9e2df83bcce796d1931e04ab2f53fb
 - filename: conftest.py
-  checksum: a17ce992990a59928baab025a092e3d561dd5f5bdee013ec86ceafcb21d07359
+  checksum: e5697a536e77dd0d10a3a7aa899da6cb02223491783161895aa618910c82e409
 - filename: core/pages.py
   checksum: 292dc4f6a239dfc2068d4144f0dd2617271f6d42aa5f3b878877722907751204
 - filename: ssa/static/ssa/treeselectjs.umd.js

--- a/.talismanrc
+++ b/.talismanrc
@@ -42,4 +42,4 @@ fileignoreconfig:
 - filename: core/migrations/0034_alter_document_document_type.py
   checksum: ad80322fb2dab542fe667054b83761da8e386ce7357b123b2e30a0fea28f1f10
 - filename: .github/workflows/django.yml
-  checksum: a4958b535bcef8735290a7af3d0e857222a36b4513e07056167daf363c4a4d76
+  checksum: bb2812e864802e3e55d05b28f6da146973a78b382dad3d94d1de8d4f10430657

--- a/requirements.in
+++ b/requirements.in
@@ -28,3 +28,4 @@ django-countries
 testcontainers[sftp]
 whitenoise
 pytest-split
+pytest-rerunfailures

--- a/requirements.txt
+++ b/requirements.txt
@@ -121,6 +121,7 @@ packaging==24.0
     # via
     #   gunicorn
     #   pytest
+    #   pytest-rerunfailures
 platformdirs==4.2.0
     # via virtualenv
 playwright==1.52.0
@@ -147,6 +148,8 @@ pytest==8.3.3
     #   pytest-django
     #   pytest-env
     #   pytest-playwright
+    #   pytest-rerunfailures
+    #   pytest-split
     #   pytest-xdist
 pytest-base-url==2.1.0
     # via pytest-playwright
@@ -155,6 +158,8 @@ pytest-django==4.11.1
 pytest-env==1.1.5
     # via -r requirements.in
 pytest-playwright==0.7.0
+    # via -r requirements.in
+pytest-rerunfailures==15.1
     # via -r requirements.in
 pytest-split==0.10.0
     # via -r requirements.in


### PR DESCRIPTION
- Cache les dépendances Playwright
- Relance les tests en échec une seule fois après un délai de 10s secondes sur un `ERR_NETWORK_CHANGED`
- Augmente le nombre de tests en parallèle de 8 à 12.