### PR TITLE
feat(test): désactive toutes les animations CSS pendant les tests

### DIFF
--- a/core/static/core/base.css
+++ b/core/static/core/base.css
@@ -1,6 +1,15 @@
 body{
     background-color: #F6F6F6;
 }
+
+body.environment-test *,
+body.environment-test *:before,
+body.environment-test *:after {
+    transition-property: none !important;
+    transform: none !important;
+    animation: none !important;
+}
+
 header{
     border-bottom: 2px solid #000091;
 }

--- a/seves/context_processors.py
+++ b/seves/context_processors.py
@@ -12,6 +12,8 @@ def environment_class(request):
             return {"environment_class": "environment-banner environment-recette"}
         case "dev":
             return {"environment_class": "environment-banner environment-dev"}
+        case "test":
+            return {"environment_class": "environment-banner environment-test"}
         case _:
             return {"environment_class": ""}
 


### PR DESCRIPTION
Les animations d'interface posent un vrai défi aux tests d'intégration au point qu'il est de notoriété publique dans la commun du développement Android qu'il vaut mieux les désactiver entièrement. Cette PR tente de supprimer au maximum les animations CSS sur l'interface pendant les tests pour éviter les problèmes de tests flaky à cause des collisions dopération dûes à des animations.