### PR TITLE
Add bloc commun to evenement simple object

### DIFF
--- a/core/constants.py
+++ b/core/constants.py
@@ -12,6 +12,7 @@ SERVICE_ACCOUNT_NAME = "service_account"
 SV_DOMAIN = "Santé des végétaux"
 SSA_DOMAIN = "Sécurité sanitaire des aliments"
 SSA_STRUCTURES = [MUS_STRUCTURE, "BEAD", "BETD", "BPMED", "BAMRA", "BEPIAS", "BIB", "SIVEP", "BICMA", "BPRSE", "BSA"]
+TIAC_STRUCTURES = [MUS_STRUCTURE, "BEAD", "BETD", "BPMED", "BAMRA", "BEPIAS", "BIB", "SIVEP", "BICMA", "BPRSE", "BSA"]
 
 REGION_STRUCTURE_MAPPING = {
     "Auvergne-Rhône-Alpes": "DRAAF-AUVERGNE-RHONE-ALPES",

--- a/core/managers.py
+++ b/core/managers.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Case, When, Value, IntegerField, QuerySet, Q, Manager, OuterRef, Subquery, Func, F, Exists
 
-from core.constants import MUS_STRUCTURE, BSV_STRUCTURE, SERVICE_ACCOUNT_NAME, SSA_STRUCTURES
+from core.constants import MUS_STRUCTURE, BSV_STRUCTURE, SERVICE_ACCOUNT_NAME, SSA_STRUCTURES, TIAC_STRUCTURES
 
 
 class DocumentManager(Manager):
@@ -67,6 +67,9 @@ class ContactQueryset(QuerySet):
 
     def get_ssa_structures(self):
         return self.filter(structure__libelle__in=SSA_STRUCTURES).prefetch_related("structure")
+
+    def get_tiac_structures(self):
+        return self.filter(structure__libelle__in=TIAC_STRUCTURES).prefetch_related("structure")
 
     def can_be_emailed(self):
         return self.exclude_empty_emails().with_active_agent() | self.exclude_empty_emails().structures_only()

--- a/core/pages.py
+++ b/core/pages.py
@@ -3,6 +3,8 @@ from abc import ABC, abstractmethod
 from django.conf import settings
 from playwright.sync_api import Page, expect
 
+from core.models import Document
+
 
 class BaseMessagePage(ABC):
     TITLE_ID = "#id_title"
@@ -176,6 +178,31 @@ class WithDocumentsPage:
     def open_edit_document(self, id):
         self.page.locator(f'.fr-btns-group button[aria-controls="fr-modal-edit-{id}"]').click()
         expect(self.page.locator(f"#fr-modal-edit-{id}")).to_be_visible()
+
+    @property
+    def document_add_title(self):
+        return self.page.locator("#fr-modal-add-doc #id_nom")
+
+    @property
+    def document_add_type(self):
+        return self.page.locator("#fr-modal-add-doc #id_document_type")
+
+    @property
+    def document_add_description(self):
+        return self.page.locator("#fr-modal-add-doc #id_description")
+
+    @property
+    def document_add_file(self):
+        return self.page.locator("#fr-modal-add-doc #id_file")
+
+    def add_document(self):
+        self.open_document_tab()
+        self.open_add_document()
+        self.document_add_title.fill("Name of the document")
+        self.document_add_type.select_option(Document.TypeDocument.AUTRE)
+        self.document_add_description.fill("Description")
+        self.document_add_file.set_input_files(settings.BASE_DIR / "static/images/marianne.png")
+        self.page.get_by_test_id("documents-send").click()
 
     def document_edit_title(self, id):
         return self.page.locator(f"#fr-modal-edit-{id} #id_nom")

--- a/core/tests/generic_tests/documents.py
+++ b/core/tests/generic_tests/documents.py
@@ -1,5 +1,6 @@
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
+from core.models import Document
 from core.pages import WithDocumentsPage
 from seves import settings
 
@@ -13,3 +14,24 @@ def generic_test_cant_see_document_type_from_other_app(
     document_page.open_add_document()
     expected = [settings.SELECT_EMPTY_CHOICE, *[t.label for t in object.get_allowed_document_types()]]
     check_select_options_from_element(document_page.add_document_types, expected, with_default_value=False)
+
+
+def generic_test_can_add_document_to_evenement(live_server, page: Page, mocked_authentification_user, object):
+    page.goto(f"{live_server.url}{object.get_absolute_url()}")
+    document_page = WithDocumentsPage(page)
+    document_page.add_document()
+
+    assert object.documents.count() == 1
+    document = object.documents.get()
+
+    assert document.document_type == Document.TypeDocument.AUTRE
+    assert document.nom == "Name of the document"
+    assert document.description == "Description"
+    assert document.created_by == mocked_authentification_user.agent
+    assert document.created_by_structure == mocked_authentification_user.agent.structure
+
+    # Check the document is now listed on the page
+    document_page.open_document_tab()
+    expect(page.get_by_text("Name of the document Information")).to_be_visible()
+    expect(page.get_by_text(str(mocked_authentification_user.agent.structure).upper(), exact=True)).to_be_visible()
+    expect(page.locator(".fr-tag", has_text=f"{document.get_document_type_display()}")).to_be_visible()

--- a/ssa/tests/test_evenement_produit_documents.py
+++ b/ssa/tests/test_evenement_produit_documents.py
@@ -3,9 +3,17 @@ from playwright.sync_api import expect
 
 from core.factories import DocumentFactory
 from core.pages import WithDocumentsPage
-from core.tests.generic_tests.documents import generic_test_cant_see_document_type_from_other_app
+from core.tests.generic_tests.documents import (
+    generic_test_cant_see_document_type_from_other_app,
+    generic_test_can_add_document_to_evenement,
+)
 from ssa.factories import EvenementProduitFactory
 from ssa.models import EvenementProduit
+
+
+def test_can_add_document_to_evenement(live_server, page: Page, mocked_authentification_user):
+    evenement = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    generic_test_can_add_document_to_evenement(live_server, page, mocked_authentification_user, evenement)
 
 
 def test_can_edit_document_on_evenement(live_server, page: Page):

--- a/sv/tests/test_evenement_documents.py
+++ b/sv/tests/test_evenement_documents.py
@@ -14,7 +14,10 @@ from core.models import Structure, Document, Message
 from django.contrib.auth import get_user_model
 
 from core.pages import WithDocumentsPage
-from core.tests.generic_tests.documents import generic_test_cant_see_document_type_from_other_app
+from core.tests.generic_tests.documents import (
+    generic_test_cant_see_document_type_from_other_app,
+    generic_test_can_add_document_to_evenement,
+)
 from core.validators import MAX_UPLOAD_SIZE_BYTES
 from sv.factories import EvenementFactory
 from sv.models import Evenement
@@ -24,35 +27,7 @@ User = get_user_model()
 
 def test_can_add_document_to_evenement(live_server, page: Page, mocked_authentification_user: User):
     evenement = EvenementFactory()
-    page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
-    page.get_by_test_id("documents").click()
-    expect(page.get_by_test_id("documents-add")).to_be_visible()
-    page.get_by_test_id("documents-add").click()
-
-    expect(page.locator("#fr-modal-add-doc")).to_be_visible()
-
-    page.locator("#id_nom").fill("Name of the document")
-    page.locator("#fr-modal-add-doc #id_document_type").select_option(Document.TypeDocument.COMPTE_RENDU_REUNION)
-    page.locator("#id_description").fill("Description")
-    page.locator("#fr-modal-add-doc").locator("#id_file").set_input_files(
-        settings.BASE_DIR / "static/images/marianne.png"
-    )
-    page.get_by_test_id("documents-send").click()
-
-    assert evenement.documents.count() == 1
-    document = evenement.documents.get()
-
-    assert document.document_type == Document.TypeDocument.COMPTE_RENDU_REUNION
-    assert document.nom == "Name of the document"
-    assert document.description == "Description"
-    assert document.created_by == mocked_authentification_user.agent
-    assert document.created_by_structure == mocked_authentification_user.agent.structure
-
-    # Check the document is now listed on the page
-    page.get_by_test_id("documents").click()
-    expect(page.get_by_text("Name of the document Information")).to_be_visible()
-    expect(page.get_by_text(str(mocked_authentification_user.agent.structure).upper(), exact=True)).to_be_visible()
-    expect(page.locator(".fr-tag", has_text=f"{document.get_document_type_display()}")).to_be_visible()
+    generic_test_can_add_document_to_evenement(live_server, page, mocked_authentification_user, evenement)
 
 
 def test_cant_add_document_with_incorrect_extension(live_server, page: Page, mocked_authentification_user: User):

--- a/tiac/templates/tiac/evenement_simple_detail.html
+++ b/tiac/templates/tiac/evenement_simple_detail.html
@@ -5,7 +5,26 @@
 
 {% block extrahead %}
   <link rel="stylesheet" href="{% static 'core/_etablissement_card.css' %}">
+  <link rel="stylesheet" href="{% static 'core/has_sidebar.css' %}">
 {% endblock extrahead %}
+{% block scripts %}
+  <script type="module" src="{% static 'core/sidebar.js' %}"></script>
+  <script type="module" src="{% static 'core/message_form.js' %}"></script>
+  <script type="module" src="{% static 'core/document_form.js' %}"></script>
+  <script type="module" src="{% static 'core/contact_add_form.js' %}"></script>
+{% endblock %}
+
+{% block aside %}
+  {% include "core/_sidebar_message_form.html" with object=object id="sidebar" action=object.add_message_url %}
+  {% include "core/_document_warning_modal.html" %}
+  {% include "core/_message_update_forms.html" with object=object %}
+  {% for message in message_list %}
+    {% if not message.is_draft %}
+      {% include "core/_sidebar_message_details.html" %}
+    {% endif %}
+  {% endfor %}
+{% endblock aside %}
+
 
 {% block content %}
   <main class="main-container">
@@ -38,6 +57,9 @@
         {% include "tiac/_evenement_simple_etablissements.html" %}
         {% include "core/_list_free_links.html" with classes="fr-mt-4v" title="Événements liés" object=object %}
       </div>
+      {% if not object.is_draft %}
+        {% include "core/_fiche_bloc_commun.html" with object=object %}
+      {% endif %}
     </div>
   </main>
 {% endblock content %}

--- a/tiac/tests/test_evenement_simple_contact_add.py
+++ b/tiac/tests/test_evenement_simple_contact_add.py
@@ -1,0 +1,8 @@
+from core.tests.generic_tests.contacts import generic_test_add_contact_agent_to_an_evenement
+from tiac.factories import EvenementSimpleFactory
+from tiac.models import EvenementSimple
+
+
+def test_add_contact_agent_to_an_evenement(live_server, page, choice_js_fill):
+    evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_add_contact_agent_to_an_evenement(live_server, page, choice_js_fill, evenement)

--- a/tiac/tests/test_evenement_simple_documents.py
+++ b/tiac/tests/test_evenement_simple_documents.py
@@ -1,0 +1,18 @@
+from playwright.sync_api import Page
+
+from core.tests.generic_tests.documents import (
+    generic_test_cant_see_document_type_from_other_app,
+    generic_test_can_add_document_to_evenement,
+)
+from tiac.factories import EvenementSimpleFactory
+from tiac.models import EvenementSimple
+
+
+def test_can_add_document_to_evenement(live_server, page: Page, mocked_authentification_user):
+    evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_add_document_to_evenement(live_server, page, mocked_authentification_user, evenement)
+
+
+def test_cant_see_document_type_from_other_app(live_server, page: Page, check_select_options_from_element):
+    evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_cant_see_document_type_from_other_app(live_server, page, check_select_options_from_element, evenement)

--- a/tiac/tests/test_evenement_simple_message.py
+++ b/tiac/tests/test_evenement_simple_message.py
@@ -1,0 +1,110 @@
+import pytest
+from playwright.sync_api import Page
+
+from core.models import Message
+from core.tests.generic_tests.messages import (
+    generic_test_can_add_and_see_message_without_document,
+    generic_test_can_update_draft_note,
+    generic_test_can_update_draft_point_situation,
+    generic_test_can_send_draft_element_suivi,
+    generic_test_can_finaliser_draft_note,
+    generic_test_can_send_draft_fin_suivi,
+    generic_test_can_only_see_own_document_types_in_message_form,
+    generic_test_can_see_and_delete_documents_from_draft_message,
+    generic_test_only_displays_app_contacts,
+)
+from tiac.factories import EvenementSimpleFactory
+from tiac.models import EvenementSimple
+
+
+def test_can_add_and_see_message_without_document(live_server, page: Page, choice_js_fill):
+    evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_add_and_see_message_without_document(live_server, page, choice_js_fill, evenement_produit)
+
+
+def test_can_update_draft_note(live_server, page: Page, choice_js_fill, mocked_authentification_user, mailoutbox):
+    evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_update_draft_note(live_server, page, mocked_authentification_user, evenement_produit, mailoutbox)
+
+
+def test_can_update_draft_point_situation(live_server, page: Page, mocked_authentification_user, mailoutbox):
+    evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_update_draft_point_situation(
+        live_server, page, mocked_authentification_user, evenement_produit, mailoutbox
+    )
+
+
+def test_can_update_draft_demande_intervention(live_server, page: Page, mocked_authentification_user, mailoutbox):
+    evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_update_draft_point_situation(
+        live_server, page, mocked_authentification_user, evenement_produit, mailoutbox
+    )
+
+
+def test_can_update_draft_compte_rendu_demande_intervention(
+    live_server, page: Page, mocked_authentification_user, mailoutbox
+):
+    evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_update_draft_point_situation(
+        live_server, page, mocked_authentification_user, evenement_produit, mailoutbox
+    )
+
+
+def test_can_update_draft_fin_suivi(live_server, page: Page, mocked_authentification_user, mailoutbox):
+    evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_update_draft_point_situation(
+        live_server, page, mocked_authentification_user, evenement_produit, mailoutbox
+    )
+
+
+@pytest.mark.parametrize(
+    "message_type",
+    [
+        Message.MESSAGE,
+        Message.POINT_DE_SITUATION,
+        Message.DEMANDE_INTERVENTION,
+    ],
+)
+def test_can_send_draft_element_suivi(live_server, page: Page, mocked_authentification_user, mailoutbox, message_type):
+    evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_send_draft_element_suivi(
+        live_server, page, mocked_authentification_user, evenement_produit, mailoutbox, message_type
+    )
+
+
+def test_can_finaliser_draft_note(live_server, page: Page, mocked_authentification_user):
+    evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_finaliser_draft_note(live_server, page, mocked_authentification_user, evenement_produit)
+
+
+def test_can_send_draft_fin_suivi(live_server, page: Page, mocked_authentification_user, mailoutbox):
+    evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_send_draft_fin_suivi(
+        live_server, page, mocked_authentification_user, evenement_produit, mailoutbox
+    )
+
+
+def test_can_only_see_own_document_types_in_message_form(live_server, page: Page, check_select_options_from_element):
+    generic_test_can_only_see_own_document_types_in_message_form(
+        live_server,
+        page,
+        check_select_options_from_element,
+        EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS),
+    )
+
+
+def test_can_see_and_delete_documents_from_draft_message(
+    live_server, page: Page, mocked_authentification_user, mailoutbox
+):
+    generic_test_can_see_and_delete_documents_from_draft_message(
+        live_server,
+        page,
+        EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS),
+        mocked_authentification_user,
+        mailoutbox,
+    )
+
+
+def test_only_displays_ssa_contacts(live_server, page: Page, mocked_authentification_user):
+    evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_only_displays_app_contacts(live_server, page, evenement_produit, "ssa")

