### PR TITLE
Allow for a tiac list view mixed between two models

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,7 @@ django-dsfr
 dj-importmap
 django-template-partials
 django-waffle
+django-querysetsequence
 # Dev
 djhtml
 django-debug-toolbar

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,6 +65,7 @@ django==5.2.6
     #   django-dsfr
     #   django-filter
     #   django-post-office
+    #   django-querysetsequence
     #   django-reversion
     #   django-storages
     #   django-template-partials
@@ -86,6 +87,8 @@ django-environ==0.12.0
 django-filter==25.1
     # via -r requirements.in
 django-post-office==3.10.1
+    # via -r requirements.in
+django-querysetsequence==0.18
     # via -r requirements.in
 django-reversion==5.1.0
     # via -r requirements.in

--- a/tiac/display.py
+++ b/tiac/display.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+
+from tiac.models import EvenementSimple, InvestigationTiac
+
+
+@dataclass
+class DisplayItem:
+    numero: str
+    absolute_url: str
+    createur: str
+    date_reception: str
+    nb_sick_persons: str
+    type_evenement: str
+    etat: str
+    readable_etat: str
+
+    @classmethod
+    def from_evenement_simple(cls, evenement_simple: EvenementSimple):
+        return cls(
+            numero=evenement_simple.numero,
+            absolute_url=evenement_simple.get_absolute_url(),
+            createur=str(evenement_simple.createur),
+            date_reception=evenement_simple.date_reception.strftime("%d/%m/%Y"),
+            nb_sick_persons=str(evenement_simple.nb_sick_persons or "-"),
+            type_evenement=f"Enr. simple / {evenement_simple.get_follow_up_display() if evenement_simple.get_follow_up_display() else '-'}",
+            etat=evenement_simple.etat,
+            readable_etat=evenement_simple.readable_etat,
+        )
+
+    @classmethod
+    def from_investigation_tiac(cls, investigation_tiac: InvestigationTiac):
+        return cls(
+            numero=investigation_tiac.numero,
+            absolute_url=investigation_tiac.get_absolute_url(),
+            createur=str(investigation_tiac.createur),
+            date_reception=investigation_tiac.date_reception.strftime("%d/%m/%Y"),
+            nb_sick_persons="-",
+            type_evenement=investigation_tiac.type_evenement_display,
+            etat=investigation_tiac.etat,
+            readable_etat=investigation_tiac.readable_etat,
+        )
+
+    @classmethod
+    def from_object(cls, obj):
+        if isinstance(obj, EvenementSimple):
+            return DisplayItem.from_evenement_simple(obj)
+        if isinstance(obj, InvestigationTiac):
+            return DisplayItem.from_investigation_tiac(obj)
+        raise NotImplementedError

--- a/tiac/filters.py
+++ b/tiac/filters.py
@@ -4,10 +4,17 @@ from core.filters_mixins import WithNumeroFilterMixin, WithStructureContactFilte
 from tiac.models import EvenementSimple
 
 
