### PR TITLE
Pouvoir modifier une fiche événement produit

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -109,6 +109,18 @@ def choice_js_option_disabled(db, page):
     return _choice_js_cant_pick
 
 
+@pytest.fixture
+def choice_js_get_values(db, page):
+    def _choice_js_get_values(page, locator):
+        selected_options = page.locator(f'{locator} ~ div [aria-selected="true"]')
+        texts = []
+        for i in range(selected_options.count()):
+            texts.append(selected_options.nth(i).inner_text())
+        return texts
+
+    return _choice_js_get_values
+
+
 def _check_select_options_on_element(element, expected_options, with_default_value):
     options = element.locator("option").element_handles()
     visible_texts = []

--- a/ssa/forms.py
+++ b/ssa/forms.py
@@ -89,7 +89,9 @@ class EvenementProduitForm(DSFRForm, WithEvenementProduitFreeLinksMixin, forms.M
     def save(self, commit=True):
         if self.data.get("action") == "publish":
             self.instance.etat = WithEtatMixin.Etat.EN_COURS
-        self.instance.createur = self.user.agent.structure
+
+        if not self.instance.pk:
+            self.instance.createur = self.user.agent.structure
         instance = super().save(commit)
         self.save_free_links(instance)
         return instance

--- a/ssa/models/evenement_produit.py
+++ b/ssa/models/evenement_produit.py
@@ -12,6 +12,7 @@ from core.mixins import (
     WithMessageUrlsMixin,
     EmailNotificationMixin,
     AllowsSoftDeleteMixin,
+    WithFreeLinkIdsMixin,
 )
 from core.model_mixins import WithBlocCommunFieldsMixin
 from core.models import Structure, Document
@@ -138,6 +139,7 @@ class EvenementProduit(
     WithContactPermissionMixin,
     WithEtatMixin,
     WithNumeroMixin,
+    WithFreeLinkIdsMixin,
     models.Model,
 ):
     createur = models.ForeignKey(Structure, on_delete=models.PROTECT, verbose_name="Structure créatrice")
@@ -193,6 +195,9 @@ class EvenementProduit(
 
     def get_absolute_url(self):
         return reverse("ssa:evenement-produit-details", kwargs={"numero": self.numero})
+
+    def get_update_url(self):
+        return reverse("ssa:evenement-produit-update", kwargs={"pk": self.pk})
 
     def save(self, *args, **kwargs):
         with transaction.atomic():
@@ -281,6 +286,9 @@ class EvenementProduit(
         if user.agent.is_in_structure(self.createur):
             return True
         return not self.is_draft
+
+    def can_be_updated(self, user):
+        return self._user_can_interact(user)
 
     def can_user_delete(self, user):
         return self.can_user_access(user)

--- a/ssa/static/ssa/_rappel_conso_form.js
+++ b/ssa/static/ssa/_rappel_conso_form.js
@@ -18,6 +18,12 @@ document.documentElement.addEventListener('dsfr.ready', () => {
         handleDisabledRappelConsoBtn()
     }
 
+    function initExistingRappelConso(){
+        if (!document.getElementById("id_numeros_rappel_conso").value) return;
+        rappelConso = document.getElementById("id_numeros_rappel_conso").value.split(",")
+        showRappelConso()
+    }
+
     function showRappelConso() {
         const rappelContainer = document.getElementById("rappel-container")
         let innerHtml = ""
@@ -85,4 +91,5 @@ document.documentElement.addEventListener('dsfr.ready', () => {
     submitDraftBtn.addEventListener("click", addNumeroRappelConsoToHiddenFieldAndSubmit)
     submitPublishBtn.addEventListener("click", addNumeroRappelConsoToHiddenFieldAndSubmit)
     toNextInput.forEach(element => element.addEventListener("keyup", () => goToNextIfNeeded(element)))
+    initExistingRappelConso()
 })

--- a/ssa/static/ssa/evenement_produit_form.js
+++ b/ssa/static/ssa/evenement_produit_form.js
@@ -2,7 +2,7 @@ import {setUpFreeLinks} from "/static/core/free_links.js";
 import {patchItems, findPath} from "/static/ssa/_custom_tree_select.js"
 
 document.addEventListener('DOMContentLoaded', () => {
-  function disableSourceOptions(typeEvenementInput, sourceInput) {
+  function disableSourceOptions(typeEvenementInput, sourceInput, reset=true) {
     const isHumanCase = typeEvenementInput.value === "investigation_cas_humain";
     sourceInput.querySelectorAll('option').forEach(option => {
       if (option.value !== "autre") {
@@ -13,14 +13,17 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       }
     });
-    sourceInput.selectedIndex = 0;
+    if (reset===true){
+      sourceInput.selectedIndex = 0;
+    }
   }
 
   function setupCategorieProduit(){
     const options = JSON.parse(document.getElementById("categorie-produit-data").textContent)
+    const selectedValue = document.getElementById("id_categorie_produit").value
     const treeselect = new Treeselect({
       parentHtmlContainer: document.getElementById("categorie-produit"),
-      value: null,
+      value: selectedValue,
       options: options,
       isSingleSelect: true,
       showTags: false,
@@ -56,9 +59,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function setupCategorieDanger(){
     const options = JSON.parse(document.getElementById("categorie-danger-data").textContent)
+    const selectedValue = document.getElementById("id_categorie_danger").value
     const treeselect = new Treeselect({
       parentHtmlContainer: document.getElementById("categorie-danger"),
-      value: null,
+      value: selectedValue,
       options: options,
       isSingleSelect: true,
       showTags: false,
@@ -107,7 +111,9 @@ document.addEventListener('DOMContentLoaded', () => {
       },
     })
     document.querySelector("#categorie-danger .treeselect-input").classList.add("fr-input")
-    document.querySelector("#categorie-danger .treeselect-input__clear").classList.add("fr-hidden")
+    if (!selectedValue){
+      document.querySelector("#categorie-danger .treeselect-input__clear").classList.add("fr-hidden")
+    }
     treeselect.srcElement.addEventListener("update-dom", ()=>{patchItems(treeselect.srcElement)})
     treeselect.srcElement.addEventListener('input', (e) => {
       if (!!e.detail){
@@ -124,8 +130,8 @@ document.addEventListener('DOMContentLoaded', () => {
   typeEvenementInput.addEventListener("change", () => {
     disableSourceOptions(typeEvenementInput, sourceInput)
   })
-  disableSourceOptions(typeEvenementInput, sourceInput)
-  setUpFreeLinks(document.getElementById("id_free_link"), null)
+  disableSourceOptions(typeEvenementInput, sourceInput, false)
+  setUpFreeLinks(document.getElementById("id_free_link"), document.getElementById('free-links-id'))
   new Choices(document.getElementById("id_quantification_unite"), {
     classNames: {
       containerInner: 'fr-select',

--- a/ssa/templates/ssa/evenement_produit_form.html
+++ b/ssa/templates/ssa/evenement_produit_form.html
@@ -33,11 +33,19 @@
         <main class="main-container">
 
             <div class="evenement-produit-form-header">
-                <h1>Création d'un événement</h1>
+                <h1>{% if form.instance.pk %}Modification de l'événement {{ form.instance.numero }}{% else %}Création d'un événement{% endif %}</h1>
                 <div class="fr-mb-auto">
                     <a href="{% url 'ssa:evenement-produit-liste' %}" class="fr-link fr-mr-3w">Annuler</a>
-                    <button id="submit_draft" type="submit" name="action" value="draft" class="fr-btn fr-btn--secondary fr-mr-2w">Enregistrer le brouillon</button>
-                    <button id="submit_publish" type="submit" name="action" value="publish" class="fr-btn">Publier</button>
+                    {% if form.instance and form.instance.is_draft %}
+                        <button id="submit_draft" type="submit" name="action" value="draft" class="fr-btn fr-btn--secondary fr-mr-2w">Enregistrer le brouillon</button>
+                    {% endif %}
+                    <button id="submit_publish" type="submit" name="action" value="publish" class="fr-btn">
+                        {% if form.instance.pk %}
+                            Enregistrer
+                        {% else %}
+                            Publier
+                        {% endif %}
+                    </button>
                 </div>
             </div>
 
@@ -48,7 +56,7 @@
                         <div class="fr-col-12 fr-col-lg-4 flex-column ">
                             <div id="date-creation">
                                 <label class="fr-label" for="date-creation-input">Date de création</label>
-                                <input type="text" id="date-creation-input" class="fr-input fr-mt-0" value="{% now 'd/m/Y' %}" disabled>
+                                <input type="text" id="date-creation-input" class="fr-input fr-mt-0" value="{% if form.instance.date_creation %}{{ form.instance.date_creation|date:"d/m/Y" }}{% else %}{% now 'd/m/Y' %}{% endif %}" disabled>
                             </div>
                             {% if form.numero_rasff %}
                                 <div class="rasff">{% render_field form.numero_rasff %}</div>
@@ -171,6 +179,7 @@
             {% include "ssa/_etablissement_block.html" %}
             <div id="liens-libre" class="white-container fr-mt-2w">
                 <h3>Liens libres</h3>
+                {{ form.instance.free_link_ids|json_script:"free-links-id" }}
                 <span class="fr-hint-text fr-mb-1w">Pour lier un événement saisissez son numéro ci-dessous.</span>
                 <div>
                     {{ form.free_link }}

--- a/ssa/tests/test_evenement_produit_creation.py
+++ b/ssa/tests/test_evenement_produit_creation.py
@@ -9,7 +9,7 @@ from core.models import LienLibre, Contact
 from ssa.factories import EvenementProduitFactory, EtablissementFactory
 from ssa.models import EvenementProduit, Etablissement
 from ssa.models import TypeEvenement, Source
-from ssa.tests.pages import EvenementProduitCreationPage
+from ssa.tests.pages import EvenementProduitFormPage
 from ssa.views import FindNumeroAgrementView
 
 FIELD_TO_EXCLUDE_ETABLISSEMENT = ["_state", "id", "code_insee", "evenement_produit_id"]
@@ -17,7 +17,7 @@ FIELD_TO_EXCLUDE_ETABLISSEMENT = ["_state", "id", "code_insee", "evenement_produ
 
 def test_can_create_evenement_produit_with_required_fields_only(live_server, mocked_authentification_user, page: Page):
     input_data = EvenementProduitFactory.build()
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(input_data)
     creation_page.submit_as_draft()
@@ -32,7 +32,7 @@ def test_can_create_evenement_produit_with_required_fields_only(live_server, moc
 
 def test_can_create_evenement_produit_with_all_fields(live_server, mocked_authentification_user, page: Page):
     input_data = EvenementProduitFactory.build(not_bacterie=True)
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(input_data)
     creation_page.source.select_option(input_data.source)
@@ -75,7 +75,7 @@ def test_can_create_evenement_produit_with_all_fields(live_server, mocked_authen
 
 def test_can_create_evenement_produit_with_pam_if_bacterie(live_server, mocked_authentification_user, page: Page):
     input_data = EvenementProduitFactory.build(bacterie=True)
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(input_data)
 
@@ -89,7 +89,7 @@ def test_can_create_evenement_produit_with_pam_if_bacterie(live_server, mocked_a
 
 def test_can_publish_evenement_produit(live_server, mocked_authentification_user, page: Page):
     input_data = EvenementProduitFactory.build()
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(input_data)
     creation_page.publish()
@@ -107,7 +107,7 @@ def test_ac_can_fill_rasff_number(live_server, mocked_authentification_user, pag
     structure.niveau1 = AC_STRUCTURE
     structure.save()
     input_data = EvenementProduitFactory.build()
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(input_data)
     creation_page.numero_rasff.fill("2024.2222")
@@ -118,14 +118,14 @@ def test_ac_can_fill_rasff_number(live_server, mocked_authentification_user, pag
 
 
 def test_non_ac_cant_fill_rasff_number(live_server, mocked_authentification_user, page: Page):
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     expect(creation_page.numero_rasff).not_to_be_visible()
 
 
 def test_can_add_and_delete_numero_rappel_conso(live_server, mocked_authentification_user, page: Page):
     input_data = EvenementProduitFactory.build()
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(input_data)
     creation_page.add_rappel_conso("2025-01-1234")
@@ -141,7 +141,7 @@ def test_can_add_and_delete_numero_rappel_conso(live_server, mocked_authentifica
 
 
 def test_source_list_is_updated_when_type_evenement_is_changed(live_server, page: Page, check_select_options):
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.type_evenement.select_option(label=TypeEvenement.ALERTE_PRODUIT_NATIONALE.label)
     creation_page.source.click()
@@ -161,7 +161,7 @@ def test_can_add_etablissements(live_server, page: Page, assert_models_are_equal
 
     etablissement_1, etablissement_2, etablissement_3 = EtablissementFactory.build_batch(3, evenement_produit=evenement)
 
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(evenement)
     creation_page.add_etablissement(etablissement_1)
@@ -183,7 +183,7 @@ def test_can_edit_etablissement_multiple_times(live_server, page: Page, assert_m
 
     etablissement = EtablissementFactory.build(evenement_produit=evenement)
 
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(evenement)
     creation_page.add_etablissement(etablissement)
@@ -205,7 +205,7 @@ def test_can_edit_etablissement_multiple_times(live_server, page: Page, assert_m
 def test_card_etablissement_content(live_server, page: Page):
     etablissement = EtablissementFactory()
 
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.add_etablissement(etablissement)
 
@@ -221,7 +221,7 @@ def test_can_add_etablissement_with_required_fields_only(live_server, page: Page
     evenement = EvenementProduitFactory()
 
     etablissement = EtablissementFactory.build()
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(evenement)
     creation_page.add_etablissement_with_required_fields(etablissement)
@@ -237,7 +237,7 @@ def test_can_add_and_delete_etablissements(live_server, page: Page, assert_model
 
     etablissement_1, etablissement_2, etablissement_3 = EtablissementFactory.build_batch(3, evenement_produit=evenement)
 
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(evenement)
     creation_page.add_etablissement(etablissement_1)
@@ -257,7 +257,7 @@ def test_can_add_and_delete_etablissements(live_server, page: Page, assert_model
 def test_can_add_free_links(live_server, page: Page, choice_js_fill):
     evenement = EvenementProduitFactory.build()
     evenement_1, evenement_2 = EvenementProduitFactory.create_batch(2, etat=EvenementProduit.Etat.EN_COURS)
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(evenement)
     creation_page.add_free_link(evenement_1.numero, choice_js_fill)
@@ -277,7 +277,7 @@ def test_cant_add_free_links_for_etat_brouillon(live_server, page: Page, choice_
     evenement = EvenementProduitFactory()
     evenement_1 = EvenementProduitFactory(etat=EvenementProduit.Etat.BROUILLON)
 
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(evenement)
     numero = "Événement produit : " + str(evenement_1.numero)
@@ -306,7 +306,7 @@ def test_can_create_etablissement_with_ban_auto_complete(live_server, page: Page
         route.fulfill(status=200, content_type="application/json", body=json.dumps(response))
         call_count["count"] += 1
 
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(evenement)
     creation_page.page.route(
@@ -354,7 +354,7 @@ def test_can_create_etablissement_force_ban_auto_complete(live_server, page: Pag
         route.fulfill(status=200, content_type="application/json", body=json.dumps(response))
         call_count["count"] += 1
 
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(evenement)
     creation_page.page.route(
@@ -383,7 +383,7 @@ def test_ac_can_fill_rasff_number_6_digits(live_server, mocked_authentification_
     structure.niveau1 = AC_STRUCTURE
     structure.save()
     input_data = EvenementProduitFactory.build()
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(input_data)
     creation_page.numero_rasff.fill("123456")
@@ -395,7 +395,7 @@ def test_ac_can_fill_rasff_number_6_digits(live_server, mocked_authentification_
 
 def test_add_contacts_on_creation(live_server, mocked_authentification_user, page: Page):
     input_data = EvenementProduitFactory.build()
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(input_data)
     creation_page.submit_as_draft()
@@ -415,7 +415,7 @@ def test_can_add_etablissement_and_quit_modal(live_server, page: Page, assert_mo
 
     etablissement = EtablissementFactory(evenement_produit=evenement)
 
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(evenement)
     creation_page.add_etablissement(etablissement)
@@ -464,7 +464,7 @@ def test_can_create_etablissement_with_sirene_autocomplete(
         handle,
     )
 
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
 
     mocked_view = mock.Mock()
     mocked_view.side_effect = lambda request: JsonResponse({"numero_agrement": "03.223.432"})
@@ -523,7 +523,7 @@ def test_can_create_etablissement_with_force_siret_value(
         handle,
     )
 
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
 
     with mock.patch("core.mixins.requests.post") as mock_post:
         mock_post.return_value.json.return_value = {"access_token": "FAKE_TOKEN"}
@@ -605,7 +605,7 @@ def test_can_create_etablissement_with_full_siren_will_filter_results(
         handle,
     )
 
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
 
     with mock.patch("core.mixins.requests.post") as mock_post:
         mock_post.return_value.json.return_value = {"access_token": "FAKE_TOKEN"}
@@ -630,7 +630,7 @@ def test_can_create_evenement_produit_using_shortcut_on_categorie_danger(
     live_server, mocked_authentification_user, page: Page
 ):
     input_data = EvenementProduitFactory.build()
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(input_data)
     creation_page.page.locator("#categorie-danger .treeselect-input__edit").click()
@@ -647,7 +647,7 @@ def test_can_create_evenement_produit_using_shortcut_on_categorie_danger(
 def test_cant_add_etablissement_with_incorrect_numero_agrement(live_server, page: Page):
     evenement = EvenementProduitFactory()
 
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(evenement)
     creation_page.open_etablissement_modal()
@@ -659,7 +659,7 @@ def test_cant_add_etablissement_with_incorrect_numero_agrement(live_server, page
 
 
 def test_categorie_danger_dont_show(live_server, mocked_authentification_user, page: Page):
-    creation_page = EvenementProduitCreationPage(page, live_server.url)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     dropdown = creation_page.display_and_get_categorie_danger()
     # Force open the dropdown by clicking it

--- a/ssa/tests/test_evenement_produit_update.py
+++ b/ssa/tests/test_evenement_produit_update.py
@@ -1,0 +1,128 @@
+from playwright.sync_api import expect
+
+from core.factories import StructureFactory
+from core.models import LienLibre
+from ssa.factories import EvenementProduitFactory
+from ssa.models import EvenementProduit
+from ssa.tests.pages import EvenementProduitFormPage
+
+
+def test_can_update_evenement_produit_descripteur_and_save_as_draft(
+    live_server, page, choice_js_get_values, choice_js_fill
+):
+    evenement: EvenementProduit = EvenementProduitFactory(numeros_rappel_conso=["2000-01-1111"])
+    wanted_values = EvenementProduitFactory.build()
+    for_free_link = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    for_other_free_link = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    LienLibre.objects.create(related_object_1=evenement, related_object_2=for_free_link)
+
+    update_page = EvenementProduitFormPage(page, live_server.url)
+    update_page.navigate_update_page(evenement)
+
+    expect(update_page.date_creation).to_have_value(evenement.date_creation.strftime("%d/%m/%Y"))
+
+    inputs_fields = [
+        "description",
+        "denomination",
+        "marque",
+        "lots",
+        "description_complementaire",
+        "precision_danger",
+        "quantification",
+        "evaluation",
+        "reference_souches",
+        "reference_clusters",
+    ]
+    select_fields = ["type_evenement", "source", "actions_engagees"]
+
+    # We need to check all the values *before* we make any changes because some field resets when there is a change
+    for field in inputs_fields + select_fields:
+        expect(getattr(update_page, field)).to_have_value(str(getattr(evenement, field)))
+
+    expect(update_page.numero_rasff).not_to_be_visible()
+
+    assert choice_js_get_values(page, "#id_quantification_unite") == [evenement.get_quantification_unite_display()]
+    assert choice_js_get_values(page, "#id_free_link") == [f"Événement produit : {for_free_link.numero}Remove item"]
+    expect(update_page.page.get_by_text("2000-01-1111", exact=True)).to_be_visible()
+
+    assert update_page.get_treeselect_options("categorie-danger") == [
+        evenement.get_categorie_danger_display().split(">")[-1].strip()
+    ]
+    assert update_page.get_treeselect_options("categorie-produit") == [
+        evenement.get_categorie_produit_display().split(">")[-1].strip()
+    ]
+
+    # Making changes on all fields
+    for field in inputs_fields:
+        getattr(update_page, field).fill(getattr(wanted_values, field))
+
+    for field in select_fields:
+        getattr(update_page, field).select_option(getattr(wanted_values, field))
+
+    update_page.set_categorie_produit(wanted_values)
+    update_page.set_categorie_danger(wanted_values)
+
+    update_page.delete_rappel_conso("2000-01-1111")
+    update_page.add_rappel_conso("2025-12-1212")
+    update_page.add_free_link(for_other_free_link.numero, choice_js_fill)
+
+    update_page.submit_as_draft()
+    expect(update_page.page.get_by_text("L'événement produit a bien été modifié.")).to_be_visible()
+
+    evenement.refresh_from_db()
+    assert evenement.is_draft is True
+
+    for field in inputs_fields + select_fields:
+        assert getattr(evenement, field) == getattr(wanted_values, field), f"Failed on field : {field}"
+
+    assert evenement.categorie_produit == wanted_values.categorie_produit
+    assert evenement.categorie_danger == wanted_values.categorie_danger
+    assert evenement.numeros_rappel_conso == ["2025-12-1212"]
+
+    assert LienLibre.objects.count() == 2
+    assert [lien.related_object_1 for lien in LienLibre.objects.all()] == [evenement, evenement]
+    expected = sorted([for_free_link.numero, for_other_free_link.numero])
+    assert sorted([lien.related_object_2.numero for lien in LienLibre.objects.all()]) == expected
+
+
+def test_can_update_evenement_produit_descripteur_and_publish(live_server, page):
+    evenement: EvenementProduit = EvenementProduitFactory()
+    update_page = EvenementProduitFormPage(page, live_server.url)
+    update_page.navigate_update_page(evenement)
+    update_page.description.fill("New value")
+    update_page.publish()
+
+    expect(update_page.page.get_by_text("L'événement produit a bien été modifié.")).to_be_visible()
+    evenement.refresh_from_db()
+    assert evenement.is_published is True
+    assert evenement.description == "New value"
+
+
+def test_update_evenement_produit_will_not_change_createur(live_server, page):
+    createur = StructureFactory()
+    evenement: EvenementProduit = EvenementProduitFactory(createur=createur, etat=EvenementProduit.Etat.EN_COURS)
+    update_page = EvenementProduitFormPage(page, live_server.url)
+    update_page.navigate_update_page(evenement)
+    update_page.description.fill("New value")
+    update_page.publish()
+
+    expect(update_page.page.get_by_text("L'événement produit a bien été modifié.")).to_be_visible()
+    evenement.refresh_from_db()
+    assert evenement.createur == createur
+
+
+def test_update_adds_agent_and_structure_to_contacts(live_server, page, mocked_authentification_user):
+    createur = StructureFactory()
+    evenement: EvenementProduit = EvenementProduitFactory(createur=createur, etat=EvenementProduit.Etat.EN_COURS)
+    assert evenement.contacts.count() == 0
+
+    update_page = EvenementProduitFormPage(page, live_server.url)
+    update_page.navigate_update_page(evenement)
+    update_page.description.fill("New value")
+    update_page.publish()
+
+    expect(update_page.page.get_by_text("L'événement produit a bien été modifié.")).to_be_visible()
+    evenement.refresh_from_db()
+    assert evenement.contacts.count() == 2
+    assert mocked_authentification_user.agent.contact_set.get() in evenement.contacts.all()
+    assert mocked_authentification_user.agent.structure.contact_set.get() in evenement.contacts.all()

--- a/ssa/urls.py
+++ b/ssa/urls.py
@@ -5,6 +5,7 @@ from .views import (
     EvenementProduitCreateView,
     EvenementProduitListView,
     FindNumeroAgrementView,
+    EvenementUpdateView,
 )
 from .views.produit import EvenementProduitExportView
 
@@ -19,6 +20,11 @@ urlpatterns = [
         "evenement-produit/<str:numero>/",
         EvenementProduitDetailView.as_view(),
         name="evenement-produit-details",
+    ),
+    path(
+        "evenement-produit/<int:pk>/modification",
+        EvenementUpdateView.as_view(),
+        name="evenement-produit-update",
     ),
     path(
         "evenement-produit/",

--- a/ssa/views/__init__.py
+++ b/ssa/views/__init__.py
@@ -1,4 +1,5 @@
 from .produit import EvenementProduitCreateView as EvenementProduitCreateView
 from .produit import EvenementProduitDetailView as EvenementProduitDetailView
 from .produit import EvenementProduitListView as EvenementProduitListView
+from .produit import EvenementUpdateView as EvenementUpdateView
 from .api import FindNumeroAgrementView as FindNumeroAgrementView


### PR DESCRIPTION
- Quelques modifications de JS et HTML pour initialiser des données (liens libre, picker produit et danger, etc.)
- Changement du nom de l'utilitaire de form pour utiliser le même sur la page de création et de modification
- Quelques changement dans le form pour ne pas changer le créateur à chaque modification