### PR TITLE
Try to improve test failure on tiac

### DIFF
--- a/tiac/tests/pages.py
+++ b/tiac/tests/pages.py
@@ -349,6 +349,7 @@ class InvestigationTiacFormPage(WithTreeSelect, WithEtablissementMixin):
     def add_aliment_simple(self, aliment: AlimentSuspect):
         self.page.get_by_test_id("add-aliment").click()
 
+        self.page.locator("#categorie-produit").evaluate("el => el.scrollIntoView()")
         self._set_treeselect_option("categorie-produit", aliment.get_categorie_produit_display())
         self.current_modal.get_by_label("Aliment simple/ingrédient").click(force=True)
 


### PR DESCRIPTION
It looks like some "categorie produit" cannot be selected because they were hidden inside the small modal, scrolling into the modal seems to improve the situation.