--- a/tiac/tests/test_evenement_simple_structure_add.py
+++ b/tiac/tests/test_evenement_simple_structure_add.py
@@ -1,0 +1,8 @@
+from core.tests.generic_tests.contacts import generic_test_add_contact_structure_to_an_evenement
+from tiac.factories import EvenementSimpleFactory
+from tiac.models import EvenementSimple
+
+
+def test_add_contact_structure_to_an_evenement(live_server, page, choice_js_fill):
+    evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_add_contact_structure_to_an_evenement(live_server, page, choice_js_fill, evenement)

--- a/tiac/views.py
+++ b/tiac/views.py
@@ -4,7 +4,17 @@ from django.contrib.messages.views import SuccessMessageMixin
 from django.http import Http404
 from django.views.generic import CreateView, DetailView, ListView
 
-from core.mixins import WithFormErrorsAsMessagesMixin, WithFreeLinksListInContextMixin, WithClotureContextMixin
+from core.mixins import (
+    WithFormErrorsAsMessagesMixin,
+    WithFreeLinksListInContextMixin,
+    WithClotureContextMixin,
+    WithBlocCommunPermission,
+    WithDocumentListInContextMixin,
+    WithDocumentUploadFormMixin,
+    WithMessageMixin,
+    WithContactFormsInContextMixin,
+    WithContactListInContextMixin,
+)
 from core.views import MediaDefiningMixin
 from tiac import forms
 from tiac.mixins import WithFilteredListMixin
@@ -30,6 +40,12 @@ class EvenementSimpleDetailView(
     UserPassesTestMixin,
     WithFreeLinksListInContextMixin,
     WithClotureContextMixin,
+    WithBlocCommunPermission,
+    WithDocumentListInContextMixin,
+    WithDocumentUploadFormMixin,
+    WithMessageMixin,
+    WithContactFormsInContextMixin,
+    WithContactListInContextMixin,
     DetailView,
 ):
     model = EvenementSimple


### PR DESCRIPTION
Allow to handle contacts, documents, messages, etc. Move some tests to generic testing to make sure we can at least add a document in tiac.