### PR TITLE
Allow to see Etablissements on EvenementSimple detail

### DIFF
--- a/core/static/core/_etablissement_card.css
+++ b/core/static/core/_etablissement_card.css
@@ -1,0 +1,4 @@
+#etablissement-card-container {
+    display: flex;
+    gap: 1rem;
+}

--- a/ssa/static/ssa/_etablissement_card.css
+++ b/ssa/static/ssa/_etablissement_card.css
@@ -1,7 +1,3 @@
-#etablissement-card-container {
-    display: flex;
-    gap: 1rem;
-}
 .etablissement-card {
     background-color: var(--background-contrast-grey);
     margin-bottom: 1rem;

--- a/ssa/templates/ssa/evenement_produit_detail.html
+++ b/ssa/templates/ssa/evenement_produit_detail.html
@@ -3,7 +3,7 @@
 {% load etat_tags %}
 {% load or_empty_value_tag %}
 {% block extrahead %}
-  <link rel="stylesheet" href="{% static 'ssa/_etablissement_card.css' %}">
+  <link rel="stylesheet" href="{% static 'core/_etablissement_card.css' %}">
   <link rel="stylesheet" href="{% static 'ssa/evenement_produit_detail.css' %}">
   <link rel="stylesheet" href="{% static 'core/has_sidebar.css' %}">
 {% endblock %}

--- a/ssa/templates/ssa/evenement_produit_form.html
+++ b/ssa/templates/ssa/evenement_produit_form.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load render_field %}
 {% block extrahead %}
-    <link rel="stylesheet" href="{% static 'ssa/_etablissement_card.css' %}">
+    <link rel="stylesheet" href="{% static 'core/_etablissement_card.css' %}">
     <link rel="stylesheet" href="{% static 'ssa/evenement_produit_form.css' %}">
     <link rel="stylesheet" href="{% static 'ssa/_custom_tree_select.css' %}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/treeselectjs@0.13.1/dist/treeselectjs.css" />

--- a/tiac/admin.py
+++ b/tiac/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
-from .models import EvenementSimple
+from .models import EvenementSimple, Etablissement
 
 admin.site.register(EvenementSimple)
+admin.site.register(Etablissement)

--- a/tiac/models.py
+++ b/tiac/models.py
@@ -126,3 +126,12 @@ class Etablissement(BaseEtablissement, models.Model):
                 name="inspection_required_for_inspection_related_fields",
             ),
         ]
+
+    @property
+    def address_summary(self):
+        value = ""
+        if self.commune:
+            value = self.commune
+        if self.departement:
+            value += f" ({self.departement.numero}) | {self.departement.nom}"
+        return value

--- a/tiac/templates/tiac/_evenement_simple_etablissement_modal.html
+++ b/tiac/templates/tiac/_evenement_simple_etablissement_modal.html
@@ -1,0 +1,58 @@
+{% load or_empty_value_tag dsfr_tags %}
+<dialog aria-labelledby="fr-modal-title-modal-etablissement-{{ etablissement.pk }}" role="dialog"
+        id="fr-modal-etablissement-{{ etablissement.pk }}" class="fr-modal">
+    <div class="fr-container fr-container--fluid fr-container-md">
+        <div class="fr-grid-row fr-grid-row--center">
+            <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
+                <div class="fr-modal__body">
+                    <div class="fr-modal__header">
+                        <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale"
+                                aria-controls="fr-modal-etablissement-{{ etablissement.pk }}">Fermer
+                        </button>
+                    </div>
+                    <div class="fr-modal__content">
+                        <h1 id="fr-modal-title-modal-etablissement-{{ etablissement.pk }}"
+                            class="fr-modal__title">{{ etablissement.raison_sociale }}</h1>
+
+                        <div class="fr-container--fluid">
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-col-3 bold">Type d'établissement</div>
+                                <div class="fr-col-3">{% dsfr_badge label=etablissement.type_etablissement extra_classes="fr-mb-2v fr-badge--info fr-badge--no-icon fr-badge--sm fr-mt-2v" %}</div>
+                                <div class="fr-col-3 bold">Numero Résytal</div>
+                                <div class="fr-col-3">{{ etablissement.numero_resytal|or_empty_value_tag }}</div>
+                            </div>
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-col-3 bold">Siret</div>
+                                <div class="fr-col-3">{{ etablissement.siret }}</div>
+                                <div class="fr-col-3 bold">Évaluation globale</div>
+                                <div class="fr-col-3">{{ etablissement.evaluation|or_empty_value_tag }}</div>
+                            </div>
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-col-3 bold">Enseigne usuelle</div>
+                                <div class="fr-col-3">{{ etablissement.enseigne_usuelle }}</div>
+                            </div>
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-col-3 bold">Adresse</div>
+                                <div class="fr-col-3">{{ etablissement.adresse_lieu_dit }}</div>
+                                <div class="fr-col-3 bold">Commentaire</div>
+                                <div class="fr-col-3">{{ etablissement.commentaire|or_empty_value_tag }}</div>
+                            </div>
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-col-3 bold">Commune</div>
+                                <div class="fr-col-3">{{ etablissement.commune }}</div>
+                            </div>
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-col-3 bold">Département</div>
+                                <div class="fr-col-3">{{ etablissement.departement }}</div>
+                            </div>
+                            <div class="fr-grid-row fr-grid-row--gutters">
+                                <div class="fr-col-3 bold">Région</div>
+                                <div class="fr-col-3">{{ etablissement.departement.region }}</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</dialog>

