### PR TITLE
Fix link for Event creation in SSA

### DIFF
--- a/tiac/templates/tiac/base.html
+++ b/tiac/templates/tiac/base.html
@@ -13,8 +13,8 @@
                         aria-expanded="false" title="Sélectionner un type de fiche a créer">Créer un événement</button>
                 <div class="fr-collapse fr-translate__menu fr-menu" id="translate-1">
                     <ul class="fr-menu__list">
-                        <li><a class="fr-translate__language fr-nav__link open-sidebar" href="{% url 'tiac:evenement-simple-creation' %}">Enregistrement simple</a></li>
-                        <li><a class="fr-translate__language fr-nav__link open-sidebar" href="{% url 'tiac:investigation-tiac-creation' %}">Investigation de tiac</a></li>
+                        <li><a class="fr-translate__language fr-nav__link" href="{% url 'tiac:evenement-simple-creation' %}">Enregistrement simple</a></li>
+                        <li><a class="fr-translate__language fr-nav__link" href="{% url 'tiac:investigation-tiac-creation' %}">Investigation de tiac</a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
The addition of the open-sidebar class would lead on some pages (the pages where sidebar.js is loaded) to trigger a sidebar opening instead of following the href target of the link.