### PR TITLE
Proposition: ajout de `BaseMultiForm` pour supporter plusieurs formulaires en un sur une page

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,5 +1,6 @@
 allowed_patterns:
 - 'class[^:]*:'  # Allow python classes
+- 'from[\.\s\w,]+import[\s\w,]+'  # Allow python imports
 fileignoreconfig:
 - filename: core/models.py
   checksum: adfe480045477f475255740963694ccd05f7adc0ad88d52aa59eedcdcc74005a
@@ -75,5 +76,6 @@ fileignoreconfig:
   checksum: 4c60d8d5e703622c010ba919827f5fda1000e1f0f0f607e1eadc0673698b11b2
 - filename: tiac/tests/test_investigation_tiac_creation.py
   checksum: 196568476526faea3adb5f423bea7345e4098501b7d3061406d7db800a493626
-  checksum: 20d45b7457f86a1f29c4acdc0e2392dd3ec0ccd626e4f3ec33b22062ee173a2a
+- filename: core/form_mixins.py
+  checksum: 828e19f7b1bd39d676d07357d3d04bb5b340b1033dbab4c98726e1d8505c36be
 version: "1.0"

--- a/core/form_mixins.py
+++ b/core/form_mixins.py
@@ -1,9 +1,18 @@
+import operator
 from collections import defaultdict
+from copy import deepcopy
+from functools import reduce
+from typing import Union, Iterable, Tuple
 
 from django import forms
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError
-from django.forms import Script
+from django.core.exceptions import ValidationError, NON_FIELD_ERRORS
+from django.db.models import QuerySet
+from django.db.models.utils import AltersData
+from django.forms import Script, BaseForm, BaseFormSet, BaseModelForm, BaseModelFormSet, MediaDefiningClass
+from django.forms.utils import ErrorList
+from django.utils.datastructures import MultiValueDict
+from django.utils.translation import ngettext
 
 from core.fields import MultiModelChoiceField
 from core.models import LienLibre
@@ -91,3 +100,257 @@ class WithFreeLinksMixin:
         if self.instance and self.instance in self.cleaned_data["free_link"]:
             raise ValidationError("Vous ne pouvez pas lier un objet a lui-même.")
         return self.cleaned_data["free_link"]
