### PR TITLE
Add prefix to object number in interface

### DIFF
--- a/ssa/models/evenement_produit.py
+++ b/ssa/models/evenement_produit.py
@@ -195,7 +195,8 @@ class EvenementProduit(
     SOURCES_FOR_HUMAN_CASE = [Source.DO_LISTERIOSE, Source.CAS_GROUPES]
 
     def get_absolute_url(self):
-        return reverse("ssa:evenement-produit-details", kwargs={"numero": self.numero})
+        numero = f"{self.numero_annee}.{self.numero_evenement}"
+        return reverse("ssa:evenement-produit-details", kwargs={"numero": numero})
 
     def get_update_url(self):
         return reverse("ssa:evenement-produit-update", kwargs={"pk": self.pk})
@@ -208,6 +209,10 @@ class EvenementProduit(
                     self.numero_annee = annee
                     self.numero_evenement = numero
                 super().save(*args, **kwargs)
+
+    @property
+    def numero(self):
+        return f"A-{self.numero_annee}.{self.numero_evenement}"
 
     def __str__(self):
         return self.numero

--- a/ssa/tests/test_evenement_produit_export.py
+++ b/ssa/tests/test_evenement_produit_export.py
@@ -55,7 +55,7 @@ def test_export_evenement_produit_simple_case(mailoutbox):
         evenement.reference_clusters,
         evenement.get_actions_engagees_display(),
         ",".join(evenement.numeros_rappel_conso),
-        "2024.22",
+        "A-2024.22",
         "",
         "",
         "",
@@ -178,9 +178,9 @@ def test_export_evenement_produit_from_ui(live_server, mocked_authentification_u
     task = Export.objects.get()
     assert task.task_done is True
     lines = task.file.read().decode("utf-8").split("\n")
-    assert lines[1].startswith('"2025.21",')
-    assert lines[2].startswith('"2025.2",')
-    assert lines[3].startswith('"2025.1",')
+    assert lines[1].startswith('"A-2025.21",')
+    assert lines[2].startswith('"A-2025.2",')
+    assert lines[3].startswith('"A-2025.1",')
     assert len(lines) == 5
 
     assert len(mailoutbox) == 1

--- a/ssa/tests/test_evenement_produit_list.py
+++ b/ssa/tests/test_evenement_produit_list.py
@@ -16,10 +16,10 @@ def test_list_table_order(live_server, mocked_authentification_user, page: Page)
     search_page = EvenementProduitListPage(page, live_server.url)
     search_page.navigate()
 
-    assert search_page.numero_cell(line_index=1).text_content() == "2025.22"
-    assert search_page.numero_cell(line_index=2).text_content() == "2025.2"
-    assert search_page.numero_cell(line_index=3).text_content() == "2025.1"
-    assert search_page.numero_cell(line_index=4).text_content() == "2024.22"
+    assert search_page.numero_cell(line_index=1).text_content() == "A-2025.22"
+    assert search_page.numero_cell(line_index=2).text_content() == "A-2025.2"
+    assert search_page.numero_cell(line_index=3).text_content() == "A-2025.1"
+    assert search_page.numero_cell(line_index=4).text_content() == "A-2024.22"
 
 
 def test_list_filtered_by_visibilite(live_server, mocked_authentification_user, page: Page):
@@ -66,7 +66,7 @@ def test_list_can_filter_by_numero(live_server, mocked_authentification_user, pa
 
     search_page.numero_field.fill("2025")
     search_page.submit_search()
-    assert search_page.numero_cell().text_content() == "2025.2"
+    assert search_page.numero_cell().text_content() == "A-2025.2"
     expect(search_page.page.get_by_text("2024.22")).not_to_be_visible()
 
 
@@ -78,7 +78,7 @@ def test_list_can_filter_by_numero_rasff(live_server, mocked_authentification_us
 
     search_page.numero_rasff_field.fill("123456")
     search_page.submit_search()
-    assert search_page.numero_cell().text_content() == "2025.2"
+    assert search_page.numero_cell().text_content() == "A-2025.2"
     expect(search_page.page.get_by_text("2025.1")).not_to_be_visible()
 
 
@@ -90,7 +90,7 @@ def test_list_can_filter_by_type_evenement(live_server, mocked_authentification_
 
     search_page.type_evenement_select.select_option(TypeEvenement.NON_ALERTE)
     search_page.submit_search()
-    assert search_page.numero_cell().text_content() == "2025.1"
+    assert search_page.numero_cell().text_content() == "A-2025.1"
     expect(search_page.page.get_by_text("2025.2")).not_to_be_visible()
 
 
@@ -105,7 +105,7 @@ def test_list_can_filter_by_date(live_server, mocked_authentification_user, page
     search_page.start_date_field.fill("2024-06-19")
     search_page.end_date_field.fill("2024-06-20")
     search_page.submit_search()
-    assert search_page.numero_cell().text_content() == "2025.2"
+    assert search_page.numero_cell().text_content() == "A-2025.2"
     expect(search_page.page.get_by_text("2025.1")).not_to_be_visible()
     expect(search_page.page.get_by_text("2025.3")).not_to_be_visible()
 

--- a/tiac/models.py
+++ b/tiac/models.py
@@ -52,3 +52,10 @@ class EvenementSimple(
                     self.numero_annee = annee
                     self.numero_evenement = numero
                 super().save(*args, **kwargs)
+
+    @property
+    def numero(self):
+        return f"T-{self.numero_annee}.{self.numero_evenement}"
+
+    def __str__(self):
+        return self.numero


### PR DESCRIPTION
To be able to make the difference between the fiche A (Alim, SSA) and T (TIAC, SSA).