### PR TITLE
Toujours ouvrir les pickers treeselectjs vers le bas

### DIFF
--- a/ssa/static/ssa/evenement_produit_form.js
+++ b/ssa/static/ssa/evenement_produit_form.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
       isSingleSelect: true,
       showTags: false,
       placeholder: "Choisir",
+      direction: "bottom",
       openCallback() {
         patchItems(treeselect.srcElement)
       },
@@ -64,6 +65,7 @@ document.addEventListener('DOMContentLoaded', () => {
       showTags: false,
       placeholder: "Choisir",
       emptyText: "Pas de résultat",
+      direction: "bottom",
       openCallback() {
         patchItems(treeselect.srcElement)
         if (this._customHeaderAdded) {


### PR DESCRIPTION
Afin d'éviter qu'ils s'ouvrent vert le haut et soient tronqués par le bloc parent.