### PR TITLE
Fix de la fragilité sur le test `test_export_evenement_produit_simple_case` 

### DIFF
--- a/ssa/tests/test_evenement_produit_export.py
+++ b/ssa/tests/test_evenement_produit_export.py
@@ -48,7 +48,7 @@ def test_export_evenement_produit_simple_case(mailoutbox):
         evenement.get_temperature_conservation_display(),
         evenement.get_categorie_danger_display(),
         str(evenement.quantification),
-        evenement.quantification_unite,
+        evenement.get_quantification_unite_display(),
         evenement.evaluation,
         evenement.get_produit_pret_a_manger_display(),
         evenement.reference_souches,


### PR DESCRIPTION
Ce test échouait de temps en temps lorsque `EvenementProduit.quantification_unite == QuantificationUnite.AUTRE`. `QuantificationUnite.AUTRE` est le seul élément de l'enum a avoir un label différent de sa valeur, c'est-à-dire pour lequel `quantification_unite != get_quantification_unite_display()`. C'est pourquoi ce test n'échouait que dans cette circonstance.