### PR TITLE
Réparation sur le formulaire établissement pour les navigateur qui n'implémentent pas le sélecteur ':has()'

### DIFF
--- a/sv/static/sv/fichedetection_form.css
+++ b/sv/static/sv/fichedetection_form.css
@@ -148,7 +148,8 @@ main {
 .etablissement-fields--lookup .fr-search-bar{
     text-align: start;
 }
-.fr-modal__content:has(input[type="checkbox"][id$="-is_etablissement"]:checked) .etablissement-fields {
+.fr-modal__content:has(input[type="checkbox"][id$="-is_etablissement"]:checked) .etablissement-fields,
+.fr-modal__content.is-etablissement .etablissement-fields {
     display: block;
 }
 .fr-search-bar .choices{

--- a/sv/static/sv/fichedetection_lieux_form.js
+++ b/sv/static/sv/fichedetection_lieux_form.js
@@ -54,9 +54,30 @@ function displayLieuxCards() {
 function showLieuModal(event){
     event.preventDefault()
     const currentModal = getNextAvailableModal()
+    handleHasNotImplemented(currentModal)
     modalHTMLContent[currentModal.dataset.id] = currentModal.querySelector(".fr-modal__content").innerHTML
     dsfr(currentModal).modal.disclose()
     dataRequiredToRequired(currentModal)
+}
+
+function handleEvent(evt) {
+    const target = evt instanceof Event ? evt.target : evt;
+    if(target.checked) {
+        target.closest(".fr-modal__content").classList.add("is-etablissement")
+    } else {
+        target.closest(".fr-modal__content").classList.remove("is-etablissement")
+    }
+}
+
+function handleHasNotImplemented(modal) {
+    try {
+        document.querySelector(":has(body)")
+    } catch {
+        const checkBox = modal.querySelector("[name*='is_etablissement']")
+        checkBox.removeEventListener("change", handleEvent)
+        checkBox.addEventListener("change", handleEvent)
+        handleEvent(checkBox)
+    }
 }
 
 function buildLieuCardFromModal(element){


### PR DESCRIPTION
Les autres utilisations sont esthétiques donc ça pose moins de problème.