### PR TITLE
Improve / refacto test on messages

### DIFF
--- a/ssa/tests/test_evenement_produit_message.py
+++ b/ssa/tests/test_evenement_produit_message.py
@@ -1,4 +1,3 @@
-import pytest
 from playwright.sync_api import Page, expect
 
 from core.constants import MUS_STRUCTURE
@@ -9,7 +8,6 @@ from core.tests.generic_tests.messages import (
     generic_test_can_add_and_see_message_without_document,
     generic_test_can_update_draft_note,
     generic_test_can_update_draft_point_situation,
-    generic_test_can_send_draft_element_suivi,
     generic_test_can_finaliser_draft_note,
     generic_test_can_send_draft_fin_suivi,
     generic_test_can_only_see_own_document_types_in_message_form,
@@ -17,6 +15,9 @@ from core.tests.generic_tests.messages import (
     generic_test_only_displays_app_contacts,
     generic_test_cant_see_drafts_from_other_users,
     generic_test_structure_show_only_one_entry_in_select,
+    generic_test_can_send_draft_message,
+    generic_test_can_send_draft_point_de_situation,
+    generic_test_can_send_draft_demande_intervention,
 )
 from ssa.factories import EvenementProduitFactory
 from ssa.models import EvenementProduit
@@ -89,18 +90,22 @@ def test_can_update_draft_fin_suivi(live_server, page: Page, mocked_authentifica
     )
 
 
-@pytest.mark.parametrize(
-    "message_type",
-    [
-        Message.MESSAGE,
-        Message.POINT_DE_SITUATION,
-        Message.DEMANDE_INTERVENTION,
-    ],
-)
-def test_can_send_draft_element_suivi(live_server, page: Page, mocked_authentification_user, mailoutbox, message_type):
+def test_can_send_draft_message(live_server, page: Page, mocked_authentification_user, mailoutbox):
     evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
-    generic_test_can_send_draft_element_suivi(
-        live_server, page, mocked_authentification_user, evenement_produit, mailoutbox, message_type
+    generic_test_can_send_draft_message(live_server, page, mocked_authentification_user, evenement_produit, mailoutbox)
+
+
+def test_can_send_draft_point_de_situation(live_server, page: Page, mocked_authentification_user, mailoutbox):
+    evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    generic_test_can_send_draft_point_de_situation(
+        live_server, page, mocked_authentification_user, evenement_produit, mailoutbox
+    )
+
+
+def test_can_send_draft_demande_intervention(live_server, page: Page, mocked_authentification_user, mailoutbox):
+    evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    generic_test_can_send_draft_demande_intervention(
+        live_server, page, mocked_authentification_user, evenement_produit, mailoutbox
     )
 
 

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -28,7 +28,6 @@ from core.tests.generic_tests.messages import (
     generic_test_can_update_draft_point_situation,
     generic_test_can_update_draft_demande_intervention,
     generic_test_can_update_draft_fin_suivi,
-    generic_test_can_send_draft_element_suivi,
     generic_test_can_finaliser_draft_note,
     generic_test_can_send_draft_fin_suivi,
     generic_test_can_only_see_own_document_types_in_message_form,
@@ -36,6 +35,8 @@ from core.tests.generic_tests.messages import (
     generic_test_only_displays_app_contacts,
     generic_test_cant_see_drafts_from_other_users,
     generic_test_structure_show_only_one_entry_in_select,
+    generic_test_can_send_draft_message,
+    generic_test_can_send_draft_point_de_situation,
 )
 from seves import settings
 from sv.factories import EvenementFactory
@@ -1578,17 +1579,13 @@ def test_can_update_draft_fin_suivi(live_server, page: Page, mocked_authentifica
     )
 
 
-@pytest.mark.parametrize(
-    "message_type",
-    [
-        Message.MESSAGE,
-        Message.POINT_DE_SITUATION,
-        Message.DEMANDE_INTERVENTION,
-    ],
-)
-def test_can_send_draft_element_suivi(live_server, page: Page, mocked_authentification_user, mailoutbox, message_type):
-    generic_test_can_send_draft_element_suivi(
-        live_server, page, mocked_authentification_user, EvenementFactory(), mailoutbox, message_type
+def test_can_send_draft_message(live_server, page: Page, mocked_authentification_user, mailoutbox):
+    generic_test_can_send_draft_message(live_server, page, mocked_authentification_user, EvenementFactory(), mailoutbox)
+
+
+def test_can_send_draft_point_de_situation(live_server, page: Page, mocked_authentification_user, mailoutbox):
+    generic_test_can_send_draft_point_de_situation(
+        live_server, page, mocked_authentification_user, EvenementFactory(), mailoutbox
     )
 
 

--- a/tiac/tests/test_evenement_simple_message.py
+++ b/tiac/tests/test_evenement_simple_message.py
@@ -1,12 +1,9 @@
-import pytest
 from playwright.sync_api import Page
 
-from core.models import Message
 from core.tests.generic_tests.messages import (
     generic_test_can_add_and_see_message_without_document,
     generic_test_can_update_draft_note,
     generic_test_can_update_draft_point_situation,
-    generic_test_can_send_draft_element_suivi,
     generic_test_can_finaliser_draft_note,
     generic_test_can_send_draft_fin_suivi,
     generic_test_can_only_see_own_document_types_in_message_form,
@@ -14,6 +11,10 @@ from core.tests.generic_tests.messages import (
     generic_test_only_displays_app_contacts,
     generic_test_cant_see_drafts_from_other_users,
     generic_test_structure_show_only_one_entry_in_select,
+    generic_test_can_update_draft_demande_intervention,
+    generic_test_can_send_draft_message,
+    generic_test_can_send_draft_demande_intervention,
+    generic_test_can_send_draft_point_de_situation,
 )
 from tiac.factories import EvenementSimpleFactory
 from tiac.models import EvenementSimple
@@ -41,10 +42,12 @@ def test_can_update_draft_point_situation(live_server, page: Page, mocked_authen
     )
 
 
-def test_can_update_draft_demande_intervention(live_server, page: Page, mocked_authentification_user, mailoutbox):
+def test_can_update_draft_demande_intervention(
+    live_server, page: Page, choice_js_fill, mocked_authentification_user, mailoutbox
+):
     evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
-    generic_test_can_update_draft_point_situation(
-        live_server, page, mocked_authentification_user, evenement_produit, mailoutbox
+    generic_test_can_update_draft_demande_intervention(
+        live_server, page, choice_js_fill, mocked_authentification_user, evenement_produit, mailoutbox
     )
 
 
@@ -64,18 +67,22 @@ def test_can_update_draft_fin_suivi(live_server, page: Page, mocked_authentifica
     )
 
 
-@pytest.mark.parametrize(
-    "message_type",
-    [
-        Message.MESSAGE,
-        Message.POINT_DE_SITUATION,
-        Message.DEMANDE_INTERVENTION,
-    ],
-)
-def test_can_send_draft_element_suivi(live_server, page: Page, mocked_authentification_user, mailoutbox, message_type):
+def test_can_send_draft_message(live_server, page: Page, mocked_authentification_user, mailoutbox):
     evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
-    generic_test_can_send_draft_element_suivi(
-        live_server, page, mocked_authentification_user, evenement_produit, mailoutbox, message_type
+    generic_test_can_send_draft_message(live_server, page, mocked_authentification_user, evenement_produit, mailoutbox)
+
+
+def test_can_send_draft_point_de_situation(live_server, page: Page, mocked_authentification_user, mailoutbox):
+    evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_send_draft_point_de_situation(
+        live_server, page, mocked_authentification_user, evenement_produit, mailoutbox
+    )
+
+
+def test_can_send_draft_demande_intervention(live_server, page: Page, mocked_authentification_user, mailoutbox):
+    evenement_produit = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_send_draft_demande_intervention(
+        live_server, page, mocked_authentification_user, evenement_produit, mailoutbox
     )
 
 

--- a/tiac/tests/test_investigation_message.py
+++ b/tiac/tests/test_investigation_message.py
@@ -1,12 +1,9 @@
-import pytest
 from playwright.sync_api import Page
 
-from core.models import Message
 from core.tests.generic_tests.messages import (
     generic_test_can_add_and_see_message_without_document,
     generic_test_can_update_draft_note,
     generic_test_can_update_draft_point_situation,
-    generic_test_can_send_draft_element_suivi,
     generic_test_can_finaliser_draft_note,
     generic_test_can_send_draft_fin_suivi,
     generic_test_can_only_see_own_document_types_in_message_form,
@@ -14,6 +11,10 @@ from core.tests.generic_tests.messages import (
     generic_test_only_displays_app_contacts,
     generic_test_cant_see_drafts_from_other_users,
     generic_test_structure_show_only_one_entry_in_select,
+    generic_test_can_update_draft_demande_intervention,
+    generic_test_can_send_draft_message,
+    generic_test_can_send_draft_demande_intervention,
+    generic_test_can_send_draft_point_de_situation,
 )
 from tiac.factories import InvestigationTiacFactory
 from tiac.models import InvestigationTiac
@@ -41,10 +42,12 @@ def test_can_update_draft_point_situation(live_server, page: Page, mocked_authen
     )
 
 
-def test_can_update_draft_demande_intervention(live_server, page: Page, mocked_authentification_user, mailoutbox):
+def test_can_update_draft_demande_intervention(
+    live_server, page: Page, choice_js_fill, mocked_authentification_user, mailoutbox
+):
     evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
-    generic_test_can_update_draft_point_situation(
-        live_server, page, mocked_authentification_user, evenement, mailoutbox
+    generic_test_can_update_draft_demande_intervention(
+        live_server, page, choice_js_fill, mocked_authentification_user, evenement, mailoutbox
     )
 
 
@@ -64,18 +67,22 @@ def test_can_update_draft_fin_suivi(live_server, page: Page, mocked_authentifica
     )
 
 
-@pytest.mark.parametrize(
-    "message_type",
-    [
-        Message.MESSAGE,
-        Message.POINT_DE_SITUATION,
-        Message.DEMANDE_INTERVENTION,
-    ],
-)
-def test_can_send_draft_element_suivi(live_server, page: Page, mocked_authentification_user, mailoutbox, message_type):
+def test_can_send_draft_message(live_server, page: Page, mocked_authentification_user, mailoutbox):
     evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
-    generic_test_can_send_draft_element_suivi(
-        live_server, page, mocked_authentification_user, evenement, mailoutbox, message_type
+    generic_test_can_send_draft_message(live_server, page, mocked_authentification_user, evenement, mailoutbox)
+
+
+def test_can_send_draft_point_de_situation(live_server, page: Page, mocked_authentification_user, mailoutbox):
+    evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
+    generic_test_can_send_draft_point_de_situation(
+        live_server, page, mocked_authentification_user, evenement, mailoutbox
+    )
+
+
+def test_can_send_draft_demande_intervention(live_server, page: Page, mocked_authentification_user, mailoutbox):
+    evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
+    generic_test_can_send_draft_demande_intervention(
+        live_server, page, mocked_authentification_user, evenement, mailoutbox
     )
 
 


### PR DESCRIPTION
- First issue the generic_test_can_update_draft_point_situation test was used in the test that was meant for the demande d'intervention.
- Second issue, each object needs a different setup (for example the demande d'intervention need a Structure as a contact not an Agent, this is not guaranted by the factory). Splitting into different tests just looks easier.