### PR TITLE
Corriger les boutons d'actions pour les détections

### DIFF
--- a/sv/static/sv/evenement_details.js
+++ b/sv/static/sv/evenement_details.js
@@ -59,6 +59,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     document.querySelectorAll(".no-tab-look .fr-tabs__panel").forEach(element =>{
         element.addEventListener('dsfr.disclose', event=>{
+            if (!event.target.getAttribute("id").includes("tabpanel")) return;
             const tabId = event.target.getAttribute("id").replace("tabpanel-", "").replace("-panel", "")
             showOnlyActionsForDetection(tabId)
             updateURLParameters('detection', tabId);

--- a/sv/tests/test_evenement_details.py
+++ b/sv/tests/test_evenement_details.py
@@ -353,6 +353,23 @@ def test_will_edit_correct_fiche_detection(live_server, page: Page):
     assert fiche_2.get_update_url() in page.url
 
 
+def test_will_show_action_buttons_for_fiche_detection_after_showing_lieu_modal(live_server, page: Page):
+    evenement = EvenementFactory()
+    fiche_1 = FicheDetectionFactory(evenement=evenement)
+    LieuFactory(fiche_detection=fiche_1)
+
+    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
+    page.get_by_role("tab", name=fiche_1.numero_detection).click()
+    expect(page.get_by_role("button", name="Modifier la détection", exact=True)).to_be_visible()
+    expect(page.get_by_role("button", name="Supprimer la détection", exact=True)).to_be_visible()
+
+    page.locator(".lieu-initial").get_by_text("Voir le détail", exact=True).click()
+    page.keyboard.press("Escape")
+
+    expect(page.get_by_role("button", name="Modifier la détection", exact=True)).to_be_visible()
+    expect(page.get_by_role("button", name="Supprimer la détection", exact=True)).to_be_visible()
+
+
 @pytest.mark.parametrize("createur", [MUS_STRUCTURE, BSV_STRUCTURE])
 def test_visibilite_display_text_when_evenement_locale_and_createur_ac(
     live_server, page: Page, mocked_authentification_user, createur


### PR DESCRIPTION
Corriger un problème qui arrivait quand une personne ouvrait une modale de lieu sur une fiche détection dans SV. On ne savait pas quels boutons d'action afficher donc ils restaient tous en état masqué. S'assure que la logique n'est appliqué que si on est sur un tag / faux onglet de détection.