### PR TITLE
Nettoyage du HTML sur les boutons de création évènement/fiche pour TIAC/SSA/SV

### DIFF
--- a/ssa/templates/ssa/base.html
+++ b/ssa/templates/ssa/base.html
@@ -2,10 +2,10 @@
 
 {% block product_nav %}
     <li>
-        <button class="fr-btn fr-btn--header-blue fr-my-auto">
-            <span class="fr-icon-add-line" aria-hidden="true"></span>
-            <a href="{% url 'ssa:evenement-produit-creation' %}">Créer un événement</a>
-        </button>
+        <a
+            class="fr-btn fr-btn--icon-left fr-btn--header-blue fr-my-auto fr-icon-add-line"
+            href="{% url 'ssa:evenement-produit-creation' %}"
+        >Créer un événement</a>
     </li>
     <li class="{% block highlight_menu_evenements %}{% endblock %}">
         <a class="fr-btn" href="{% url 'ssa:evenement-produit-liste' %}">Liste des événements</a>

--- a/sv/templates/sv/base.html
+++ b/sv/templates/sv/base.html
@@ -3,10 +3,10 @@
 
 {% block product_nav %}
     <li>
-        <button class="fr-btn fr-btn--header-blue fr-my-auto">
-            <span class="fr-icon-add-line" aria-hidden="true"></span>
-            <a href="{% url 'sv:fiche-detection-creation' %}">Créer une fiche</a>
-        </button>
+        <a
+            class="fr-btn fr-btn--header-blue fr-btn--icon-left fr-icon-add-line fr-my-auto"
+            href="{% url 'sv:fiche-detection-creation' %}"
+        >Créer une fiche</a>
     </li>
     <li class="{% block highlight_menu_evenements %}{% endblock %}">
         <a class="fr-btn" href="{% url 'sv:evenement-liste' %}">Évènements</a>

--- a/tiac/templates/tiac/base.html
+++ b/tiac/templates/tiac/base.html
@@ -7,10 +7,10 @@
 
 {% block product_nav %}
     <li>
-        <button class="fr-btn fr-btn--header-blue fr-my-auto">
-            <span class="fr-icon-add-line" aria-hidden="true"></span>
-            <a href="{% url 'tiac:evenement-simple-creation' %}">Créer un événement</a>
-        </button>
+        <a
+            class="fr-btn fr-btn--header-blue fr-btn--icon-left fr-icon-add-line fr-my-auto"
+            href="{% url 'tiac:evenement-simple-creation' %}"
+        >Créer un événement</a>
     </li>
     <li class="{% block highlight_menu_evenements %}{% endblock %}">
         <a class="fr-btn" href="{% url 'tiac:evenement-liste' %}">Liste des événements</a>


### PR DESCRIPTION
Je vient de tomber là-dessus. Je suis pas sûr de comprendre la raison pour laquelle le lien est contenu dans un bouton sur lequel n'est associé aucun listener d'évènement. Ça me semble sémantiquement erroné.