### PR TITLE
Améliorations CSS sur le champs qui utilise le composant Choices

### DIFF
--- a/core/static/core/base.css
+++ b/core/static/core/base.css
@@ -89,10 +89,13 @@ header .fr-header__body-row {
 .menu__item--active {
     border-bottom: 4px solid var(--background-active-blue-france);
 }
-.choices .fr-select {
-	/* Make sure we never have 2 down arrows (1 via choices js, 1 via DSFR) for select inputs that uses choices js*/
-    background-image: none;
+
+/* Make .fr-select carry the carret */
+.choices::after {
+    content: none !important;
+    background-image: inherit !important;
 }
+
 .choices__list--multiple .choices__item {
     /* Customize ChoicesJS multiple choices picker */
     min-width: 0px;
@@ -105,8 +108,10 @@ header .fr-header__body-row {
 }
 .choices__input {
     background-color: var(--background-contrast-grey) !important;
-    margin-left: 1rem;
+    margin: 0 !important;  /* margin should be carried by .fr-select parent */
+    padding: 0 !important;
 }
+
 .choices__list--dropdown{
     z-index: 10 !important;
 }

--- a/core/static/core/contact_add_form.js
+++ b/core/static/core/contact_add_form.js
@@ -5,8 +5,8 @@ document.addEventListener('DOMContentLoaded', function() {
             containerInner: 'fr-select',
         },
         removeItemButton: true,
-        placeholderValue: "Choisir",
-        searchPlaceholderValue: "Choisir",
+        placeholderValue: "Choisir dans la liste",
+        searchPlaceholderValue: "Choisir dans la liste",
         noResultsText: 'Aucun résultat trouvé',
         noChoicesText: 'Aucune fiche à sélectionner',
     };


### PR DESCRIPTION
La librairie Choices apporte son propre design de chevron qui entre en conflit avec celui de la DSFR. Cette PR corrige le CSS pour que les champs de Choice suivent le design du DSFR.

## Avant :

![](https://github.com/user-attachments/assets/86133c78-904e-4cb0-bae2-de8a80d6920b)
![](https://github.com/user-attachments/assets/f99f891c-6adb-4736-ac8d-06f599033331)

## Arpès :

![](https://github.com/user-attachments/assets/14413bad-d005-4da6-84e0-3a04cdf1dd82)
![](https://github.com/user-attachments/assets/e7075a2a-cca0-419c-8ea2-13c6409b2853)
