### PR TITLE
Corriger la fin de suivi pour SSA

### DIFF
--- a/core/model_mixins.py
+++ b/core/model_mixins.py
@@ -1,5 +1,5 @@
 from django.contrib.contenttypes.fields import GenericRelation
-from django.db import models
+from django.db import models, transaction
 
 from core.models import Document, Message, Contact, FinSuiviContact
 
@@ -20,3 +20,20 @@ class WithBlocCommunFieldsMixin(models.Model):
 
     def get_message_form(self):
         raise NotImplementedError
+
+    def add_fin_suivi(self, user):
+        with transaction.atomic():
+            fin_suivi_contact = FinSuiviContact(
+                content_object=self,
+                contact=Contact.objects.get(structure=user.agent.structure),
+            )
+            fin_suivi_contact.full_clean()
+            fin_suivi_contact.save()
+
+            Message.objects.create(
+                title="Fin de suivi",
+                content="Fin de suivi ajoutée automatiquement suite à la clôture de l'événement.",
+                sender=user.agent.contact_set.get(),
+                message_type=Message.FIN_SUIVI,
+                content_object=self,
+            )

--- a/ssa/tests/test_evenement_produit_details_actions.py
+++ b/ssa/tests/test_evenement_produit_details_actions.py
@@ -39,6 +39,25 @@ def test_can_cloturer_evenement_produit(live_server, page: Page, mocked_authenti
     expect(page.get_by_text(f"L'événement n°{evenement.numero} a bien été clôturé.")).to_be_visible()
 
 
+def test_can_cloturer_evenement_produit_if_last_remaining_structure(
+    live_server, page: Page, mocked_authentification_user
+):
+    ac_structure = Structure.objects.create(niveau1=AC_STRUCTURE, niveau2=MUS_STRUCTURE, libelle=MUS_STRUCTURE)
+    contact = Contact.objects.create(structure=ac_structure)
+    evenement = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS, createur=ac_structure)
+    mocked_authentification_user.agent.structure = ac_structure
+    evenement.contacts.add(contact)
+
+    details_page = EvenementProduitDetailsPage(page, live_server.url)
+    details_page.navigate(evenement)
+    details_page.cloturer()
+
+    evenement.refresh_from_db()
+    assert evenement.etat == EvenementProduit.Etat.CLOTURE
+    expect(page.get_by_text("Clôturé", exact=True)).to_be_visible()
+    expect(page.get_by_text(f"L'événement n°{evenement.numero} a bien été clôturé.")).to_be_visible()
+
+
 def test_can_publish_evenement_produit(live_server, page: Page, mocked_authentification_user):
     evenement = EvenementProduitFactory(etat=EvenementProduit.Etat.BROUILLON)
 

--- a/sv/models/evenements.py
+++ b/sv/models/evenements.py
@@ -18,7 +18,7 @@ from core.mixins import (
 )
 from core.mixins import WithEtatMixin
 from core.model_mixins import WithBlocCommunFieldsMixin
-from core.models import Message, Contact, Structure, FinSuiviContact, Document
+from core.models import Structure, Document
 from . import FicheZoneDelimitee
 from .common import OrganismeNuisible, StatutReglementaire
 from .models_mixins import WithDerniereMiseAJourMixin
@@ -168,23 +168,6 @@ class Evenement(
 
     def get_cloture_confirm_message(self):
         return f"L'événement n°{self.numero} a bien été clôturé."
-
-    def add_fin_suivi(self, user):
-        with transaction.atomic():
-            fin_suivi_contact = FinSuiviContact(
-                content_object=self,
-                contact=Contact.objects.get(structure=user.agent.structure),
-            )
-            fin_suivi_contact.full_clean()
-            fin_suivi_contact.save()
-
-            Message.objects.create(
-                title="Fin de suivi",
-                content="Fin de suivi ajoutée automatiquement suite à la clôture de l'événement.",
-                sender=user.agent.contact_set.get(),
-                message_type=Message.FIN_SUIVI,
-                content_object=self,
-            )
 
     def get_email_subject(self):
         return f"{self.organisme_nuisible.code_oepp} {self.numero}"


### PR DESCRIPTION
En cas de cloture d'une fiche, si la structure est la dernière on met la fiche en fin de suivi. Pour cela on déplace la méthode du modèle Evenement de SV dans le mixins qui gère la fin de suivi et les messages. Ajout d'un test spécifique a cette situation.

Fixes SEVES-59