### PR TITLE
fix: fiabilisation `test_fiche_detection_create_without_lieux_and_prelevement`

### DIFF
--- a/sv/static/sv/evenement_form.js
+++ b/sv/static/sv/evenement_form.js
@@ -7,7 +7,9 @@ function setUpOrganismeNuisible(){
         classNames: {
             containerInner: 'fr-select',
         },
-        itemSelectText: ''
+        itemSelectText: '',
+        searchResultLimit: -1,
+        position: 'bottom'
     });
 
     choices.passedElement.element.addEventListener("choice", (event)=> {

--- a/sv/static/sv/fichedetection_form.js
+++ b/sv/static/sv/fichedetection_form.js
@@ -7,6 +7,7 @@ function setUpOrganismeNuisible(){
             containerInner: 'fr-select',
         },
         itemSelectText: '',
+        searchResultLimit: -1,
         position: 'bottom'
     });
 


### PR DESCRIPTION
Par défault [Choices](https://github.com/Choices-js/Choices#readme) n'affiche que 4 résultats max lors de la recherche. La sélection de ces résultats ne semble pas fiable. L'option `searchResultLimit` permet d'afficher tous les résultats et d'avoir la certitude que celui qui est cherché dans le test sera présent.