### PR TITLE
Remove second * character in transfer modal

### DIFF
--- a/tiac/static/tiac/base.css
+++ b/tiac/static/tiac/base.css
@@ -13,14 +13,14 @@ label:has(+ .choices select[data-required="true"])::after,
 
 /* Except in modals because the field is marked as not required in the form class but the required attribute is
 added via JS when opening the modal */
-.fr-modal__content label:has(+ input:required)::after,
-.fr-modal__content label:has(+ input[data-required="true"])::after,
-.fr-modal__content label:has(+ select:required)::after,
-.fr-modal__content label:has(+ select[data-required="true"])::after,
-.fr-modal__content label:has(+ textarea:required)::after,
-.fr-modal__content label:has(+ textarea[data-required="true"])::after,
-.fr-modal__content label:has(+ .choices select:required)::after,
-.fr-modal__content label:has(+ .choices select[data-required="true"])::after,
+.modal-etablissement label:has(+ input:required)::after,
+.modal-etablissement label:has(+ input[data-required="true"])::after,
+.modal-etablissement label:has(+ select:required)::after,
+.modal-etablissement label:has(+ select[data-required="true"])::after,
+.modal-etablissement label:has(+ textarea:required)::after,
+.modal-etablissement label:has(+ textarea[data-required="true"])::after,
+.modal-etablissement label:has(+ .choices select:required)::after,
+.modal-etablissement label:has(+ .choices select[data-required="true"])::after,
 .required-field::after {
     content: "*";
 }


### PR DESCRIPTION
Keep them only in the etablissement modal in TIAC for now.