### PR TITLE
Permettre de filtrer les destinataires des messages par application

### DIFF
--- a/core/factories.py
+++ b/core/factories.py
@@ -1,7 +1,9 @@
 import random
 
 import factory
+from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
 from django.core.files.uploadedfile import SimpleUploadedFile
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice
@@ -76,10 +78,16 @@ class ContactAgentFactory(DjangoModelFactory):
 
     @factory.post_generation
     def with_active_agent(self, create, extracted, **kwargs):
-        if not create or not extracted:
+        if not create or (not extracted and not kwargs):
             return
+
+        kwargs.setdefault("with_groups", [])
+
         self.agent.user.is_active = True
         self.agent.user.save()
+        for group in kwargs["with_groups"]:
+            group, _ = Group.objects.get_or_create(name=group)
+            self.agent.user.groups.add(group)
 
 
 class ContactStructureFactory(DjangoModelFactory):
@@ -92,11 +100,17 @@ class ContactStructureFactory(DjangoModelFactory):
 
     @factory.post_generation
     def with_one_active_agent(self, create, extracted, **kwargs):
-        if not create or not extracted:
+        if not create or (not extracted and not kwargs):
             return
+
+        kwargs.setdefault("with_groups", [])
+
         active_agent = AgentFactory(structure=self.structure)
         active_agent.user.is_active = True
         active_agent.user.save()
+        for group in kwargs["with_groups"]:
+            group, _ = Group.objects.get_or_create(name=group)
+            active_agent.user.groups.add(group)
 
 
 class DocumentFactory(DjangoModelFactory):
@@ -147,9 +161,13 @@ class MessageFactory(DjangoModelFactory):
         for i in range(random.randint(1, 10)):
             factory_class = random.choice([ContactAgentFactory, ContactStructureFactory])
             if factory_class is ContactAgentFactory:
-                self.recipients.add(ContactAgentFactory(with_active_agent=True))
+                self.recipients.add(
+                    ContactAgentFactory(with_active_agent__with_groups=(settings.SSA_GROUP, settings.SV_GROUP))
+                )
             else:
-                self.recipients.add(ContactStructureFactory(with_one_active_agent=True))
+                self.recipients.add(
+                    ContactStructureFactory(with_one_active_agent__with_groups=(settings.SSA_GROUP, settings.SV_GROUP))
+                )
 
     @factory.post_generation
     def recipients_copy(self, create, extracted, **kwargs):
@@ -161,9 +179,13 @@ class MessageFactory(DjangoModelFactory):
         for i in range(random.randint(1, 10)):
             factory_class = random.choice([ContactAgentFactory, ContactStructureFactory])
             if factory_class is ContactAgentFactory:
-                self.recipients.add(ContactAgentFactory(with_active_agent=True))
+                self.recipients.add(
+                    ContactAgentFactory(with_active_agent__with_groups=(settings.SSA_GROUP, settings.SV_GROUP))
+                )
             else:
-                self.recipients.add(ContactStructureFactory(with_one_active_agent=True))
+                self.recipients.add(
+                    ContactStructureFactory(with_one_active_agent__with_groups=(settings.SSA_GROUP, settings.SV_GROUP))
+                )
 
 
 class RegionFactory(DjangoModelFactory):

