### PR TITLE
Corriger la couleur du tag de position dossier

### DIFF
--- a/ssa/static/ssa/_etablissement_form.js
+++ b/ssa/static/ssa/_etablissement_form.js
@@ -140,8 +140,11 @@ document.addEventListener('DOMContentLoaded', () => {
             baseCard.querySelector('.position-dossier').innerText = positionDossier
             baseCard.querySelector('.position-dossier').classList.remove("fr-hidden")
             const extraClass = positionDossierInput.options[positionDossierInput.selectedIndex].dataset.extraClass
+            const basePositionDossier = baseCard.querySelector('.position-dossier')
             if (!!extraClass){
-                baseCard.querySelector('.position-dossier').classList.add(extraClass)
+                basePositionDossier.classList.add(extraClass)
+            } else {
+                basePositionDossier.classList.value = basePositionDossier.dataset.resetClasses
             }
         }
         return baseCard

--- a/ssa/templates/ssa/_etablissement_block.html
+++ b/ssa/templates/ssa/_etablissement_block.html
@@ -78,6 +78,6 @@
         <p class="pays fr-tag fr-hidden fr-mb-2v"></p>
         <div class="structure"></div>
         <div class="numero-agrement fr-hidden"></div>
-        <p class="position-dossier fr-badge fr-hidden fr-my-2v"></p>
+        <p class="position-dossier fr-badge fr-hidden fr-my-2v" data-reset-classes="position-dossier fr-badge fr-my-2v"></p>
     </div>
 </template>

--- a/ssa/widgets.py
+++ b/ssa/widgets.py
@@ -1,15 +1,9 @@
 from django import forms
 
-from ssa.models.etablissement import PositionDossier, Etablissement
+from ssa.models.etablissement import Etablissement
 
 
 class PositionDossierWidget(forms.Select):
-    RED_CASES = [
-        PositionDossier.SURVENUE_NON_CONFORMITE,
-        PositionDossier.DETECTION_NON_CONFORMITE,
-        PositionDossier.DETECTION_ET_SURVENUE_NON_CONFORMITE,
-    ]
-
     def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
         option = super().create_option(name, value, label, selected, index, subindex, attrs)
         if value:


### PR DESCRIPTION
Dans le cas suivant:
- Création d'un établissement avec une position de dossier "importante" (bleue)
- Édition de l'établissement pour une position de dossier "classique" (grise)

Le tag restait bleue à la place de redevenir gris. Correction de ce point, suppression de code mort au passage.