### PR TITLE
Afficher le nombre correct de fiche

### DIFF
--- a/ssa/templates/ssa/evenementproduit_list.html
+++ b/ssa/templates/ssa/evenementproduit_list.html
@@ -47,7 +47,7 @@
     <main class="main-container">
 
         <div class="evenements_liste__table--header">
-            <div>{{ object_list.count }} sur un total de {{ page_obj.paginator.count }}</div>
+            <div>{{ object_list.count }} sur un total de {{ total_object_count }}</div>
             <form action="{% url 'ssa:export-evenement-produit' %}?{{ request.GET.urlencode }}" method="post">
                 {% csrf_token %}
                 <button type="submit" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-file-download-line">Extraire</button>

--- a/ssa/tests/test_evenement_produit_list.py
+++ b/ssa/tests/test_evenement_produit_list.py
@@ -514,3 +514,20 @@ def test_search_with_agent_contact(live_server, page: Page, choice_js_fill, choi
 
     expect(page.get_by_text(evenement_1.numero, exact=True)).not_to_be_visible()
     expect(page.get_by_text(evenement_2.numero, exact=True)).to_be_visible()
+
+
+def test_number_of_total_items(live_server, mocked_authentification_user, page: Page):
+    EvenementProduitFactory(etat=EvenementProduit.Etat.BROUILLON, createur=StructureFactory())
+    EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    EvenementProduitFactory(etat=EvenementProduit.Etat.BROUILLON)
+
+    search_page = EvenementProduitListPage(page, live_server.url)
+    search_page.navigate()
+    expect(page.get_by_text("2 sur un total de 2", exact=True)).to_be_visible()
+
+    search_page.open_sidebar()
+    search_page.etat.select_option("En cours")
+    search_page.add_filters()
+    search_page.submit_search()
+
+    expect(page.get_by_text("1 sur un total de 2", exact=True)).to_be_visible()

--- a/ssa/tests/test_evenement_produit_list_performances.py
+++ b/ssa/tests/test_evenement_produit_list_performances.py
@@ -4,7 +4,7 @@ from playwright.sync_api import Page
 from core.models import LienLibre
 from ssa.factories import EvenementProduitFactory
 
-NB_QUERIES = 7
+NB_QUERIES = 9
 
 
 def test_list_performances(live_server, mocked_authentification_user, page: Page, django_assert_num_queries, client):

--- a/ssa/views/mixins.py
+++ b/ssa/views/mixins.py
@@ -18,16 +18,18 @@ class WithFilteredListMixin(WithOrderingMixin):
     def get_default_order_by(self):
         return "numero_evenement"
 
-    def get_queryset(self):
+    def get_raw_queryset(self):
         user = self.request.user
         contact = user.agent.structure.contact_set.get()
-        queryset = (
+        return (
             EvenementProduit.objects.select_related("createur")
             .get_user_can_view(user)
             .with_fin_de_suivi(contact)
             .with_nb_liens_libres()
         )
-        queryset = self.apply_ordering(queryset)
+
+    def get_queryset(self):
+        queryset = self.apply_ordering(self.get_raw_queryset())
         self.filter = EvenementProduitFilter(self.request.GET, queryset=queryset)
         return self.filter.qs
 

--- a/ssa/views/produit.py
+++ b/ssa/views/produit.py
@@ -185,6 +185,8 @@ class EvenementProduitListView(WithFilteredListMixin, ListView):
             etat_data = evenement.get_etat_data_from_fin_de_suivi(evenement.has_fin_de_suivi)
             evenement.etat = etat_data["etat"]
             evenement.readable_etat = etat_data["readable_etat"]
+
+        context["total_object_count"] = self.get_raw_queryset().count()
         return context
 
 

--- a/sv/templates/sv/evenement_list.html
+++ b/sv/templates/sv/evenement_list.html
@@ -38,7 +38,7 @@
 
     <div class="evenements__list-container">
         <div class="evenements__list-header">
-            <span class="evenements__count">{{ evenement_list.count }} sur un total de {{ page_obj.paginator.count }}</span>
+            <span class="evenements__count">{{ evenement_list.count }} sur un total de {{ total_object_count }}</span>
             <button class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-file-add-line" data-fr-opened="false" data-testid="extract-open" aria-controls="fr-modal-extract">
                 Extraire
             </button>

--- a/sv/tests/test_evenement_search.py
+++ b/sv/tests/test_evenement_search.py
@@ -218,7 +218,7 @@ def test_search_with_region_structure_mapping(live_server, page: Page) -> None:
     expect(page.get_by_role("cell", name=str(evenement_lieu_naq_structure_naq.numero))).to_have_count(1)
     expect(page.get_by_role("cell", name=str(evenement_sans_lieu_structure_naq.numero))).to_be_visible()
     expect(page.get_by_role("cell", name=str(evenement_structure_naq.numero))).to_be_visible()
-    expect(page.locator("body")).to_contain_text("4 sur un total de 4")
+    expect(page.locator("body")).to_contain_text("4 sur un total de 7")
 
 
 def test_search_with_organisme_nuisible(live_server, page: Page, mocked_authentification_user, choice_js_fill) -> None:
@@ -293,7 +293,7 @@ def test_search_with_crossed_dates(live_server, page: Page, mocked_authentificat
     page.get_by_label("Au").fill("2024-06-19")
     page.get_by_role("button", name="Rechercher").click()
 
-    expect(page.get_by_text("0 sur un total de 0")).to_be_visible()
+    expect(page.get_by_text("0 sur un total de 1")).to_be_visible()
 
 
 def test_search_with_state(live_server, page: Page) -> None:

--- a/sv/tests/test_fiche_list_performances.py
+++ b/sv/tests/test_fiche_list_performances.py
@@ -9,13 +9,13 @@ def test_list_detection_performance(client, django_assert_num_queries, mocked_au
     FicheDetectionFactory()
     client.get(reverse("sv:evenement-liste"))
 
-    with django_assert_num_queries(12):
+    with django_assert_num_queries(15):
         client.get(reverse("sv:evenement-liste"))
 
     for _ in range(0, 5):
         FicheDetectionFactory()
 
-    with django_assert_num_queries(12):
+    with django_assert_num_queries(15):
         client.get(reverse("sv:evenement-liste"))
 
 
@@ -25,11 +25,11 @@ def test_list_zone_performance(client, django_assert_num_queries, mocked_authent
     url = reverse("sv:evenement-liste")
     client.get(url)
 
-    with django_assert_num_queries(11):
+    with django_assert_num_queries(14):
         client.get(url)
 
     for _ in range(0, 5):
         EvenementFactory(fiche_zone_delimitee=FicheZoneFactory())
 
-    with django_assert_num_queries(11):
+    with django_assert_num_queries(14):
         client.get(url)


### PR DESCRIPTION
Afficher le nombre total de fiche qu'un utilisateur peut voir si il avait affiché la page sans aucun filtres.