### PR TITLE
Corriger la gestion des adresses dans les modales SV

### DIFF
--- a/sv/forms.py
+++ b/sv/forms.py
@@ -56,9 +56,15 @@ class DepartementModelChoiceField(forms.ModelChoiceField):
         return super().prepare_value(value)
 
 
+class AdresseLieuDitField(forms.ChoiceField):
+    def validate(self, value):
+        # Autorise n'importe quelle valeur
+        return
+
+
 class LieuForm(DSFRForm, WithDataRequiredConversionMixin, forms.ModelForm):
     nom = forms.CharField(widget=forms.TextInput(), required=True)
-    adresse_lieu_dit = forms.CharField(widget=forms.Select(), required=False)
+    adresse_lieu_dit = AdresseLieuDitField(choices=[], required=False)
     commune = forms.CharField(widget=forms.HiddenInput(), required=False)
     code_insee = forms.CharField(widget=forms.HiddenInput(), required=False)
     departement = DepartementModelChoiceField(
@@ -108,7 +114,7 @@ class LieuForm(DSFRForm, WithDataRequiredConversionMixin, forms.ModelForm):
             }
         ),
     )
-    adresse_etablissement = forms.CharField(widget=forms.Select(), required=False, label="Adresse ou lieu-dit")
+    adresse_etablissement = AdresseLieuDitField(choices=[], required=False, label="Adresse ou lieu-dit")
     departement_etablissement = DepartementModelChoiceField(
         queryset=Departement.objects.all(),
         to_field_name="numero",
@@ -134,6 +140,14 @@ class LieuForm(DSFRForm, WithDataRequiredConversionMixin, forms.ModelForm):
     def __init__(self, *args, **kwargs):
         convert_required_to_data_required = kwargs.pop("convert_required_to_data_required", False)
         super().__init__(*args, **kwargs)
+
+        if not self.is_bound and self.instance and self.instance.pk and self.instance.adresse_lieu_dit:
+            if self.instance.adresse_lieu_dit:
+                choice = (self.instance.adresse_lieu_dit, self.instance.adresse_lieu_dit)
+                self.fields["adresse_lieu_dit"].choices = [choice]
+            if self.instance.adresse_etablissement:
+                choice = (self.instance.adresse_etablissement, self.instance.adresse_etablissement)
+                self.fields["adresse_etablissement"].choices = [choice]
 
         if convert_required_to_data_required:
             self._convert_required_to_data_required()

--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -86,7 +86,76 @@ def test_fiche_detection_update_page_content(live_server, page: Page, form_eleme
         fiche_detection.mesures_surveillance_specifique
     )
 
-    # TODO: ajouter les tests pour les lieux et les prélèvements
+    # TODO: ajouter les tests pour les prélèvements
+
+
+def test_fiche_detection_update_lieu_modal_content(
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    lieu_form_elements: LieuFormDomElements,
+    choice_js_fill,
+    choice_js_get_values,
+):
+    fiche_detection = FicheDetectionFactory()
+    lieu = LieuFactory(fiche_detection=fiche_detection, is_etablissement=True)
+    page.goto(f"{live_server.url}{fiche_detection.get_update_url()}")
+
+    # modification du lieu
+    page.get_by_role("button", name="Modifier le lieu").click()
+
+    expect(lieu_form_elements.close_btn).to_be_visible()
+    expect(lieu_form_elements.close_btn).to_have_text("Fermer")
+
+    expect(page.get_by_role("heading", name="Ajouter un lieu")).to_be_visible()
+    expect(lieu_form_elements.title).to_have_text("Ajouter un lieu")
+
+    expect(lieu_form_elements.nom_label).to_be_visible()
+    expect(lieu_form_elements.nom_label).to_have_text("Nom du lieu")
+    expect(lieu_form_elements.nom_input).to_be_visible()
+    expect(lieu_form_elements.nom_input).to_have_value(lieu.nom)
+
+    expect(lieu_form_elements.adresse_input).to_have_value(lieu.adresse_lieu_dit)
+    expected_value = f"{lieu.adresse_lieu_dit}\nRemove item"
+    assert choice_js_get_values(page, '[id^="id_lieux-"][id$="adresse_lieu_dit"]')[0].replace(
+        "\n", " "
+    ) == expected_value.replace("\n", " ")
+
+    expect(lieu_form_elements.commune_hidden_input).to_have_value(lieu.commune)
+    expect(lieu_form_elements.code_insee_hidden_input).to_have_value(lieu.code_insee)
+    expect(page.get_by_text(f"{lieu.commune} ({lieu.departement.numero})Remove item")).to_be_visible()
+    expect(lieu_form_elements.departement_hidden_input).to_have_value(lieu.departement.numero)
+
+    expect(lieu_form_elements.coord_gps_wgs84_latitude_label).to_be_visible()
+    expect(lieu_form_elements.coord_gps_wgs84_latitude_label).to_have_text("Coordonnées GPS (WGS84)")
+    expect(lieu_form_elements.coord_gps_wgs84_latitude_input).to_be_visible()
+    expect(lieu_form_elements.coord_gps_wgs84_latitude_input).to_have_value(str(lieu.wgs84_latitude))
+    expect(lieu_form_elements.coord_gps_wgs84_longitude_input).to_be_visible()
+    expect(lieu_form_elements.coord_gps_wgs84_longitude_input).to_have_value(str(lieu.wgs84_longitude))
+
+    expect(lieu_form_elements.is_etablissement_checkbox).to_be_checked()
+
+    expect(lieu_form_elements.siret_etablissement_input).to_be_visible()
+    expect(lieu_form_elements.siret_etablissement_input).to_have_value(lieu.siret_etablissement)
+
+    expect(lieu_form_elements.adresse_etablissement_input).to_be_visible()
+
+    expect(lieu_form_elements.adresse_etablissement_hidden_input).to_have_value(lieu.adresse_etablissement)
+    expected_value = f"{lieu.adresse_etablissement}\nRemove item"
+    assert choice_js_get_values(page, '[id^="id_lieux-"][id$="adresse_etablissement"]')[0].replace(
+        "\n", " "
+    ) == expected_value.replace("\n", " ")
+
+    expect(lieu_form_elements.pays_etablissement_input).to_be_visible()
+    expect(lieu_form_elements.pays_etablissement_input).to_have_value(lieu.pays_etablissement.code)
+
+    expect(lieu_form_elements.code_inupp_etablissement_input).to_be_visible()
+    expect(lieu_form_elements.code_inupp_etablissement_input).to_have_value(str(lieu.code_inupp_etablissement))
+
+    expect(lieu_form_elements.position_etablissement_input).to_be_visible()
+    expect(lieu_form_elements.position_etablissement_input).to_have_value(
+        str(lieu.position_chaine_distribution_etablissement.id)
+    )
 
 
 def test_fiche_detection_update_page_content_with_no_data(

--- a/sv/tests/test_utils.py
+++ b/sv/tests/test_utils.py
@@ -266,6 +266,14 @@ class LieuFormDomElements:
         return self.page.locator('[id^="id_lieux-"][id$="raison_sociale_etablissement"]').locator("visible=true")
 
     @property
+    def adresse_etablissement_hidden_input(self) -> Locator:
+        return (
+            self.page.locator(".fr-modal__content")
+            .locator("visible=true")
+            .locator('[id^="id_lieux-"][id$="adresse_etablissement"]')
+        )
+
+    @property
     def adresse_etablissement_input(self) -> Locator:
         return self.page.locator(".adresse-etablissement .choices__list--single").locator("visible=true").locator("..")
 


### PR DESCRIPTION
Dans les modales d'édition de lieu dans SV corriger les deux adresses pour que la donnée soit reprise lors de l'édition à la place d'un champ vide. Ajout d'un test qui test le contenu des champs.