### PR TITLE
Permettre d'éditer les établissements

### DIFF
--- a/ssa/formsets.py
+++ b/ssa/formsets.py
@@ -5,5 +5,5 @@ from ssa.models import EvenementProduit
 from ssa.models.etablissement import Etablissement
 
 EtablissementFormSet = inlineformset_factory(
-    EvenementProduit, Etablissement, form=EtablissementForm, extra=10, can_delete=False
+    EvenementProduit, Etablissement, form=EtablissementForm, extra=10, can_delete=True
 )

--- a/ssa/static/ssa/_rappel_conso_form.js
+++ b/ssa/static/ssa/_rappel_conso_form.js
@@ -88,7 +88,9 @@ document.documentElement.addEventListener('dsfr.ready', () => {
     })
 
     rappelContainer.forEach(input => input.addEventListener('input', handleDisabledRappelConsoBtn))
-    submitDraftBtn.addEventListener("click", addNumeroRappelConsoToHiddenFieldAndSubmit)
+    if (!!submitDraftBtn){
+        submitDraftBtn.addEventListener("click", addNumeroRappelConsoToHiddenFieldAndSubmit)
+    }
     submitPublishBtn.addEventListener("click", addNumeroRappelConsoToHiddenFieldAndSubmit)
     toNextInput.forEach(element => element.addEventListener("keyup", () => goToNextIfNeeded(element)))
     initExistingRappelConso()

--- a/ssa/templates/ssa/_etablissement_block.html
+++ b/ssa/templates/ssa/_etablissement_block.html
@@ -2,39 +2,20 @@
     <h3>Établissements</h3>
     {{ formset.management_form }}
     <button type="button" id="add-etablissement" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-line fr-mb-2w">Ajouter</button>
+
+    {% for etablissement_form in formset %}
+        {% if etablissement_form.instance.pk %}
+            {{ etablissement_form.id }}
+            {% include "ssa/_etablissement_modal.html" with form=etablissement_form extra_str=forloop.counter0 data_etablissement_id=forloop.counter0 sirene_token=sirene_token  with_delete=True %}
+        {% endif %}
+    {% endfor %}
+
     <div class="fr-mt-2w" id="etablissement-card-container">
     </div>
 </div>
 
 <template id="etablissement-template">
-    <button class="fr-btn fr-hidden"  data-fr-opened="false" aria-controls="fr-modal-etablissement__prefix__" ></button>
-    <dialog aria-labelledby="fr-modal-title-modal-etablissement__prefix__" role="dialog" id="fr-modal-etablissement__prefix__" class="fr-modal modal-etablissement">
-        <div class="fr-container fr-container--fluid fr-container-md">
-            <div class="fr-grid-row fr-grid-row--center">
-                <div class="fr-col-12 fr-col-md-8">
-                    <div class="fr-modal__body">
-                        <div class="fr-modal__header">
-                            <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-etablissement__prefix__" type="button">Fermer</button>
-                        </div>
-                        <div class="fr-modal__content">
-                            <h1 id="fr-modal-title-modal--etablissement__prefix__" class="fr-modal__title"><span class="fr-icon-arrow-right-line fr-icon--lg"></span>Ajouter un établissement</h1>
-                            <div class="fr-fieldset__element">
-                                <label for="search-siret-input-{{ id }}">N° SIRET</label>
-                                <select class="fr-input" type="search" id="search-siret-input-{{ id }}" name="search-{{ id }}-input" data-token="{{ sirene_token }}"></select>
-                            </div>
-                            {{ empty_form.as_dsfr_div }}
-                        </div>
-                        <div class="fr-modal__footer">
-                            <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg">
-                                <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-etablissement__prefix__" type="button">Annuler</button>
-                                <button type="submit" class="fr-btn save-btn" id="etablissement-save-btn-__prefix__">Enregistrer</button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </dialog>
+    {% include "ssa/_etablissement_modal.html" with form=empty_form extra_str="__prefix__" sirene_token=sirene_token %}
 </template>
 
 <template id="etablissement-card-template">

