### PR TITLE
Corriger les numéros de rappels conso sur Evenement publié

### DIFF
--- a/ssa/tests/test_evenement_produit_update.py
+++ b/ssa/tests/test_evenement_produit_update.py
@@ -255,3 +255,20 @@ def test_can_udpate_etablissement_with_error_show_message(live_server, page, ass
     ).to_be_visible()
 
     assert Etablissement.objects.get().numero_agrement == etablissement.numero_agrement
+
+
+def test_can_update_and_handle_rappel_conso_on_publised_evenement_produit(live_server, page):
+    evenement: EvenementProduit = EvenementProduitFactory(
+        numeros_rappel_conso=["2000-01-1111"], not_bacterie=True, etat=EvenementProduit.Etat.EN_COURS
+    )
+
+    update_page = EvenementProduitFormPage(page, live_server.url)
+    update_page.navigate_update_page(evenement)
+    expect(update_page.page.get_by_text("2000-01-1111", exact=True)).to_be_visible()
+    update_page.delete_rappel_conso("2000-01-1111")
+    update_page.add_rappel_conso("2025-12-1212")
+    update_page.publish()
+    expect(update_page.page.get_by_text("L'événement produit a bien été modifié.")).to_be_visible()
+
+    evenement.refresh_from_db()
+    assert evenement.numeros_rappel_conso == ["2025-12-1212"]


### PR DESCRIPTION
Pour les événements publiés (qui n'ont pas de bouton de sauvegarde en brouillon), corrige la sauvegarde des numéros de rappels conso.