### PR TITLE
Vider le champ PAM à la mise a jour si danger non bactérien

### DIFF
--- a/ssa/forms.py
+++ b/ssa/forms.py
@@ -86,6 +86,11 @@ class EvenementProduitForm(DSFRForm, WithEvenementProduitFreeLinksMixin, forms.M
         if not self.user.agent.structure.is_ac:
             self.fields.pop("numero_rasff")
 
+    def clean(self):
+        super().clean()
+        if self.cleaned_data["categorie_danger"] not in CategorieDanger.dangers_bacteriens():
+            self.cleaned_data["produit_pret_a_manger"] = ""
+
     def save(self, commit=True):
         if self.data.get("action") == "publish":
             self.instance.etat = WithEtatMixin.Etat.EN_COURS

--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -122,6 +122,11 @@ class EvenementProduitFormPage(WithTreeSelect):
         label = evenement_produit.get_categorie_danger_display()
         self._set_treeselect_option("categorie-danger", label, clear_input)
 
+    def set_categorie_danger_from_shortcut(self, label):
+        self.page.locator("#categorie-danger .treeselect-input__edit").click()
+        self.page.locator("#categorie-danger").evaluate("el => el.scrollIntoView()")
+        self.page.locator("#categorie-danger .shortcut", has_text=label).locator("..").click()
+
     def set_quantification_unite(self, value):
         self.page.query_selector(".risk-column .choices").click()
         self.page.wait_for_selector("input:focus", state="visible", timeout=2_000)

--- a/ssa/tests/test_evenement_produit_creation.py
+++ b/ssa/tests/test_evenement_produit_creation.py
@@ -633,11 +633,7 @@ def test_can_create_evenement_produit_using_shortcut_on_categorie_danger(
     creation_page = EvenementProduitFormPage(page, live_server.url)
     creation_page.navigate()
     creation_page.fill_required_fields(input_data)
-    creation_page.page.locator("#categorie-danger .treeselect-input__edit").click()
-    creation_page.page.locator("#categorie-danger").evaluate("el => el.scrollIntoView()")
-    creation_page.page.locator("#categorie-danger .shortcut", has_text="Escherichia coli (non STEC - EHEC)").locator(
-        ".."
-    ).click()
+    creation_page.set_categorie_danger_from_shortcut("Escherichia coli (non STEC - EHEC)")
     creation_page.submit_as_draft()
 
     evenement_produit = EvenementProduit.objects.get()


### PR DESCRIPTION
Pour rester cohérent avec la contrainte de base on vide la valeur du champ PAM quand le danger est non bactérien (le champ est déjà masqué côté front).