### PR TITLE
Loosen up the restrictions on number and RASFF filters

### DIFF
--- a/core/filters_mixins.py
+++ b/core/filters_mixins.py
@@ -1,6 +1,5 @@
-import re
-
 import django_filters
+from django.db.models import Q
 from django.forms.widgets import TextInput
 
 from core.models import Contact, Structure
@@ -14,32 +13,9 @@ class WithNumeroFilterMixin(django_filters.FilterSet):
         widget=TextInput(
             attrs={
                 "placeholder": "2024",
-                "pattern": "^\\d{4}(\\.\\d+)?$",
-                "title": "Le format attendu est AAAA ou AAAA.N (ex: 2025 ou 2024.5)",
             }
         ),
     )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._validate_numero_format()
-
-    def _validate_numero_format(self):
-        numero = self.data.get("numero")
-        if not numero:
-            return
-        errors = self.errors.get("numero", [])
-
-        if not re.match(r"^\d{4}(\.\d+)?$", numero):
-            errors.append("Format 'numero' invalide. Le format attendu est AAAA ou AAAA.N (ex: 2025 ou 2025.1)")
-            return
-
-        try:
-            _annee = int(numero[:4])
-        except ValueError:
-            errors.append("Format 'numero' invalide. Le numéro doit commencer par quatre chiffres'")
-
-        self.errors["numero"] = errors
 
     def filter_numero(self, queryset, name, value):
         if self.errors.get("numero") or not value:
@@ -47,9 +23,9 @@ class WithNumeroFilterMixin(django_filters.FilterSet):
 
         parts = value.split(".")
         if len(parts) == 1:
-            return queryset.filter(numero_annee=int(parts[0]))
+            return queryset.filter(Q(numero_annee__icontains=parts[0]) | Q(numero_evenement__icontains=parts[0]))
         if len(parts) == 2:
-            return queryset.filter(numero_annee=int(parts[0]), numero_evenement=int(parts[1]))
+            return queryset.filter(numero_annee__icontains=parts[0], numero_evenement__icontains=parts[1])
         return queryset
 
 

--- a/ssa/filters.py
+++ b/ssa/filters.py
@@ -49,11 +49,10 @@ class EvenementProduitFilter(
     )
     numero_rasff = django_filters.CharFilter(
         label="Numéro RASFF/AAC",
+        lookup_expr="contains",
         widget=TextInput(
             attrs={
                 "placeholder": "0000.0000 ou 000000",
-                "pattern": r"^(\d{4}\.\d{4}|AA\d{2}\.\d{4}|\d{6})$",
-                "title": "Le format attendu est XXXX.YYYY ou AAXX.YYYY ou XXXXXX (ex: 2025.1234 ou AA24.1234 ou 123456)",
             }
         ),
     )

--- a/sv/tests/test_evenement_search.py
+++ b/sv/tests/test_evenement_search.py
@@ -108,7 +108,7 @@ def test_reset_button_clears_form_when_filters_in_url(live_server, page: Page, c
 
 @pytest.mark.django_db
 def test_search_with_evenement_number(live_server, page: Page) -> None:
-    """Test la recherche d'un évènement en utilisant un numéro d'évènement valide (format année.numéro)"""
+    """Test la recherche d'un évènement en utilisant un numéro d'évènement"""
     EvenementFactory(numero_annee=2024, numero_evenement=1)
     EvenementFactory(numero_annee=2024, numero_evenement=2)
 
@@ -118,6 +118,23 @@ def test_search_with_evenement_number(live_server, page: Page) -> None:
 
     expect(page.get_by_role("cell", name="2024.1")).to_be_visible()
     expect(page.get_by_role("cell", name="2024.2")).not_to_be_visible()
+
+
+@pytest.mark.django_db
+def test_search_with_evenement_number_loose_case(live_server, page: Page) -> None:
+    EvenementFactory(numero_annee=2024, numero_evenement=1)
+    EvenementFactory(numero_annee=2024, numero_evenement=2)
+    EvenementFactory(numero_annee=2023, numero_evenement=1243)
+    EvenementFactory(numero_annee=2023, numero_evenement=23)
+
+    page.goto(f"{live_server.url}{get_fiche_detection_search_form_url()}")
+    page.get_by_label("Numéro").fill("24")
+    page.get_by_role("button", name="Rechercher").click()
+
+    expect(page.get_by_role("cell", name="2024.1")).to_be_visible()
+    expect(page.get_by_role("cell", name="2024.2")).to_be_visible()
+    expect(page.get_by_role("cell", name="2023.1243")).to_be_visible()
+    expect(page.get_by_role("cell", name="2023.23")).not_to_be_visible()
 
 
 @pytest.mark.django_db
@@ -133,27 +150,6 @@ def test_search_with_evenement_number_allows_year_only(live_server, page: Page):
     expect(page.get_by_role("cell", name="2024.1", exact=True)).to_be_visible()
     expect(page.get_by_role("cell", name="2024.10")).to_be_visible()
     expect(page.get_by_role("cell", name="2023.1")).not_to_be_visible()
-
-
-def test_search_with_invalid_evenement_number(live_server, page: Page):
-    page.goto(f"{live_server.url}{get_fiche_detection_search_form_url()}")
-    numero_input = page.get_by_label("Numéro")
-
-    numero_input.fill("az.erty")
-    page.get_by_role("button", name="Rechercher").click()
-    validation_message = numero_input.evaluate("el => el.validationMessage")
-    assert validation_message in [
-        "Please match the requested format.",
-        "Le format attendu est AAAA ou AAAA.N (ex: 2025 ou 2025.1)",
-    ]
-
-    numero_input.fill("2025-15")
-    page.get_by_role("button", name="Rechercher").click()
-    validation_message = numero_input.evaluate("el => el.validationMessage")
-    assert validation_message in [
-        "Please match the requested format.",
-        "Le format attendu est AAAA ou AAAA.N (ex: 2025 ou 2025.1)",
-    ]
 
 
 def test_search_with_region(live_server, page: Page, mocked_authentification_user, ensure_departements) -> None:


### PR DESCRIPTION
Make sure we don't need to input the exact number in the correct format for the search to work properly.