### PR TITLE
Make sure a test wont fail randomly

### DIFF
--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -882,10 +882,10 @@ def test_can_add_lieu_with_adresse_etablissement_autocomplete(
     lieu_form_elements: LieuFormDomElements,
     choice_js_fill,
     choice_js_fill_from_element,
+    ensure_departements,
 ):
     call_count = {"count": 0}
-    region = Region.objects.create(nom="Île-de-France")
-    Departement.objects.create(numero=75, nom="Paris", region=region)
+    ensure_departements("Paris")
 
     def handle(route):
         response = {


### PR DESCRIPTION
Initial error:
>       region = Region.objects.create(nom="Île-de-France")

FAILED sv/tests/test_fichedetection_create.py::test_can_add_lieu_with_adresse_etablissement_autocomplete - django.db.utils.IntegrityError: duplicate key value violates unique constraint "sv_region_nom_key"
DETAIL:  Key (nom)=(Île-de-France) already exists.