### PR TITLE
Allow to add free links to an investigation tiac

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -74,6 +74,5 @@ fileignoreconfig:
 - filename: tiac/tests/pages.py
   checksum: 4c60d8d5e703622c010ba919827f5fda1000e1f0f0f607e1eadc0673698b11b2
 - filename: tiac/tests/test_investigation_tiac_creation.py
-  checksum: 196568476526faea3adb5f423bea7345e4098501b7d3061406d7db800a493626
-  checksum: 20d45b7457f86a1f29c4acdc0e2392dd3ec0ccd626e4f3ec33b22062ee173a2a
+  checksum: 91853f8d50c79914c242736f87adfaf98e71eb4758ba87a3b689d9086ec066cc
 version: "1.0"

--- a/ssa/form_mixins.py
+++ b/ssa/form_mixins.py
@@ -1,7 +1,7 @@
 from core.fields import MultiModelChoiceField
 from core.form_mixins import WithFreeLinksMixin
 from ssa.models import EvenementProduit
-from tiac.models import EvenementSimple
+from tiac.models import EvenementSimple, InvestigationTiac
 
 
 class WithEvenementProduitFreeLinksMixin(WithFreeLinksMixin):
@@ -23,6 +23,14 @@ class WithEvenementProduitFreeLinksMixin(WithFreeLinksMixin):
             .exclude(etat=EvenementSimple.Etat.BROUILLON)
         )
 
+    def _get_investigation_tiac_queryset(self, user):
+        return (
+            InvestigationTiac.objects.all()
+            .order_by_numero()
+            .get_user_can_view(user)
+            .exclude(etat=EvenementSimple.Etat.BROUILLON)
+        )
+
     def _add_free_links(self, model):
         instance = getattr(self, "instance", None)
         self.fields["free_link"] = MultiModelChoiceField(
@@ -31,5 +39,6 @@ class WithEvenementProduitFreeLinksMixin(WithFreeLinksMixin):
             model_choices=[
                 (self.model_label, self.get_queryset(model, self.user, instance)),
                 ("Enregistrement simple", self._get_evenement_simple_queryset(self.user)),
+                ("Investigation de tiac", self._get_investigation_tiac_queryset(self.user)),
             ],
         )

--- a/ssa/tests/test_evenement_produit_creation.py
+++ b/ssa/tests/test_evenement_produit_creation.py
@@ -13,7 +13,7 @@ from ssa.models import EvenementProduit, Etablissement
 from ssa.models import TypeEvenement, Source
 from ssa.tests.pages import EvenementProduitFormPage
 from ssa.views import FindNumeroAgrementView
