### PR TITLE
Fix de la MEP 30/07/2025

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ django-environ==0.12.0
     # via -r requirements.in
 django-filter==25.1
     # via -r requirements.in
-django-post-office==3.9.1
+django-post-office==3.10.0
     # via -r requirements.in
 django-reversion==5.1.0
     # via -r requirements.in
@@ -180,11 +180,11 @@ requests==2.32.3
     # via
     #   mozilla-django-oidc
     #   pytest-base-url
-ruff==0.12.2
+ruff==0.12.4
     # via -r requirements.in
 s3transfer==0.10.2
     # via boto3
-sentry-sdk[django]==2.32.0
+sentry-sdk[django]==2.33.1
     # via -r requirements.in
 six==1.16.0
     # via


### PR DESCRIPTION
#1179 a résolu le conflit entre `production` et `main` mais malheureusement à cause d'une mauvaise manipulation, c'est la version de `production` de `requirements.txt` qui s'est retrouvé mergé et pas celle de `main`.