### PR TITLE
Add default choice on document type

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from django import forms
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.utils.safestring import mark_safe
@@ -34,7 +35,10 @@ class DocumentUploadForm(DSFRForm, WithNextUrlMixin, WithContentTypeMixin, forms
         obj = kwargs.pop("obj")
         next = kwargs.pop("next", None)
         super().__init__(*args, **kwargs)
-        self.fields["document_type"].choices = [(c.value, c.label) for c in obj.get_allowed_document_types()]
+        self.fields["document_type"].choices = [
+            ("", settings.SELECT_EMPTY_CHOICE),
+            *[(c.value, c.label) for c in obj.get_allowed_document_types()],
+        ]
         self.add_content_type_fields(obj)
         self.add_next_field(next)
 
@@ -252,7 +256,10 @@ class MessageDocumentForm(DSFRForm, forms.ModelForm):
     def __init__(self, *args, **kwargs):
         obj = kwargs.pop("object")
         super().__init__(*args, **kwargs)
-        self.fields["document_type"].choices = [(c.value, c.label) for c in obj.get_allowed_document_types()]
+        self.fields["document_type"].choices = [
+            ("", settings.SELECT_EMPTY_CHOICE),
+            *[(c.value, c.label) for c in obj.get_allowed_document_types()],
+        ]
 
 
 class VisibiliteUpdateBaseForm(DSFRForm):

--- a/core/tests/generic_tests/documents.py
+++ b/core/tests/generic_tests/documents.py
@@ -1,6 +1,7 @@
 from playwright.sync_api import Page
 
 from core.pages import WithDocumentsPage
+from seves import settings
 
 
 def generic_test_cant_see_document_type_from_other_app(
@@ -10,5 +11,5 @@ def generic_test_cant_see_document_type_from_other_app(
     document_page = WithDocumentsPage(page)
     document_page.open_document_tab()
     document_page.open_add_document()
-    expected = [c.label for c in object.get_allowed_document_types()]
+    expected = [settings.SELECT_EMPTY_CHOICE, *[t.label for t in object.get_allowed_document_types()]]
     check_select_options_from_element(document_page.add_document_types, expected, with_default_value=False)

--- a/core/tests/generic_tests/messages.py
+++ b/core/tests/generic_tests/messages.py
@@ -274,7 +274,7 @@ def generic_test_can_only_see_own_document_types_in_message_form(
     message_page = CreateMessagePage(page)
     message_page.new_message()
 
-    expected = [t.label for t in object.get_allowed_document_types()]
+    expected = [settings.SELECT_EMPTY_CHOICE, *[t.label for t in object.get_allowed_document_types()]]
     check_select_options_from_element(message_page.document_type_input, expected, False)
 
 

--- a/tiac/tests/test_evenement_simple_creation.py
+++ b/tiac/tests/test_evenement_simple_creation.py
@@ -47,5 +47,7 @@ def test_can_create_evenement_simple_with_all_fields(
     creation_page.submit_as_draft()
 
     evenement = EvenementSimple.objects.last()
-    assert_models_are_equal(input_data, evenement, to_exclude=["id", "_state", "numero_annee", "date_creation"])
+    assert_models_are_equal(
+        input_data, evenement, to_exclude=["id", "_state", "numero_annee", "numero_evenement", "date_creation"]
+    )
     assert LienLibre.objects.count() == 2


### PR DESCRIPTION
This was not the case anymore since the different apps have different allowed document types.