### PR TITLE
Restrict visibility of draft message to sender

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -10,6 +10,7 @@ from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError, PermissionDenied
 from django.db import models, transaction
+from django.db.models import Q
 from django.forms.utils import RenderableMixin
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
@@ -113,7 +114,7 @@ class WithMessageMixin:
         context["max_upload_size_mb"] = MAX_UPLOAD_SIZE_MEGABYTES
         context["message_status"] = Message.Status
         message_list = (
-            obj.messages.all()
+            obj.messages.filter(Q(status=Message.Status.FINALISE) | Q(sender=self.request.user.agent.contact_set.get()))
             .select_related("sender__agent__structure", "sender_structure")
             .prefetch_related(
                 "recipients__agent",

--- a/core/tests/generic_tests/messages.py
+++ b/core/tests/generic_tests/messages.py
@@ -74,6 +74,20 @@ def generic_test_can_update_draft_message(
     assert len(mailoutbox) == 0
 
 
+def generic_test_cant_see_drafts_from_other_users(live_server, page: Page, object):
+    contact = ContactAgentFactory(with_active_agent=True)
+    message = MessageFactory(
+        content_object=object,
+        status=Message.Status.BROUILLON,
+        message_type=Message.MESSAGE,
+        recipients=[contact],
+    )
+
+    page.goto(f"{live_server.url}{object.get_absolute_url()}")
+    message_page = UpdateMessagePage(page, message.id)
+    expect(message_page.page.get_by_text("Pas de message pour le moment", exact=True)).to_be_visible()
+
+
 def generic_test_can_update_draft_note(live_server, page: Page, mocked_authentification_user, object, mailoutbox):
     message = MessageFactory(
         content_object=object,

--- a/ssa/tests/test_evenement_produit_details_performances.py
+++ b/ssa/tests/test_evenement_produit_details_performances.py
@@ -1,7 +1,7 @@
 from core.models import LienLibre
 from ssa.factories import EvenementProduitFactory, EtablissementFactory
 
-NUMBER_BASE_QUERIES = 19
+NUMBER_BASE_QUERIES = 20
 
 
 def test_evenement_produit_performances(client, django_assert_num_queries):

--- a/ssa/tests/test_evenement_produit_message.py
+++ b/ssa/tests/test_evenement_produit_message.py
@@ -15,6 +15,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_only_see_own_document_types_in_message_form,
     generic_test_can_see_and_delete_documents_from_draft_message,
     generic_test_only_displays_app_contacts,
+    generic_test_cant_see_drafts_from_other_users,
 )
 from ssa.factories import EvenementProduitFactory
 from ssa.models import EvenementProduit
@@ -45,6 +46,11 @@ def test_can_add_and_see_compte_rendu(live_server, page: Page, choice_js_fill):
 def test_can_add_and_see_message_without_document(live_server, page: Page, choice_js_fill):
     evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
     generic_test_can_add_and_see_message_without_document(live_server, page, choice_js_fill, evenement_produit)
+
+
+def test_cant_see_drafts_from_other_users(live_server, page: Page):
+    evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    generic_test_cant_see_drafts_from_other_users(live_server, page, evenement_produit)
 
 
 def test_can_update_draft_note(live_server, page: Page, choice_js_fill, mocked_authentification_user, mailoutbox):

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -34,6 +34,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_only_see_own_document_types_in_message_form,
     generic_test_can_see_and_delete_documents_from_draft_message,
     generic_test_only_displays_app_contacts,
+    generic_test_cant_see_drafts_from_other_users,
 )
 from seves import settings
 from sv.factories import EvenementFactory
@@ -1461,30 +1462,35 @@ def test_draft_messages_always_displayed_first_in_messages_list(live_server, pag
         content_object=evenement,
         title="finalisé le plus ancien",
         status=Message.Status.FINALISE,
+        sender=mocked_authentification_user.agent.contact_set.get(),
         date_creation=timezone.make_aware(datetime(2025, 1, 1, 10, 0, 0)),
     )
     brouillon_older = MessageFactory(
         content_object=evenement,
         title="Brouillon ancien",
         status=Message.Status.BROUILLON,
+        sender=mocked_authentification_user.agent.contact_set.get(),
         date_creation=timezone.make_aware(datetime(2025, 2, 1, 10, 0, 0)),
     )
     finalise_recent = MessageFactory(
         content_object=evenement,
         title="finalisé récent",
         status=Message.Status.FINALISE,
+        sender=mocked_authentification_user.agent.contact_set.get(),
         date_creation=timezone.make_aware(datetime(2025, 3, 1, 10, 0, 0)),
     )
     brouillon_newest = MessageFactory(
         content_object=evenement,
         title="Brouillon le plus récent",
         status=Message.Status.BROUILLON,
+        sender=mocked_authentification_user.agent.contact_set.get(),
         date_creation=timezone.make_aware(datetime(2025, 4, 1, 10, 0, 0)),
     )
     finalise_newest = MessageFactory(
         content_object=evenement,
         title="finalisé le plus récent",
         status=Message.Status.FINALISE,
+        sender=mocked_authentification_user.agent.contact_set.get(),
         date_creation=timezone.make_aware(datetime(2025, 5, 1, 10, 0, 0)),
     )
 
@@ -1505,6 +1511,10 @@ def test_can_update_draft_message(live_server, page: Page, choice_js_fill, mocke
     generic_test_can_update_draft_message(
         live_server, page, choice_js_fill, mocked_authentification_user, EvenementFactory(), mailoutbox
     )
+
+
+def test_cant_see_drafts_from_other_users(live_server, page: Page):
+    generic_test_cant_see_drafts_from_other_users(live_server, page, EvenementFactory())
 
 
 def test_can_update_draft_note(live_server, page: Page, mocked_authentification_user, mailoutbox):

--- a/sv/tests/test_evenement_performance_details.py
+++ b/sv/tests/test_evenement_performance_details.py
@@ -10,7 +10,7 @@ from sv.factories import (
     LieuFactory,
 )
 
-BASE_NUM_QUERIES = 22  # Please note a first call is made without assertion to warm up any possible cache
+BASE_NUM_QUERIES = 23  # Please note a first call is made without assertion to warm up any possible cache
 
 
 @pytest.mark.django_db

--- a/tiac/tests/test_evenement_simple_message.py
+++ b/tiac/tests/test_evenement_simple_message.py
@@ -12,6 +12,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_only_see_own_document_types_in_message_form,
     generic_test_can_see_and_delete_documents_from_draft_message,
     generic_test_only_displays_app_contacts,
+    generic_test_cant_see_drafts_from_other_users,
 )
 from tiac.factories import EvenementSimpleFactory
 from tiac.models import EvenementSimple
@@ -20,6 +21,11 @@ from tiac.models import EvenementSimple
 def test_can_add_and_see_message_without_document(live_server, page: Page, choice_js_fill):
     evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
     generic_test_can_add_and_see_message_without_document(live_server, page, choice_js_fill, evenement_produit)
+
+
+def test_cant_see_drafts_from_other_users(live_server, page: Page):
+    evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_cant_see_drafts_from_other_users(live_server, page, evenement_produit)
 
 
 def test_can_update_draft_note(live_server, page: Page, choice_js_fill, mocked_authentification_user, mailoutbox):


### PR DESCRIPTION
Make sure other users cant see my draft messages. Before that the messages were shown in the table but not available to edit.