--- a/tiac/templates/tiac/_evenement_simple_etablissements.html
+++ b/tiac/templates/tiac/_evenement_simple_etablissements.html
@@ -1,0 +1,39 @@
+{% load or_empty_value_tag dsfr_tags %}
+
+<div class="fr-grid-row fr-grid-row--gutters">
+    <div class="fr-col-12">
+        <div class="white-container">
+            <h2 class="fr-h6">Établissements impliqués</h2>
+            <div id="etablissement-card-container">
+                {% for etablissement in object.etablissements.all %}
+                    {% include "tiac/_evenement_simple_etablissement_modal.html" %}
+                    <div class="etablissement-card fr-card">
+                        <div class="fr-card__body">
+                            <div class="fr-card__content">
+                                <div>
+                                    <p class="fr-card__title">{{ etablissement.raison_sociale }}</p>
+                                </div>
+                                {% if etablissement.address_summary %}
+                                    <p class="fr-card__detail fr-icon-map-pin-2-line fr-my-2v">{{ etablissement.address_summary }}</p>
+
+                                {% endif %}
+                                {% if etablissement.siret %}
+                                    Siret : {{ etablissement.siret }}
+                                {% endif %}
+                                {% if etablissement.type_etablissement %}
+                                    {% dsfr_badge label=etablissement.type_etablissement extra_classes="fr-mb-2v fr-badge--info fr-badge--no-icon fr-badge--sm fr-mt-2v" %}
+                                {% endif %}
+
+                                <div class="fr-btns-group--right">
+                                    <button data-fr-opened="false" aria-controls="fr-modal-etablissement-{{ etablissement.pk }}" class="fr-btn fr-btn--sm fr-btn--tertiary fr-btn--icon-left fr-icon-search-line fr-mt-4v">Voir le détail</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                {% empty %}
+                    <p>Aucun établissement enregistré</p>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+</div>

--- a/tiac/templates/tiac/evenement_simple_detail.html
+++ b/tiac/templates/tiac/evenement_simple_detail.html
@@ -3,6 +3,10 @@
 {% load etat_tags %}
 {% load or_empty_value_tag %}
 
+{% block extrahead %}
+  <link rel="stylesheet" href="{% static 'core/_etablissement_card.css' %}">
+{% endblock extrahead %}
+
 {% block content %}
   <main class="main-container">
     <div>
@@ -28,8 +32,12 @@
     {% include "core/_latest_revision.html" with date_derniere_mise_a_jour=object.latest_version.revision.date_created latest_version=object.latest_version %}
 
     <div id="detail-content">
+
       {% include "tiac/_evenement_simple_informations.html" %}
-      {% include "core/_list_free_links.html" with classes="fr-mt-4v" title="Événements liés" object=object %}
+      <div class="fr-container--fluid fr-mt-2w detail-content">
+        {% include "tiac/_evenement_simple_etablissements.html" %}
+        {% include "core/_list_free_links.html" with classes="fr-mt-4v" title="Événements liés" object=object %}
+      </div>
     </div>
   </main>
 {% endblock content %}

--- a/tiac/tests/conftest.py
+++ b/tiac/tests/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+from playwright.sync_api import expect
+
+
+@pytest.fixture
+def assert_etablissement_card_is_correct():
+    def _assert_etablissement_card_is_correct(locator, expected_values):
+        expect(locator.get_by_text(expected_values.raison_sociale, exact=True)).to_be_visible()
+        expect(locator.get_by_text(f"Siret : {expected_values.siret}")).to_be_visible()
+        expect(locator.get_by_text(expected_values.type_etablissement, exact=True)).to_be_visible()
+        expect(locator.get_by_text(f"{expected_values.departement.nom}")).to_be_visible()
+        expect(locator.get_by_text(expected_values.commune)).to_be_visible()
+
+    return _assert_etablissement_card_is_correct