+
+
+FormLike = Union[BaseForm, BaseFormSet]
+ModelFormLike = Union[BaseModelForm, BaseModelFormSet]
+
+
+class DeclarativeFormMetaclass(MediaDefiningClass):
+    def __new__(mcs, name, bases, attrs):
+        attrs["declared_form_classes"] = {
+            key: attrs.pop(key)
+            for key, value in list(attrs.items())
+            if isinstance(value, type) and issubclass(value, FormLike)
+        }
+
+        new_class = super().__new__(mcs, name, bases, attrs)
+
+        # Walk through the MRO.
+        declared_form_classes = {}
+        for base in reversed(new_class.__mro__):
+            # Collect fields from base class.
+            if hasattr(base, "declared_form_classes"):
+                declared_form_classes.update(base.declared_form_classes)
+
+            # Field shadowing.
+            for attr, value in base.__dict__.items():
+                if value is None and attr in declared_form_classes:
+                    declared_form_classes.pop(attr)
+
+        new_class.base_form_casses = declared_form_classes
+
+        return new_class
+
+
+class BaseMultiForm(metaclass=DeclarativeFormMetaclass):
+    def __init__(
+        self,
+        data=None,
+        files=None,
+        auto_id="id_%s",
+        prefix=None,
+        initial=None,
+        error_class=ErrorList,
+        form_kwargs=None,
+        renderer=None,
+    ):
+        self.is_bound = data is not None or files is not None
+        self.prefix = prefix or self.get_default_prefix()
+        self.auto_id = auto_id
+        self.data = MultiValueDict() if data is None else data
+        self.files = MultiValueDict() if files is None else files
+        self.initial = initial or {}
+        self.error_class = error_class or ErrorList
+        self.form_kwargs = form_kwargs or {}
+        self.renderer = renderer
+        self._errors = None  # Stores the errors after clean() has been called.
+        self.form_classes = deepcopy(self.base_form_casses)
+
+        self._forms_cache = {}
+
+    def __repr__(self):
+        if self._errors is None:
+            is_valid = "Unknown"
+        else:
+            is_valid = self.is_bound and not self._errors
+        return f"<{self.__class__.__name__} bound={self.is_bound}, valid={is_valid}, form_classes={self.form_classes}>"
+
+    def __iter__(self) -> Iterable[FormLike]:
+        for name in self.forms:
+            yield self[name]
+
+    def __getitem__(self, name) -> FormLike:
+        try:
+            return self.forms[name]
+        except KeyError:
+            raise KeyError(
+                f"Key '{name}' not found in '{self.__class__.__name__}'. "
+                f"Choices are: {', '.join(sorted(self.form_classes.keys()))}."
+            )
+
+    @property
+    def forms(self) -> dict[str, FormLike]:
+        if not self._forms_cache:
+            for name in self.form_classes:
+                self._forms_cache[name] = self.get_form(name)
+        return self._forms_cache
+
+    @classmethod
+    def get_default_prefix(cls):
+        return "multiform"
+
+    def get_form(self, name):
+        try:
+            form_class = self.form_classes[name]
+        except KeyError:
+            raise KeyError(
+                f"Key '{name}' not found in '{self.__class__.__name__}'. "
+                f"Choices are: {', '.join(sorted(self.form_classes.values()))}."
+            )
+        return self._construct_form(name, form_class, **self.get_form_kwargs(name, form_class))
+
+    def get_form_kwargs(self, name, form_class):
+        return self.form_kwargs.get(name, {}).copy()
+
+    def _construct_form(self, name, form_class, **kwargs):
+        """Instantiate and return the i-th form instance in a formset."""
+        defaults = {
+            "auto_id": self.auto_id,
+            "prefix": self.add_prefix(name),
+            "error_class": self.error_class,
+            "renderer": self.renderer,
+        }
+        if self.is_bound:
+            defaults["data"] = self.data
+            defaults["files"] = self.files
+        if self.initial and (initial := self.initial.get(name)):
+            defaults["initial"] = initial
+
+        defaults.update(kwargs)
+
+        if issubclass(form_class, BaseFormSet):
+            # renderer is not a constructor argument of formsets
+            # It need to be processed differently
+            renderer = defaults.pop("renderer", None)
+            form = form_class(**defaults)
+            if renderer:
+                form.renderer = renderer
+            return form
+
+        return form_class(**defaults)
+
+    def add_non_field_error(self, form: str | None, error: str | ValidationError):
+        if not isinstance(error, ValidationError):
+            error = ValidationError(error)
+
+        if hasattr(error, "error_dict"):
+            raise TypeError("The `error` argument cannot contains errors for multiple fields.")
+
+        form = form or NON_FIELD_ERRORS
+
+        if form in self.forms and isinstance(self.forms[form], BaseFormSet):
+            self.forms[form].non_form_errors().extend(error.error_list)
+            self.errors.setdefault(NON_FIELD_ERRORS, {})
+            self.errors[NON_FIELD_ERRORS].update({form: self.forms[form].non_form_errors()})
+        elif form in self.forms:
+            self.forms[form].add_error(None, error)
+            self.errors.setdefault(form, self.forms[form].errors)
+        elif form == NON_FIELD_ERRORS:
+            self.errors.setdefault(NON_FIELD_ERRORS, {})
+            self.errors[NON_FIELD_ERRORS].setdefault(
+                NON_FIELD_ERRORS,
+                self.error_class(error_class="nonfield", renderer=self.renderer),
+            )
+            self.errors[NON_FIELD_ERRORS][NON_FIELD_ERRORS].extend(error.error_list)
+        else:
+            raise ValueError(
+                f"'form' argument must be a form name present in {self.form_classes.keys()} or None (was {form})"
+            )
+
+    def add_prefix(self, name):
+        return "%s-%s" % (self.prefix, name)
+
+    def is_valid(self):
+        return self.is_bound and not self.errors
+
+    @property
+    def errors(self) -> dict[str, ErrorList | dict[str, ErrorList]] | None:
+        """Return a list of form.errors for every form in self.forms."""
+        if self._errors is None:
+            self.full_clean()
+        return self._errors
+
+    def full_clean(self):
+        self._errors = {}
+
+        if not self.is_bound:  # Stop further processing.
+            return
+
+        for name, form in self.forms.items():
+            if form.is_valid():
+                if not hasattr(self, "cleaned_data"):
+                    self.cleaned_data = {}
+                self.cleaned_data[name] = form.cleaned_data
+            else:
+                if form.errors:
+                    self._errors[name] = form.errors
+                if isinstance(form, BaseFormSet) and form.non_form_errors():
+                    self.errors.setdefault(NON_FIELD_ERRORS, {})
+                    self.errors[NON_FIELD_ERRORS].update({name: form.non_form_errors()})
+
+        try:
+            self.clean()
+        except ValidationError as e:
+            self.add_non_field_error(None, e)
+
+    def clean(self):
+        pass
+
+    @property
+    def media(self):
+        return reduce(operator.add, (form.media for form in self))
+
+
+class BaseModelMultiForm(BaseMultiForm, AltersData):
+    def __init__(
+        self,
+        data=None,
+        files=None,
+        auto_id="id_%s",
+        prefix=None,
+        querysets: None | dict[str, QuerySet] = None,
+        initial=None,
+        error_class=ErrorList,
+        form_kwargs=None,
+        renderer=None,
+    ):
+        self.querysets = querysets or {}
+        super().__init__(data, files, auto_id, prefix, initial, error_class, form_kwargs, renderer)
+
+    def get_queryset(self, name) -> QuerySet:
+        return self.querysets.get(name, None)
+
+    def get_form_kwargs(self, name, form_class):
+        kwargs = super().get_form_kwargs(name, form_class)
+        queryset = self.get_queryset(name)
+        if "queryset" not in kwargs and queryset is not None and issubclass(self.form_classes[name], ModelFormLike):
+            kwargs["queryset"] = queryset
+        return kwargs
+
+    @property
+    def model_forms(self) -> Iterable[Tuple[str, ModelFormLike]]:
+        for name, form in self.forms.items():
+            if isinstance(form, ModelFormLike):
+                yield name, form
+
+    def save(self, commit=True):
+        if self.errors:
+            raise ValueError(
+                ngettext(
+                    "The form %s could not be saved because it has errors.",
+                    "The forms %s could not be saved because it has errors.",
+                    len(self.errors),
+                )
+                % (list(self.errors.keys())[0] if len(self.errors) == 1 else ", ".join(self.errors.keys())),
+            )
+
+        saved_forms = {}
+
+        for name, form in self.model_forms:
+            if hasattr(self, f"save_{name}"):
+                saved_forms[name] = getattr(self, f"save_{name}")(form=form, commit=commit)
+            else:
+                saved_forms[name] = form.save(commit)
+
+        return saved_forms