--- a/ssa/templates/ssa/_etablissement_modal.html
+++ b/ssa/templates/ssa/_etablissement_modal.html
@@ -1,0 +1,31 @@
+<button class="fr-btn fr-hidden"  data-fr-opened="false" aria-controls="fr-modal-etablissement{{ extra_str }}" ></button>
+<dialog aria-labelledby="fr-modal-title-modal-etablissement{{ extra_str }}" role="dialog" id="fr-modal-etablissement{{ extra_str }}" class="fr-modal modal-etablissement">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-8">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-modal-etablissement{{ extra_str }}" type="button">Fermer</button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 id="fr-modal-title-modal--etablissement{{ extra_str }}" class="fr-modal__title"><span class="fr-icon-arrow-right-line fr-icon--lg"></span>Ajouter un établissement</h1>
+                        {% if with_delete %}
+                            <p class="fr-hidden">{{ form.DELETE }}</p>
+                        {% endif %}
+                        <div class="fr-fieldset__element">
+                            <label for="search-siret-input-">N° SIRET</label>
+                            <select class="fr-input" type="search" id="search-siret-input-" data-token="{{ sirene_token }}"></select>
+                        </div>
+                        {{ form.as_dsfr_div }}
+                    </div>
+                    <div class="fr-modal__footer">
+                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg">
+                            <button class="fr-btn fr-btn--secondary" aria-controls="fr-modal-etablissement{{ extra_str }}" type="button">Annuler</button>
+                            <button type="submit" class="fr-btn save-btn" id="etablissement-save-btn-{{ extra_str }}" {% if data_etablissement_id == 0 or data_etablissement_id %}data-etablissement-id="{{ data_etablissement_id }}"{% endif %}>Enregistrer</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/ssa/tests/conftest.py
+++ b/ssa/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from playwright.sync_api import expect
 
 from core.models import Region, Departement
 from core.constants import DEPARTEMENTS
@@ -33,3 +34,15 @@ def assert_models_are_equal():
         assert obj_1_data == obj_2_data
 
     return _assert_models_are_equal
+
+
+@pytest.fixture
+def assert_etablissement_card_is_correct():
+    def _assert_etablissement_card_is_correct(locator, expected_values):
+        expect(locator.get_by_text(expected_values.raison_sociale, exact=True)).to_be_visible()
+        expect(locator.get_by_text(expected_values.pays.name, exact=True)).to_be_visible()
+        expect(locator.get_by_text(expected_values.get_type_exploitant_display(), exact=True)).to_be_visible()
+        expect(locator.get_by_text(f"{expected_values.departement.get_num_name_display()}")).to_be_visible()
+        expect(locator.get_by_text(expected_values.get_position_dossier_display(), exact=True)).to_be_visible()
+
+    return _assert_etablissement_card_is_correct

--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -226,8 +226,7 @@ class EvenementProduitFormPage(WithTreeSelect):
         self.page.get_by_role("option", name=f"{siret} (Forcer la valeur)", exact=True).click()
         assert call_count["count"] == 1
 
-    def add_etablissement(self, etablissement: Etablissement):
-        modal = self.open_etablissement_modal()
+    def _fill_etablissement(self, modal, etablissement: Etablissement):
         self.force_siret(etablissement.siret)
         modal.locator('[id$="-numero_agrement"]').fill(etablissement.numero_agrement)
         modal.locator('[id$="raison_sociale"]').fill(etablissement.raison_sociale)
@@ -238,10 +237,19 @@ class EvenementProduitFormPage(WithTreeSelect):
         modal.locator('[id$="-type_exploitant"]').select_option(etablissement.type_exploitant)
         modal.locator('[id$="-position_dossier"]').select_option(etablissement.position_dossier)
 
+    def add_etablissement(self, etablissement: Etablissement):
+        modal = self.open_etablissement_modal()
+        self._fill_etablissement(modal, etablissement)
         self.close_etablissement_modal()
 
