### PR TITLE
Refine behavior of Agent Pathogene for TIAC

### DIFF
--- a/tiac/models.py
+++ b/tiac/models.py
@@ -411,6 +411,7 @@ class InvestigationTiac(
             CategorieDanger.CAMPYLOBACTER_COLI,
             CategorieDanger.CAMPYLOBACTER_JEJUNI,
             CategorieDanger.SALMONELLA_ENTERITIDIS,
+            CategorieDanger.SALMONELLA_TYPHIMURIUM,
             CategorieDanger.SHIGELLA,
             CategorieDanger.YERSINIA_ENTEROCOLITICA,
             CategorieDanger.HISTAMINE,

--- a/tiac/static/tiac/agents_pathogene.mjs
+++ b/tiac/static/tiac/agents_pathogene.mjs
@@ -42,6 +42,7 @@ class AgentsPathogeneController extends Controller {
             value: this.categorieDangerInputTarget.value.split("||").map(v => v.trim()),
             options: options,
             isSingleSelect: false,
+            isIndependentNodes: true,
             openCallback() {
                 patchItems(treeselect.srcElement)
                 if (this._customHeaderAdded) {
@@ -70,7 +71,11 @@ class AgentsPathogeneController extends Controller {
             patchItems(treeselect.srcElement)
         })
         treeselect.srcElement.addEventListener('input', (e) => {
-            if (!!e.detail) {
+            if (e.detail.length === 0) {
+                this.element.querySelectorAll("[id^='shortcut_']").forEach(checkbox =>{
+                    checkbox.checked = false
+                })
+            } else {
                 this.categorieDangerInputTarget.value = e.detail.join("||")
             }
         })

--- a/tiac/templates/tiac/investigation.html
+++ b/tiac/templates/tiac/investigation.html
@@ -136,7 +136,7 @@
                 <div class="fieldset-header">
                     <legend class="fr-fieldset__legend fr-h3">Agents pathogènes confirmés par l'ARS</legend>
                 </div>
-                <span class="fr-hint-text">Confirmation obtenue par examen clinique ou analytique des malades</span>
+                <span class="fr-hint-text fr-mb-1w">Confirmation obtenue par examen clinique ou analytique des malades</span>
                 {% dsfr_form_field form.agents_confirmes_ars|set_data:"agents-pathogene-target:categorieDangerInput" %}
                 <div data-agents-pathogene-target="categorieDangerContainer"></div>
 


### PR DESCRIPTION
- When we select a parent category, we don't want to select the child categories with it (`isIndependentNodes` parameter)
- Fix margins and a missing shortcut

This will also fix a test that failed randomly due to the level of danger that was selected.