### PR TITLE
Allow to use app even when INSEE is down

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -28,7 +28,7 @@ fileignoreconfig:
 - filename: sv/tests/test_evenement_list_order.py
   checksum: 8f9ff88f349a3e8be0d00903d6a9ccaa81db3c8c825a4feaccbb45042b641542
 - filename: core/mixins.py
-  checksum: 9717807f321037aee25f9711e052e85b2b9e2df83bcce796d1931e04ab2f53fb
+  checksum: a3e7662dc5fd7531847d3aea99bbd0b34e90b7b1fd3a9f57b25037fee28fb857
 - filename: conftest.py
   checksum: e5697a536e77dd0d10a3a7aa899da6cb02223491783161895aa618910c82e409
 - filename: core/pages.py

--- a/core/mixins.py
+++ b/core/mixins.py
@@ -1,6 +1,7 @@
 import base64
 import datetime
 from collections import defaultdict
+from json import JSONDecodeError
 
 import requests
 from django.conf import settings
@@ -495,7 +496,7 @@ class WithSireneTokenMixin:
         try:
             response = requests.post("https://api.insee.fr/token", headers=headers, data=data, timeout=0.200)
             context["sirene_token"] = response.json()["access_token"]
-        except (KeyError, ConnectionError, ConnectTimeout, ReadTimeout):
+        except (KeyError, ConnectionError, ConnectTimeout, ReadTimeout, JSONDecodeError):
             pass
 
         return context


### PR DESCRIPTION
When the INSEE api is in maintenance we don't receive a valide JSON from the API, causing a few important pages not to load.