-from tiac.factories import EvenementSimpleFactory
+from tiac.factories import EvenementSimpleFactory, InvestigationTiacFactory
 
 FIELD_TO_EXCLUDE_ETABLISSEMENT = [
     "_prefetched_objects_cache",
@@ -359,6 +359,22 @@ def test_can_add_free_links_to_evenement_simple(live_server, page: Page, choice_
     lien = LienLibre.objects.get()
     assert lien.related_object_1 == evenement
     assert lien.related_object_2 == evenement_simple
+
+
+def test_can_add_free_links_to_investigation_tiac(live_server, page: Page, choice_js_fill):
+    evenement = EvenementProduitFactory.build()
+    investigation = InvestigationTiacFactory(etat=EvenementProduit.Etat.EN_COURS)
+    creation_page = EvenementProduitFormPage(page, live_server.url)
+    creation_page.navigate()
+    creation_page.fill_required_fields(evenement)
+    creation_page.add_free_link(investigation.numero, choice_js_fill, link_label="Investigation de tiac : ")
+    creation_page.submit_as_draft()
+    creation_page.page.wait_for_timeout(600)
+
+    evenement = EvenementProduit.objects.get()
+    lien = LienLibre.objects.get()
+    assert lien.related_object_1 == evenement
+    assert lien.related_object_2 == investigation
 
 
 def test_cant_add_free_links_for_etat_brouillon(live_server, page: Page, choice_js_cant_pick):

--- a/tiac/templates/tiac/investigation.html
+++ b/tiac/templates/tiac/investigation.html
@@ -130,6 +130,13 @@
                 {{ aliment_formset }}
             </fieldset>
 
+            <fieldset id="liens-libre" class="fr-fieldset form-fieldset fr-mt-2w">
+                <legend class="fr-fieldset__legend fr-h3">Événements liés</legend>
+                <span class="fr-hint-text fr-mb-1w">Pour lier un événement saisissez son numéro ci-dessous.</span>
+                <div data-controller="free-links" class="free-links" data-free-links-ids-value='{{ form.instance.free_link_ids }}'>
+                    {{ form.free_link|set_data:"free-links-target:select"  }}
+                </div>
+            </fieldset>
         </main>
     </form>
 {% endblock %}

--- a/tiac/templates/tiac/investigation_tiac_detail.html
+++ b/tiac/templates/tiac/investigation_tiac_detail.html
@@ -63,6 +63,8 @@
     </div>
     {% include "core/_latest_revision.html" with date_derniere_mise_a_jour=object.latest_version.revision.date_created latest_version=object.latest_version %}
 
+    {% include "core/_list_free_links.html" with classes="fr-mt-4v" title="Événements liés" object=object %}
+
     {% if not object.is_draft %}
       {% include "core/_fiche_bloc_commun.html" with object=object %}
     {% endif %}

--- a/tiac/tests/pages.py
+++ b/tiac/tests/pages.py
@@ -419,6 +419,9 @@ class InvestigationTiacFormPage(WithTreeSelect):
     def submit_as_draft(self):
         self.page.get_by_role("button", name="Enregistrer le brouillon").click()
 
+    def add_free_link(self, numero, choice_js_fill, link_label="Investigation de tiac : "):
+        choice_js_fill(self.page, "#liens-libre .choices", str(numero), link_label + str(numero))
+
 
 class InvestigationTiacDetailsPage:
     def __init__(self, page: Page, base_url):

--- a/tiac/tests/test_evenement_simple_creation.py
+++ b/tiac/tests/test_evenement_simple_creation.py
@@ -3,7 +3,7 @@ from playwright.sync_api import Page, expect
 from core.models import LienLibre, Contact
 from ssa.factories import EvenementProduitFactory
 from ssa.models import EvenementProduit
-from tiac.factories import EvenementSimpleFactory
+from tiac.factories import EvenementSimpleFactory, InvestigationTiacFactory
 from .pages import EvenementSimpleFormPage
 from ..models import EvenementSimple
 
@@ -45,6 +45,7 @@ def test_can_create_evenement_simple_with_all_fields(
     input_data = EvenementSimpleFactory.build()
     other_evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
     evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    investigation_tiac = InvestigationTiacFactory(etat=EvenementProduit.Etat.EN_COURS)
 
     creation_page = EvenementSimpleFormPage(page, live_server.url)
     creation_page.navigate()
@@ -55,14 +56,15 @@ def test_can_create_evenement_simple_with_all_fields(
     creation_page.set_notify_ars(input_data.notify_ars)
     creation_page.nb_sick_persons.fill(str(input_data.nb_sick_persons))
     creation_page.add_free_link(other_evenement.numero, choice_js_fill)
-    creation_page.add_free_link(evenement_produit.numero, choice_js_fill, link_label="Évenement produit : ")
+    creation_page.add_free_link(evenement_produit.numero, choice_js_fill, link_label="Événement produit : ")
+    creation_page.add_free_link(investigation_tiac.numero, choice_js_fill, link_label="Investigation de tiac : ")
     creation_page.submit_as_draft()
 
     evenement = EvenementSimple.objects.last()
     assert_models_are_equal(
         input_data, evenement, to_exclude=["id", "_state", "numero_annee", "numero_evenement", "date_creation"]
     )
-    assert LienLibre.objects.count() == 2
+    assert LienLibre.objects.count() == 3
 
 
 def test_add_contacts_on_creation(live_server, mocked_authentification_user, page: Page):


### PR DESCRIPTION
Fixed a few label to make sure we are consistent. Allow investigation tiac objects to have free links on creation, modify other forms to allow to link to investigation tiac objects.