--- a/tiac/tests/pages.py
+++ b/tiac/tests/pages.py
@@ -128,3 +128,13 @@ class EvenementSimpleDetailsPage:
         self.page.get_by_role("button", name="Actions").click()
         self.page.get_by_role("link", name="Clôturer l'événement").click()
         self.page.get_by_role("button", name="Clôturer").click()
+
+    def etablissement_card(self, index=0):
+        return self.page.locator(".etablissement-card").nth(index)
+
+    def etablissement_open_modal(self, index=0):
+        return self.page.locator(".etablissement-card").nth(index).get_by_text("Voir le détail", exact=True).click()
+
+    @property
+    def etablissement_modal(self):
+        return self.page.locator(".fr-modal").locator("visible=true")

--- a/tiac/tests/test_evenement_simple_details.py
+++ b/tiac/tests/test_evenement_simple_details.py
@@ -1,8 +1,8 @@
 from playwright.sync_api import Page, expect
 
 from core.models import LienLibre
-from tiac.factories import EvenementSimpleFactory
-from tiac.models import EvenementSimple
+from tiac.factories import EvenementSimpleFactory, EtablissementFactory
+from tiac.models import EvenementSimple, Etablissement
 from tiac.tests.pages import EvenementSimpleDetailsPage
 
 
@@ -31,3 +31,31 @@ def test_evenement_simple_detail_page_content(live_server, page: Page):
     expect(details_page.context_block.get_by_text(evenement.get_follow_up_display(), exact=True)).to_be_visible()
 
     expect(details_page.links_block.get_by_text(other_evenement.numero, exact=True)).to_be_visible()
+
+
+def test_evenement_simple_detail_page_content_etablissement(
+    live_server, page: Page, assert_etablissement_card_is_correct
+):
+    evenement = EvenementSimpleFactory()
+    etablissement: Etablissement = EtablissementFactory(evenement_simple=evenement, inspection=True)
+
+    details_page = EvenementSimpleDetailsPage(page, live_server.url)
+    details_page.navigate(evenement)
+
+    etablissement_card = details_page.etablissement_card()
+    assert_etablissement_card_is_correct(etablissement_card, etablissement)
+
+    details_page.etablissement_open_modal()
+    expect(details_page.etablissement_modal.get_by_text(etablissement.raison_sociale, exact=True)).to_be_visible()
+    expect(details_page.etablissement_modal.get_by_text(etablissement.type_etablissement, exact=True)).to_be_visible()
+    expect(details_page.etablissement_modal.get_by_text(etablissement.siret, exact=True)).to_be_visible()
+    expect(details_page.etablissement_modal.get_by_text(etablissement.enseigne_usuelle, exact=True)).to_be_visible()
+    expect(details_page.etablissement_modal.get_by_text(etablissement.adresse_lieu_dit, exact=True)).to_be_visible()
+    expect(details_page.etablissement_modal.get_by_text(etablissement.commune, exact=True)).to_be_visible()
+    expect(details_page.etablissement_modal.get_by_text(etablissement.departement.nom, exact=True)).to_be_visible()
+    expect(
+        details_page.etablissement_modal.get_by_text(etablissement.departement.region.nom, exact=True)
+    ).to_be_visible()
+    expect(details_page.etablissement_modal.get_by_text(etablissement.numero_resytal, exact=True)).to_be_visible()
+    expect(details_page.etablissement_modal.get_by_text(etablissement.evaluation, exact=True)).to_be_visible()
+    expect(details_page.etablissement_modal.get_by_text(etablissement.commentaire, exact=True)).to_be_visible()

--- a/tiac/views.py
+++ b/tiac/views.py
@@ -39,7 +39,12 @@ class EvenementSimpleDetailView(
         return self.get_object().can_user_access(self.request.user)
 
     def get_queryset(self):
-        return EvenementSimple.objects.all().select_related("createur")
+        return (
+            EvenementSimple.objects.all()
+            .select_related("createur")
+            .prefetch_related("etablissements__departement")
+            .prefetch_related("etablissements__departement__region")
+        )
 
     def get_object(self, queryset=None):
         if hasattr(self, "object"):


### PR DESCRIPTION
Make sure we can see the etablissements on the EvenementSimple detail page with modal to have the details.