-    def open_edit_etablissement(self):
-        self.page.locator(".etablissement-edit-btn").click()
+    def open_edit_etablissement(self, index=0):
+        self.page.locator(".etablissement-edit-btn").nth(index).click()
+
+    def edit_etablissement_with_new_values(self, index, wanted_values: Etablissement):
+        self.open_edit_etablissement(index=index)
+        modal = self.current_modal
+        self._fill_etablissement(modal, wanted_values)
+        self.close_etablissement_modal()
 
     def etablissement_card(self, index=0):
         return self.page.locator(".etablissement-card").nth(index)

--- a/ssa/tests/test_evenement_produit_creation.py
+++ b/ssa/tests/test_evenement_produit_creation.py
@@ -214,7 +214,7 @@ def test_can_edit_etablissement_multiple_times(live_server, page: Page, ensure_d
     assert str(etablissement.departement) == "Aisne"
 
 
-def test_card_etablissement_content(live_server, page: Page):
+def test_card_etablissement_content(live_server, page: Page, assert_etablissement_card_is_correct):
     etablissement = EtablissementFactory()
 
     creation_page = EvenementProduitFormPage(page, live_server.url)
@@ -222,11 +222,7 @@ def test_card_etablissement_content(live_server, page: Page):
     creation_page.add_etablissement(etablissement)
 
     etablissement_card = creation_page.etablissement_card()
-    expect(etablissement_card.get_by_text(etablissement.raison_sociale, exact=True)).to_be_visible()
-    expect(etablissement_card.get_by_text(etablissement.pays.name, exact=True)).to_be_visible()
-    expect(etablissement_card.get_by_text(etablissement.get_type_exploitant_display(), exact=True)).to_be_visible()
-    expect(etablissement_card.get_by_text(f"{etablissement.departement.get_num_name_display()}")).to_be_visible()
-    expect(etablissement_card.get_by_text(etablissement.get_position_dossier_display(), exact=True)).to_be_visible()
+    assert_etablissement_card_is_correct(etablissement_card, etablissement)
 
 
 def test_can_add_etablissement_with_required_fields_only(live_server, page: Page, assert_models_are_equal):

--- a/ssa/tests/test_evenement_produit_details.py
+++ b/ssa/tests/test_evenement_produit_details.py
@@ -57,7 +57,9 @@ def test_evenement_produit_detail_wont_show_pam_if_not_danger_bacterien(live_ser
     expect(details_page.page.get_by_text("Produit prêt à manger (PAM)", exact=True)).not_to_be_visible()
 
 
-def test_evenement_produit_detail_page_content_etablissement(live_server, page: Page):
+def test_evenement_produit_detail_page_content_etablissement(
+    live_server, page: Page, assert_etablissement_card_is_correct
+):
     evenement = EvenementProduitFactory()
     etablissement = EtablissementFactory(evenement_produit=evenement)
 
@@ -65,13 +67,7 @@ def test_evenement_produit_detail_page_content_etablissement(live_server, page: 
     details_page.navigate(evenement)
 
     etablissement_card = details_page.etablissement_card()
-    expect(etablissement_card.get_by_text(etablissement.raison_sociale, exact=True)).to_be_visible()
-    expect(etablissement_card.get_by_text(etablissement.pays.name, exact=True)).to_be_visible()
-    expect(etablissement_card.get_by_text(etablissement.get_type_exploitant_display(), exact=True)).to_be_visible()
-    expect(
-        etablissement_card.get_by_text(f"Département : {etablissement.departement.get_num_name_display()}", exact=True)
-    ).to_be_visible()
-    expect(etablissement_card.get_by_text(etablissement.get_position_dossier_display(), exact=True)).to_be_visible()
+    assert_etablissement_card_is_correct(etablissement_card, etablissement)
 
     details_page.etablissement_open_modal()
     expect(details_page.etablissement_modal.get_by_text(etablissement.raison_sociale, exact=True)).to_be_visible()


### PR DESCRIPTION
Permettre d'éditer les établissements déjà existant lors de la mise à jour d'une fiche événement produit:

- Ajout d'un utilitaire de test pour vérifier qu'une carte établissement est correcte