### PR TITLE
Fix de la fragilité sur le test `test_search_with_region`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,8 +10,9 @@ from django.urls import resolve
 from django.urls.base import reverse
 from playwright.sync_api import expect, Page
 
+from core.constants import DEPARTEMENTS
 from core.factories import StructureFactory, UserFactory
-from core.models import Agent, Contact
+from core.models import Agent, Contact, Region, Departement
 
 User = get_user_model()
 
@@ -188,6 +189,24 @@ def assert_events_order():
     return _assert_events_order
 
 
+DEPARTEMENTS_BY_NAME = {it[1]: it for it in DEPARTEMENTS}
+
+
 @pytest.fixture
 def check_select_options_from_element():
     return _check_select_options_on_element
+
+
+@pytest.fixture
+def ensure_departements(db):
+    def _ensure_departements(*dpt_names):
+        departements = []
+        for dpt_name in dpt_names:
+            numero, nom, region_name = DEPARTEMENTS_BY_NAME[dpt_name]
+            region, _ = Region.objects.get_or_create(nom=region_name)
+            dpt, _ = Departement.objects.get_or_create(numero=numero, defaults={"region": region, "nom": nom})
+            departements.append(dpt)
+
+        return departements
+
+    return _ensure_departements

--- a/ssa/tests/conftest.py
+++ b/ssa/tests/conftest.py
@@ -1,27 +1,6 @@
 import pytest
 from playwright.sync_api import expect
 
-from core.models import Region, Departement
-from core.constants import DEPARTEMENTS
-
-
-DEPARTEMENTS_BY_NAME = {it[1]: it for it in DEPARTEMENTS}
-
-
-@pytest.fixture
-def ensure_departements(db):
-    def _ensure_departements(*dpt_names):
-        departements = []
-        for dpt_name in dpt_names:
-            numero, nom, region_name = DEPARTEMENTS_BY_NAME[dpt_name]
-            region, _ = Region.objects.get_or_create(nom=region_name)
-            dpt, _ = Departement.objects.get_or_create(numero=numero, defaults={"region": region, "nom": nom})
-            departements.append(dpt)
-
-        return departements
-
-    return _ensure_departements
-
 
 @pytest.fixture
 def assert_models_are_equal():

--- a/sv/tests/test_evenement_search.py
+++ b/sv/tests/test_evenement_search.py
@@ -3,7 +3,7 @@ from django.urls import reverse
 from playwright.sync_api import Page, expect
 
 from core.factories import ContactStructureFactory, ContactAgentFactory, RegionFactory, DepartementFactory
-from core.models import Contact, Departement, Region
+from core.models import Contact
 from core.constants import REGION_STRUCTURE_MAPPING
 from core.factories import StructureFactory
 from core.models import Visibilite
@@ -156,14 +156,13 @@ def test_search_with_invalid_evenement_number(live_server, page: Page):
     ]
 
 
-def test_search_with_region(live_server, page: Page, mocked_authentification_user) -> None:
+def test_search_with_region(live_server, page: Page, mocked_authentification_user, ensure_departements) -> None:
     """Test la recherche d'une fiche détection en utilisant une région
     Effectuer une recherche en sélectionnant uniquement une région.
     Vérifier que tous les résultats retournés sont bien associés à cette région."""
-    region, _ = Region.objects.get_or_create(nom="Corse")
-    departement, _ = Departement.objects.get_or_create(nom="Corse-du-Sud", defaults={"region": region, "numero": "2A"})
-    lieu = LieuFactory(departement=departement)
-    other_lieu = LieuFactory(departement__nom="Ain")
+    [corse, ain, *_] = ensure_departements("Corse-du-Sud", "Ain")
+    lieu = LieuFactory(departement=corse)
+    other_lieu = LieuFactory(departement=ain)
 
     page.goto(f"{live_server.url}{get_fiche_detection_search_form_url()}")
     page.get_by_label("Région").select_option("Corse")


### PR DESCRIPTION
Toujours le même soucis quand on travaille avec les modèles `Region` et `Departement` pour lesquels on n'a jamais de garantie, quand le test s'exécute, que les enregistrements existent en BDD. La fixture `ensure_departements` a été rajoutée pour s'en assurer.