-class EvenementSimpleFilter(
+class TiacFilter(
     WithNumeroFilterMixin, WithStructureContactFilterMixin, WithAgentContactFilterMixin, django_filters.FilterSet
 ):
-    pass
+    def filter_queryset(self, queryset):
+        """
+        Taken directly from Django filters, but we remove the `assert isinstance` on queryset are we are not using a
+        real queryset but a QuerySetSequence instead
+        """
+        for name, value in self.form.cleaned_data.items():
+            queryset = self.filters[name].filter(queryset, value)
+        return queryset
 
     class Meta:
         model = EvenementSimple

--- a/tiac/mixins.py
+++ b/tiac/mixins.py
@@ -1,6 +1,7 @@
 from core.mixins import WithOrderingMixin
-from tiac.filters import EvenementSimpleFilter
-from tiac.models import EvenementSimple
+from tiac.filters import TiacFilter
+from tiac.models import EvenementSimple, InvestigationTiac
+from queryset_sequence import QuerySetSequence
 
 
 class WithFilteredListMixin(WithOrderingMixin):
@@ -15,12 +16,21 @@ class WithFilteredListMixin(WithOrderingMixin):
     def get_default_order_by(self):
         return "numero_evenement"
 
+    @property
     def get_raw_queryset(self):
         user = self.request.user
         contact = user.agent.structure.contact_set.get()
-        return EvenementSimple.objects.select_related("createur").get_user_can_view(user).with_fin_de_suivi(contact)
+
+        evenement_simple_qs = (
+            EvenementSimple.objects.select_related("createur").get_user_can_view(user).with_fin_de_suivi(contact)
+        )
+        investigation_qs = (
+            InvestigationTiac.objects.select_related("createur").get_user_can_view(user).with_fin_de_suivi(contact)
+        )
+
+        return QuerySetSequence(evenement_simple_qs, investigation_qs)
 
     def get_queryset(self):
-        queryset = self.apply_ordering(self.get_raw_queryset())
-        self.filter = EvenementSimpleFilter(self.request.GET, queryset=queryset)
+        queryset = self.apply_ordering(self.get_raw_queryset)
+        self.filter = TiacFilter(self.request.GET, queryset=queryset)
         return self.filter.qs

--- a/tiac/models.py
+++ b/tiac/models.py
@@ -366,6 +366,18 @@ class InvestigationTiac(
     def __str__(self):
         return self.numero
 
+    @property
+    def numero(self):
+        return f"T-{self.numero_annee}.{self.numero_evenement}"
+
+    @property
+    def type_evenement_display(self):
+        if self.type_evenement == TypeEvenement.INVESTIGATION_DD:
+            return "Invest. locale"
+        if self.type_evenement == TypeEvenement.INVESTIGATION_COORDONNEE:
+            return "Invest. coord. / MUS informée"
+        return "-"
+
 
 class RepasSuspect(models.Model):
     investigation = models.ForeignKey(InvestigationTiac, on_delete=models.PROTECT, related_name="repas")

--- a/tiac/templates/tiac/tiac_list.html
+++ b/tiac/templates/tiac/tiac_list.html
@@ -4,9 +4,9 @@
 {% block content %}
     <main class="main-container">
         <div class="evenements_liste__table--header">
-            <div>{{ object_list.count }} sur un total de {{ total_object_count }}</div>
+            <div>{{ object_list|length }} sur un total de {{ total_object_count }}</div>
         </div>
-        {% if object_list.count %}
+        {% if object_list|length %}
             <div class="fr-table fr-table--no-caption fr-table--layout-fixed">
                 <table>
                     <thead>
@@ -23,19 +23,18 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for evenement in evenementsimple_list %}
+                        {% for evenement in object_list %}
                             <tr class="evenements__list-row">
-                                <td><a href="{{ evenement.get_absolute_url }}" class="fr-link">{{ evenement.numero }}</a></td>
+                                <td><a href="{{ evenement.absolute_url }}" class="fr-link">{{ evenement.numero }}</a></td>
                                 <td>{{ evenement.createur }}</td>
-                                <td>{{ evenement.date_reception|date:"d/m/Y" }}</td>
+                                <td>{{ evenement.date_reception }}</td>
                                 <td>-</td>
-                                <td>{% if evenement.nb_sick_persons >= 0 %}{{ evenement.nb_sick_persons }}{% else %}-{% endif %}</td>
-                                <td>Enr. simple / {{ evenement.get_follow_up_display }}</td>
+                                <td>{{ evenement.nb_sick_persons }}</td>
+                                <td>{{ evenement.type_evenement }}</td>
                                 <td>-</td>
                                 <td>-</td>
                                 <td><span class="fr-badge fr-badge--{{evenement.etat|etat_color}} fr-badge--no-icon">{{ evenement.readable_etat }}</span></td>
                             </tr>
-
                         {% endfor %}
                     </tbody>
                 </table>

--- a/tiac/tests/test_evenement_list.py
+++ b/tiac/tests/test_evenement_list.py
@@ -1,15 +1,15 @@
 from playwright.sync_api import Page
 
-from tiac.factories import EvenementSimpleFactory
-from tiac.models import EvenementSimple
+from tiac.factories import EvenementSimpleFactory, InvestigationTiacFactory
+from tiac.models import EvenementSimple, InvestigationTiac, TypeEvenement
 from tiac.tests.pages import EvenementListPage
 
 
 def test_list_table_order(live_server, mocked_authentification_user, page: Page):
     EvenementSimpleFactory(numero_annee=2025, numero_evenement=2)
     EvenementSimpleFactory(numero_annee=2025, numero_evenement=1)
-    EvenementSimpleFactory(numero_annee=2025, numero_evenement=22)
-    EvenementSimpleFactory(numero_annee=2024, numero_evenement=22)
+    InvestigationTiacFactory(numero_annee=2025, numero_evenement=22)
+    InvestigationTiacFactory(numero_annee=2024, numero_evenement=22)
     search_page = EvenementListPage(page, live_server.url)
     search_page.navigate()
 
@@ -19,7 +19,7 @@ def test_list_table_order(live_server, mocked_authentification_user, page: Page)
     assert search_page.numero_cell(line_index=4).text_content() == "T-2024.22"
 
 
-def test_row_content(live_server, mocked_authentification_user, page: Page):
+def test_row_content_evenement_simple(live_server, mocked_authentification_user, page: Page):
     evenement: EvenementSimple = EvenementSimpleFactory()
     search_page = EvenementListPage(page, live_server.url)
     search_page.navigate()
@@ -30,6 +30,22 @@ def test_row_content(live_server, mocked_authentification_user, page: Page):
     assert search_page.etablissement_cell().text_content() == "-"
     assert search_page.malades_cell().text_content() == str(evenement.nb_sick_persons)
     assert search_page.type_cell().text_content() == f"Enr. simple / {evenement.get_follow_up_display()}"
+    assert search_page.conclusion_cell().text_content() == "-"
+    assert search_page.danger_cell().text_content() == "-"
+    assert search_page.etat_cell().text_content() == "Brouillon"
+
+
+def test_row_content_investigation_tiac(live_server, mocked_authentification_user, page: Page):
+    evenement: InvestigationTiac = InvestigationTiacFactory(type_evenement=TypeEvenement.INVESTIGATION_COORDONNEE)
+    search_page = EvenementListPage(page, live_server.url)
+    search_page.navigate()
+
+    assert search_page.numero_cell().text_content() == evenement.numero
+    assert search_page.createur_cell().text_content() == mocked_authentification_user.agent.structure.libelle
+    assert search_page.date_reception_cell().text_content() == evenement.date_reception.strftime("%d/%m/%Y")
+    assert search_page.etablissement_cell().text_content() == "-"
+    assert search_page.malades_cell().text_content() == "-"
+    assert search_page.type_cell().text_content() == "Invest. coord. / MUS informée"
     assert search_page.conclusion_cell().text_content() == "-"
     assert search_page.danger_cell().text_content() == "-"
     assert search_page.etat_cell().text_content() == "Brouillon"

--- a/tiac/urls.py
+++ b/tiac/urls.py
@@ -6,7 +6,7 @@ app_name = "tiac"
 urlpatterns = [
     path(
         "evenements/",
-        views.EvenementListView.as_view(),
+        views.TiacListView.as_view(),
         name="evenement-liste",
     ),
     path(

--- a/tiac/views.py
+++ b/tiac/views.py
@@ -25,7 +25,8 @@ from tiac import forms
 from tiac.mixins import WithFilteredListMixin
 from tiac.models import EvenementSimple, InvestigationTiac
 from .constants import DangersSyndromiques
-from .filters import EvenementSimpleFilter
+from .display import DisplayItem
+from .filters import TiacFilter
 from .forms import EvenementSimpleTransferForm
 from .formsets import EtablissementFormSet, RepasFormSet, AlimentFormSet
 
@@ -148,25 +149,29 @@ class EvenementSimpleDetailView(
         return context
 
 
-class EvenementListView(WithFilteredListMixin, ListView):
-    model = EvenementSimple
+class TiacListView(WithFilteredListMixin, ListView):
     paginate_by = 100
+    context_object_name = "objects"
+
+    def get_template_names(self):
+        return ["tiac/tiac_list.html"]
 
     def get_queryset(self):
-        queryset = self.apply_ordering(self.get_raw_queryset())
-        self.filter = EvenementSimpleFilter(self.request.GET, queryset=queryset)
+        queryset = self.apply_ordering(self.get_raw_queryset)
+        self.filter = TiacFilter(self.request.GET, queryset=queryset)
         return self.filter.qs
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-
+        object_list = []
         for evenement in context["object_list"]:
             etat_data = evenement.get_etat_data_from_fin_de_suivi(evenement.has_fin_de_suivi)
             evenement.etat = etat_data["etat"]
             evenement.readable_etat = etat_data["readable_etat"]
+            object_list.append(DisplayItem.from_object(evenement))
 
-        context["total_object_count"] = self.get_raw_queryset().count()
-
+        context["total_object_count"] = self.get_raw_queryset.count()
+        context["object_list"] = object_list
         return context
 
 


### PR DESCRIPTION
With the use of `django-querysetsequence` we can re-use most of the existing code to change the evenement simple list view to a common list view.

- A few tweaks needed on the view to make it work with Django list view (context_object_name and get_template_names, mostly because Django cannot inspect to get the model name from the Meta class)
- A tweak needed in the filterset to remove an assertion on the type of the object