--- a/core/forms.py
+++ b/core/forms.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from django import forms
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
@@ -159,7 +161,7 @@ class BaseMessageForm(DSFRForm, WithNextUrlMixin, WithContentTypeMixin, forms.Mo
         structure_ids = ",".join([str(c.id) for c in self._get_structures(obj)])
         return self._build_label_with_shortcuts("Copie", structure_ids, css_class_prefix="copie")
 
-    def __init__(self, *args, sender, **kwargs):
+    def __init__(self, *args, sender, limit_contacts_to: None | Literal["sv", "ssa"] = None, **kwargs):
         obj = kwargs.pop("obj", None)
         self.obj = obj
         self.sender = sender
@@ -167,6 +169,10 @@ class BaseMessageForm(DSFRForm, WithNextUrlMixin, WithContentTypeMixin, forms.Mo
         super().__init__(*args, **kwargs)
         self.fields["status"].widget = forms.HiddenInput()
         queryset = Contact.objects.with_structure_and_agent().can_be_emailed().select_related("agent__structure")
+
+        if limit_contacts_to:
+            queryset = queryset.for_apps(limit_contacts_to)
+
         self.fields["recipients"].queryset = queryset
         self.fields["recipients_copy"].queryset = queryset
 

--- a/core/managers.py
+++ b/core/managers.py
@@ -1,3 +1,6 @@
+from typing import Literal
+
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Case, When, Value, IntegerField, QuerySet, Q, Manager
 
@@ -33,6 +36,16 @@ class DocumentQueryset(QuerySet):
 class ContactQueryset(QuerySet):
     def with_structure_and_agent(self):
         return self.select_related("structure", "agent")
+
+    def for_apps(self, *apps: None | Literal["sv", "ssa"]):
+        groups = set()
+        for app in apps:
+            match app:
+                case "sv":
+                    groups.add(settings.SV_GROUP)
+                case "ssa":
+                    groups.add(settings.SSA_GROUP)
+        return self.filter(Q(agent__user__groups__name__in=groups) | Q(structure__agent__user__groups__name__in=groups))
 
     def get_mus(self):
         return self.get(structure__niveau2=MUS_STRUCTURE)

--- a/core/tests/generic_tests/messages.py
+++ b/core/tests/generic_tests/messages.py
@@ -1,5 +1,6 @@
 import os
 
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from playwright.sync_api import Page, expect
 
@@ -10,7 +11,7 @@ from core.pages import CreateMessagePage, UpdateMessagePage
 
 
 def generic_test_can_add_and_see_message_without_document(live_server, page: Page, choice_js_fill, object):
-    active_contact = ContactAgentFactory(with_active_agent=True).agent
+    active_contact = ContactAgentFactory(with_active_agent__with_groups=(settings.SSA_GROUP, settings.SV_GROUP)).agent
 
     page.goto(f"{live_server.url}{object.get_absolute_url()}")
     message_page = CreateMessagePage(page)
@@ -189,10 +190,16 @@ def generic_test_can_send_draft_element_suivi(
     contact = mocked_authentification_user.agent.structure.contact_set.get()
     object.contacts.add(contact)
     ContactStructureFactory(
-        structure__niveau1=AC_STRUCTURE, structure__niveau2=MUS_STRUCTURE, structure__libelle=MUS_STRUCTURE
+        structure__niveau1=AC_STRUCTURE,
+        structure__niveau2=MUS_STRUCTURE,
+        structure__libelle=MUS_STRUCTURE,
+        with_one_active_agent__with_groups=(settings.SSA_GROUP, settings.SV_GROUP),
     )
     ContactStructureFactory(
-        structure__niveau1=AC_STRUCTURE, structure__niveau2=BSV_STRUCTURE, structure__libelle=BSV_STRUCTURE
+        structure__niveau1=AC_STRUCTURE,
+        structure__niveau2=BSV_STRUCTURE,
+        structure__libelle=BSV_STRUCTURE,
+        with_one_active_agent__with_groups=(settings.SSA_GROUP, settings.SV_GROUP),
     )
     message = MessageFactory(
         content_object=object,

--- a/ssa/forms.py
+++ b/ssa/forms.py
@@ -205,6 +205,10 @@ class MessageForm(BaseMessageForm):
             "status",
         ]
 
+    def __init__(self, *args, **kwargs):
+        kwargs["limit_contacts_to"] = "ssa"
+        super().__init__(*args, **kwargs)
+
     def clean(self):
         super().clean()
         if self.cleaned_data["message_type"] in Message.TYPES_WITH_LIMITED_RECIPIENTS:

--- a/sv/forms.py
+++ b/sv/forms.py
@@ -618,6 +618,7 @@ class MessageForm(BaseMessageForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        kwargs["limit_contacts_to"] = "sv"
         instance = kwargs.get("instance")
         if instance and instance.pk and "recipients_limited_recipients" in self.fields:
             self.fields["recipients_limited_recipients"].widget.attrs["id"] = (


### PR DESCRIPTION
Cette PR permet de ne pas proposer à des destinataires qui n'ont pas accès à l'application (SSA/SV) à partir de laquelle l'utilisateur ou l'utilisatrice envoie des messages.

Il manque encore des tests pour cette fonctionnalité spécifique.