### PR TITLE
Avoid duplicate contacts in Message form

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -176,7 +176,7 @@ class BaseMessageForm(DSFRForm, WithNextUrlMixin, WithContentTypeMixin, forms.Mo
         queryset = Contact.objects.with_structure_and_agent().can_be_emailed().select_related("agent__structure")
 
         if limit_contacts_to:
-            queryset = queryset.for_apps(limit_contacts_to)
+            queryset = queryset.for_apps(limit_contacts_to).distinct()
 
         self.fields["recipients"].queryset = queryset
         self.fields["recipients_copy"].queryset = queryset

--- a/core/tests/generic_tests/messages.py
+++ b/core/tests/generic_tests/messages.py
@@ -362,3 +362,22 @@ def generic_test_only_displays_app_contacts(live_server, page: Page, record, app
     assert {contact.display_with_agent_unit for contact in present} <= dropdown_items
     # Assert none of the unexpected items are there
     assert dropdown_items - {contact.display_with_agent_unit for contact in absent} == dropdown_items
+
+
+def generic_test_structure_show_only_one_entry_in_select(live_server, page: Page, record):
+    contact_structure = ContactStructureFactory()
+    ContactAgentFactory(
+        agent__structure=contact_structure.structure,
+        with_active_agent__with_groups=(settings.SSA_GROUP, settings.SV_GROUP),
+    )
+    ContactAgentFactory(
+        agent__structure=contact_structure.structure,
+        with_active_agent__with_groups=(settings.SSA_GROUP, settings.SV_GROUP),
+    )
+
+    page.goto(f"{live_server.url}{record.get_absolute_url()}")
+    message_page = CreateMessagePage(page)
+    message_page.new_message()
+
+    dropdown_items = [item.inner_text() for item in message_page.recipents_dropdown_items.all()]
+    assert len(dropdown_items) == 3

--- a/ssa/tests/test_evenement_produit_message.py
+++ b/ssa/tests/test_evenement_produit_message.py
@@ -16,6 +16,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_see_and_delete_documents_from_draft_message,
     generic_test_only_displays_app_contacts,
     generic_test_cant_see_drafts_from_other_users,
+    generic_test_structure_show_only_one_entry_in_select,
 )
 from ssa.factories import EvenementProduitFactory
 from ssa.models import EvenementProduit
@@ -163,3 +164,8 @@ def test_can_see_and_delete_documents_from_draft_message(
 def test_only_displays_ssa_contacts(live_server, page: Page, mocked_authentification_user):
     evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
     generic_test_only_displays_app_contacts(live_server, page, evenement_produit, "ssa")
+
+
+def test_structure_show_only_one_entry_in_select(live_server, page: Page):
+    evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    generic_test_structure_show_only_one_entry_in_select(live_server, page, evenement_produit)

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -35,6 +35,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_see_and_delete_documents_from_draft_message,
     generic_test_only_displays_app_contacts,
     generic_test_cant_see_drafts_from_other_users,
+    generic_test_structure_show_only_one_entry_in_select,
 )
 from seves import settings
 from sv.factories import EvenementFactory
@@ -1621,3 +1622,7 @@ def test_can_see_and_delete_documents_from_draft_message(
 
 def test_only_displays_sv_contacts(live_server, page: Page, mocked_authentification_user):
     generic_test_only_displays_app_contacts(live_server, page, EvenementFactory(), "sv")
+
+
+def test_structure_show_only_one_entry_in_select(live_server, page: Page):
+    generic_test_structure_show_only_one_entry_in_select(live_server, page, EvenementFactory())

--- a/tiac/tests/test_evenement_simple_message.py
+++ b/tiac/tests/test_evenement_simple_message.py
@@ -13,6 +13,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_see_and_delete_documents_from_draft_message,
     generic_test_only_displays_app_contacts,
     generic_test_cant_see_drafts_from_other_users,
+    generic_test_structure_show_only_one_entry_in_select,
 )
 from tiac.factories import EvenementSimpleFactory
 from tiac.models import EvenementSimple
@@ -114,3 +115,8 @@ def test_can_see_and_delete_documents_from_draft_message(
 def test_only_displays_ssa_contacts(live_server, page: Page, mocked_authentification_user):
     evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
     generic_test_only_displays_app_contacts(live_server, page, evenement_produit, "ssa")
+
+
+def test_structure_show_only_one_entry_in_select(live_server, page: Page):
+    evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_structure_show_only_one_entry_in_select(live_server, page, evenement_produit)


### PR DESCRIPTION
Avoid having duplicate contacts for structures in message forms (for all applications). This was caused by the `by_app`filtering that was added.