--- a/tiac/static/tiac/etiologie.mjs
+++ b/tiac/static/tiac/etiologie.mjs
@@ -20,7 +20,7 @@ class EtiologieFormController  extends Controller {
 
     onShowFirstModal() {
         dsfr(this.etiologieModalTarget).modal.disclose();
-        document.querySelectorAll('input[name="danger_syndromiques_suspectes_display"]').forEach(el => {
+        document.querySelectorAll('input[name*="danger_syndromiques_suspectes_display"]').forEach(el => {
             el.disabled = this.selectedValuesValue.includes(el.value)
         })
     }
@@ -66,7 +66,7 @@ class EtiologieFormController  extends Controller {
     }
 
     onChooseOption(){
-        const checked = document.querySelector('input[name="danger_syndromiques_suspectes_display"]:checked');
+        const checked = document.querySelector('input[name*="danger_syndromiques_suspectes_display"]:checked');
         if (!checked){return;}
         this.currentOption = checked.value
         this.etiologieModalConfirmationContentTarget.innerHTML = document.querySelector("#" + this.currentOption.replaceAll(" ", "-")).innerHTML

--- a/tiac/templates/tiac/_etilogie_modal.html
+++ b/tiac/templates/tiac/_etilogie_modal.html
@@ -10,7 +10,7 @@
                     </div>
                     <div class="fr-modal__content">
                         <h1 id="fr-modal-title-modal--etiologie" class="fr-modal__title"><span class="fr-icon-arrow-right-line fr-icon--lg"></span>Ajouter un danger syndromique suspecté</h1>
-                        {% dsfr_form_field form.danger_syndromiques_suspectes_display %}
+                        {% dsfr_form_field form.investigation_form.danger_syndromiques_suspectes_display %}
                     </div>
                     <div class="fr-modal__footer">
                         <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg">

--- a/tiac/templates/tiac/investigation.html
+++ b/tiac/templates/tiac/investigation.html
@@ -14,20 +14,20 @@
             <div class="evenement-produit-form-header fr-grid-row">
                 <h1 class="fr-col-6">Création d'une investigation de TIAC</h1>
                 <div class="fr-col-6 fr-mb-auto fr-grid-row fr-grid-row--right">
-                    {% if form.instance and form.instance.is_draft %}
+                    {% if form.investigation_form.instance and form.investigation_form.instance.is_draft %}
                         <button type="submit" name="action" value="draft" class="fr-btn fr-btn--secondary fr-mr-2w">
                             Enregistrer le brouillon
                         </button>
                     {% endif %}
                     <button id="submit_publish" type="submit" name="action" value="publish" class="fr-btn">
-                        {% if form.instance.pk %}Enregistrer{% else %}Publier{% endif %}
+                        {% if form.investigation_form.instance.pk %}Enregistrer{% else %}Publier{% endif %}
                     </button>
                 </div>
             </div>
 
-            {% if form.non_field_errors %}
+            {% if form.investigation_form.non_field_errors %}
                 <section class="fr-my-4v fr-input-group fr-input-group--error">
-                    {{ form.non_field_errors }}
+                    {{ form.investigation_form.non_field_errors }}
                 </section>
             {% endif %}
 
@@ -38,22 +38,22 @@
                     <div class="fr-col-12 fr-col-lg-4">
                         <div class="fr-input-group">
                             <label class="fr-label" for="date-creation-input">Date de création</label>
-                            <input type="text" id="date-creation-input" class="fr-input" value="{% if form.instance.date_creation %}{{ form.instance.date_creation|date:"d/m/Y" }}{% else %}{% now 'd/m/Y' %}{% endif %}" disabled>
+                            <input type="text" id="date-creation-input" class="fr-input" value="{% if form.investigation_form.instance.date_creation %}{{ form.investigation_form.instance.date_creation|date:"d/m/Y" }}{% else %}{% now 'd/m/Y' %}{% endif %}" disabled>
                         </div>
-                        {% dsfr_form_field form.date_reception %}
-                        {% dsfr_form_field form.evenement_origin %}
-                        {% dsfr_inline_radio_field form.modalites_declaration %}
+                        {% dsfr_form_field form.investigation_form.date_reception %}
+                        {% dsfr_form_field form.investigation_form.evenement_origin %}
+                        {% dsfr_inline_radio_field form.investigation_form.modalites_declaration %}
                     </div>
 
                     <div class="fr-col-12 fr-col-lg-4">
-                        {% dsfr_form_field form.contenu %}
+                        {% dsfr_form_field form.investigation_form.contenu %}
                     </div>
 
                     <div class="fr-col-12 fr-col-lg-4">
-                        {% dsfr_inline_radio_field form.notify_ars %}
-                        {% dsfr_inline_radio_field form.will_trigger_inquiry %}
-                        {% dsfr_form_field form.numero_sivss %}
-                        {% dsfr_form_field form.type_evenement %}
+                        {% dsfr_inline_radio_field form.investigation_form.notify_ars %}
+                        {% dsfr_inline_radio_field form.investigation_form.will_trigger_inquiry %}
+                        {% dsfr_form_field form.investigation_form.numero_sivss %}
+                        {% dsfr_form_field form.investigation_form.type_evenement %}
                     </div>
                 </div>
             </fieldset>
@@ -63,19 +63,19 @@
                 <legend class="fr-fieldset__legend fr-h3">Cas</legend>
                 <div class="fr-grid-row fr-grid-row--gutters fr-col">
                     <div class="fr-col-12 fr-col-lg-2">
-                        {% dsfr_form_field form.nb_sick_persons %}
+                        {% dsfr_form_field form.investigation_form.nb_sick_persons %}
                     </div>
                     <div class="fr-col-12 fr-col-lg-2">
-                        {% dsfr_form_field form.nb_sick_persons_to_hospital %}
+                        {% dsfr_form_field form.investigation_form.nb_sick_persons_to_hospital %}
                     </div>
                     <div class="fr-col-12 fr-col-lg-2">
-                        {% dsfr_form_field form.nb_dead_persons %}
+                        {% dsfr_form_field form.investigation_form.nb_dead_persons %}
                     </div>
                     <div class="fr-col-12 fr-col-lg-3">
-                        {% dsfr_form_field form.datetime_first_symptoms %}
+                        {% dsfr_form_field form.investigation_form.datetime_first_symptoms %}
                     </div>
                     <div class="fr-col-12 fr-col-lg-3">
-                        {% dsfr_form_field form.datetime_last_symptoms %}
+                        {% dsfr_form_field form.investigation_form.datetime_last_symptoms %}
                     </div>
                 </div>
 
@@ -107,15 +107,15 @@
 
                 {% include "tiac/_etilogie_modal.html" %}
                 {% include "tiac/_etilogie_modal_confirmation.html" %}
-                {% dsfr_form_field form.danger_syndromiques_suspectes|set_data:"etiologie-form-target:hiddenField" %}
+                {% dsfr_form_field form.investigation_form.danger_syndromiques_suspectes|set_data:"etiologie-form-target:hiddenField" %}
                 {% for danger in dangers %}
                     {% include "tiac/_etilogie_template.html" with id=danger.html_id titre=danger.name_display help_text=danger.help_text description=danger.description %}
                 {% endfor %}
 
-                {% dsfr_form_field form.analyses_sur_les_malades|dsfr_inline %}
+                {% dsfr_form_field form.investigation_form.analyses_sur_les_malades|dsfr_inline %}
                 <div class="fr-grid-row fr-grid-row--gutters fr-col">
                     <div class="fr-col-12 fr-col-lg-6">
-                        {% dsfr_form_field form.precisions %}
+                        {% dsfr_form_field form.investigation_form.precisions %}
                     </div>
                 </div>
 
@@ -126,8 +126,8 @@
                 <div>
                     {% dsfr_notice title="Pour les TIAC confirmées ou fortement suspectées, seul l'enregistrement des éléments conclusifs est requis.<br/> Vous pouvez ajouter d'autres éléments si cela vous aide dans l'investigation (ces données ne seront pas valorisées dans les bilans nationaux)" %}
                 </div>
-                {{ repas_formset }}
-                {{ aliment_formset }}
+                {{ form.repas_formset }}
+                {{ form.aliment_formset }}
             </fieldset>
 
         </main>

--- a/tiac/tests/pages.py
+++ b/tiac/tests/pages.py
@@ -269,33 +269,33 @@ class InvestigationTiacFormPage(WithTreeSelect):
         self.page = page
         self.base_url = base_url
         for field in self.fields:
-            setattr(self, field, page.locator(f"#id_{field}"))
+            setattr(self, field, page.locator(f"#id_multiform-investigation_form-{field}"))
 
     def navigate(self):
         self.page.goto(f"{self.base_url}{reverse('tiac:investigation-tiac-creation')}")
 
     def set_modalites_declaration(self, value):
-        self.page.locator("#radio-id_modalites_declaration").locator(f"input[type='radio'][value='{value}']").check(
-            force=True
-        )
+        self.page.locator("#radio-id_multiform-investigation_form-modalites_declaration").locator(
+            f"input[type='radio'][value='{value}']"
+        ).check(force=True)
 
     def set_will_trigger_inquiry(self, value):
-        self.page.locator("#radio-id_will_trigger_inquiry").locator(
+        self.page.locator("#radio-id_multiform-investigation_form-will_trigger_inquiry").locator(
             f"input[type='radio'][value='{str(value).lower()}']"
         ).check(force=True)
 
     def set_notify_ars(self, value):
-        self.page.locator("#radio-id_notify_ars").locator(f"input[type='radio'][value='{str(value).lower()}']").check(
-            force=True
-        )
+        self.page.locator("#radio-id_multiform-investigation_form-notify_ars").locator(
+            f"input[type='radio'][value='{str(value).lower()}']"
+        ).check(force=True)
 
     def set_type_evenement(self, value):
-        self.page.locator("#radio-id_type_evenement").locator(
+        self.page.locator("#radio-id_multiform-investigation_form-type_evenement").locator(
             f"input[type='radio'][value='{str(value).lower()}']"
         ).check(force=True)
 
     def set_analyses(self, value):
-        self.page.locator("#radio-id_analyses_sur_les_malades").locator(
+        self.page.locator("#radio-id_multiform-investigation_form-analyses_sur_les_malades").locator(
             f"input[type='radio'][value='{str(value).lower()}']"
         ).check(force=True)
 


### PR DESCRIPTION
@Anto59290 J'avais développé ça pour Aidants Connect pour un cas très similaire. Je trouve que ça simplifie la gestion des pages où on a un formulaire principal et des formsets associés mais peut-être que tu trouveras ça un peu compliqué. Ici il suffirait de rajouter le formset `EtablissementFormSet` à `InvestigationTiacMultiForm`.

Idéalement, il faudrait que je sépare `BaseModelMultiForm` dans une dépendance à part. 