### PR TITLE
Improve rich text editor for message

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -22,7 +22,7 @@ from core.fields import (
     SEVESChoiceField,
 )
 from core.form_mixins import DSFRForm
-from core.html import filter_tags_and_attributes, inline_styles_to_classes, replace_ol_elements_with_ul
+from core.html import filter_tags_and_attributes, replace_ol_elements_with_ul
 from core.models import Contact, Departement, Document, Message, Structure
 from core.validators import MAX_UPLOAD_SIZE_BYTES, MAX_UPLOAD_SIZE_MEGABYTES
 
@@ -279,7 +279,6 @@ class CommonMessageForm(forms.ModelForm):
 
     def clean_content(self):
         soup = BeautifulSoup(self.cleaned_data["content"], "html.parser")
-        inline_styles_to_classes(soup)
         filter_tags_and_attributes(soup)
         replace_ol_elements_with_ul(soup)
         return str(soup)

--- a/core/html.py
+++ b/core/html.py
@@ -1,41 +1,8 @@
-ALLOWED_TAGS = ["h2", "p", "ol", "li", "span", "strong", "br", "s", "em", "u"]
-ALLOWED_BG_COLORS = [
-    "yellow-tournesol-925-125",
-    "green-emeraude-950-100",
-    "green-archipel-950-100",
-    "pink-macaron-925-125",
-    "purple-glycine-925-125",
-    "blue-ecume-925-125",
-]
-ALLOWED_COLORS = [
-    "grey-925-125",
-    "blue-france-sun-113-625",
-    "blue-france-main-525",
-    "success-425-625",
-    "purple-glycine-main-494",
-    "error-425-625",
-]
+ALLOWED_TAGS = ["h2", "p", "ol", "li", "span", "strong", "br", "s", "em", "u", "ul"]
 
 
 def _get_style_value(style, selector):
     return style.split(selector)[-1].replace(";", "").strip()
-
-
-def inline_styles_to_classes(soup):
-    for element in soup.find_all(style=True):
-        classes = element.get("class", [])
-        styles = element["style"].split(";")
-        for style in styles:
-            style = style.strip()
-            if style.startswith("background-color:"):
-                for color in ALLOWED_BG_COLORS:
-                    if color in _get_style_value(style, "background-color:"):
-                        classes.append(f"background-color-{color}")
-            if style.startswith("color:"):
-                for color in ALLOWED_COLORS:
-                    if color in _get_style_value(style, "color:"):
-                        classes.append(f"text-color-{color}")
-        element["class"] = list(classes)
 
 
 def filter_tags_and_attributes(soup):

--- a/core/notifications.py
+++ b/core/notifications.py
@@ -17,6 +17,8 @@ def _send_message(recipients: list[Contact], copy: list[Contact], subject: str, 
     copy = [c for c in copy if c != ""]
     css_path = Path(settings.BASE_DIR) / "core/static/core/message_detail.css"
     css_content = css_path.read_text()
+    css_path = Path(settings.BASE_DIR) / "core/static/core/message_colors.css"
+    css_content += css_path.read_text()
     template, _ = EmailTemplate.objects.update_or_create(
         name="seves_email_template",
         defaults={

--- a/core/static/core/message_colors.css
+++ b/core/static/core/message_colors.css
@@ -1,0 +1,38 @@
+/* Variables cant be used in the following styles as they won't be included in the emails styles for notification */
+.text-color-grey-925-125 {
+    color: #2a2a2a;
+}
+.text-color-blue-france-sun-113-625 {
+    color: #000091;
+}
+.text-color-blue-france-main-525 {
+    color: #6a6af4;
+}
+.text-color-success-425-625 {
+    color: #18753c;
+}
+.text-color-purple-glycine-main-494 {
+    color: #a558a0;
+}
+.text-color-error-425-625 {
+    color: #ce0500;
+}
+
+.background-color-yellow-tournesol-925-125 {
+    background-color: #fde39c;
+}
+.background-color-green-emeraude-950-100 {
+    background-color: #c3fad5;
+}
+.background-color-green-archipel-950-100 {
+    background-color: #c7f6fc;
+}
+.background-color-pink-macaron-925-125 {
+    background-color: #fddfda;
+}
+.background-color-purple-glycine-925-125 {
+    background-color: #fddbfa;
+}
+.background-color-blue-ecume-925-125 {
+    background-color: #dee5fd;
+}

--- a/core/static/core/message_detail.css
+++ b/core/static/core/message_detail.css
@@ -1,42 +1,12 @@
 .ql-indent-1 {
-    padding-left: 3em;
+    padding-left: 3rem;
 }
-
-/* Variables cant be used in the following styles as they won't be included in the emails styles for notification */
-.text-color-grey-925-125 {
-    color: #2a2a2a;
+.ql-indent-2 {
+    padding-left: 6rem;
 }
-.text-color-blue-france-sun-113-625 {
-    color: #000091;
+.ql-indent-3 {
+    padding-left: 9rem;
 }
-.text-color-blue-france-main-525 {
-    color: #6a6af4;
-}
-.text-color-success-425-625 {
-    color: #18753c;
-}
-.text-color-purple-glycine-main-494 {
-    color: #a558a0;
-}
-.text-color-error-425-625 {
-    color: #ce0500;
-}
-
-.background-color-yellow-tournesol-925-125 {
-    background-color: #fde39c;
-}
-.background-color-green-emeraude-950-100 {
-    background-color: #c3fad5;
-}
-.background-color-green-archipel-950-100 {
-    background-color: #c7f6fc;
-}
-.background-color-pink-macaron-925-125 {
-    background-color: #fddfda;
-}
-.background-color-purple-glycine-925-125 {
-    background-color: #fddbfa;
-}
-.background-color-blue-ecume-925-125 {
-    background-color: #dee5fd;
+.ql-indent-4 {
+    padding-left: 12rem;
 }

--- a/core/static/core/rich_text_editor.mjs
+++ b/core/static/core/rich_text_editor.mjs
@@ -4,36 +4,76 @@ import {Controller} from "Stimulus"
 
 class RichTextEditorController extends Controller {
     static targets = ["textarea", "container"]
-    bgColors = [
-        "var(--yellow-tournesol-925-125)",
-        "var(--green-emeraude-950-100)",
-        "var(--green-archipel-950-100)",
-        "var(--pink-macaron-925-125)",
-        "var(--purple-glycine-925-125)",
-        "var(--blue-ecume-925-125)",
-    ]
-    colors = [
-        "var(--grey-925-125)",
-        "var(--blue-france-sun-113-625)",
-        "var(--blue-france-main-525)",
-        "var(--success-425-625)",
-        "var(--purple-glycine-main-494)",
-        "var(--error-425-625)",
-    ]
+
+    TEXT_PREFIX = "text-color"
+    BACKGROUND_PREFIX = "background-color"
+
+    allowExistingClassesForColors(quill) {
+        quill.clipboard.addMatcher("SPAN", (node, delta) => {
+            node.classList.forEach(cls => {
+                if (cls.startsWith(this.TEXT_PREFIX)) {
+                    delta.ops.forEach(op => {
+                        if (op.insert) {
+                            op.attributes = op.attributes || {}
+                            op.attributes.color = cls.replace(`${this.TEXT_PREFIX}-`, "")
+                        }
+                    })
+                }
+            })
+            return delta
+        })
+
+        quill.clipboard.addMatcher("SPAN", (node, delta) => {
+            node.classList.forEach(cls => {
+                if (cls.startsWith(this.BACKGROUND_PREFIX)) {
+                    delta.ops.forEach(op => {
+                        if (op.insert) {
+                            op.attributes = op.attributes || {}
+                            op.attributes.background = cls.replace(`${this.BACKGROUND_PREFIX}-`, "")
+                        }
+                    })
+                }
+            })
+            return delta
+        })
+    }
+
+    addCustomColorsAsClasses() {
+        const Parchment = Quill.import("parchment")
+
+        const ColorClass = new Parchment.ClassAttributor("color", this.TEXT_PREFIX, {
+            scope: Parchment.Scope.INLINE,
+        })
+        Quill.register(ColorClass, true)
+
+        const BackgroundClass = new Parchment.ClassAttributor("background", this.BACKGROUND_PREFIX, {
+            scope: Parchment.Scope.INLINE,
+        })
+        Quill.register(BackgroundClass, true)
+    }
+
+    setBackgroundColorForPickers() {
+        this.element.querySelectorAll(".ql-picker-item").forEach(el => {
+            const value = el.dataset.value
+
+            if (value) {
+                el.style.backgroundColor = "var(--" + value + ")"
+            }
+        })
+    }
 
     connect() {
         const quill = new Quill(this.containerTarget, {
             theme: "snow",
             modules: {
-                toolbar: [
-                    [{header: [2, false]}],
-                    ["bold", "italic", "underline", "strike", {list: "bullet"}],
-                    [{indent: "-1"}, {indent: "+1"}],
-                    [{color: this.colors}, {background: this.bgColors}],
-                ],
+                toolbar: "#toolbar",
             },
         })
+        this.addCustomColorsAsClasses()
+        this.allowExistingClassesForColors(quill)
+        this.setBackgroundColorForPickers()
 
+        quill.clipboard.dangerouslyPasteHTML(this.textareaTarget.value)
         quill.on("text-change", () => {
             this.textareaTarget.value = quill.root.innerHTML
         })

--- a/core/templates/core/message_detail.html
+++ b/core/templates/core/message_detail.html
@@ -3,6 +3,7 @@
 {% block extrahead %}
     {% flag "rich_text_editor" %}
         <link rel="stylesheet" href="{% static 'core/message_detail.css' %}">
+        <link rel="stylesheet" href="{% static 'core/message_colors.css' %}">
     {% endflag %}
 {% endblock %}
 {% block content %}

--- a/core/templates/core/message_form.html
+++ b/core/templates/core/message_form.html
@@ -6,6 +6,7 @@
     {% flag "rich_text_editor" %}
         <link href="https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.snow.css" rel="stylesheet">
         <link rel="stylesheet" href="{% static 'core/rich_text_editor.css' %}">
+        <link rel="stylesheet" href="{% static 'core/message_colors.css' %}">
     {% endflag %}
 {% endblock %}
 {% block scripts %}
@@ -78,9 +79,45 @@
                                 <label for="rich-text-editor" class="fr-label required-field fr-mb-2v">
                                     Message<span class="fr-sr-only fr-required-marker">*</span>
                                 </label>
+                                <div id="toolbar">
+                                    <span class="ql-formats">
+                                        <select class="ql-header">
+                                            <option value="2">Titre</option>
+                                            <option selected>Normal</option>
+                                        </select>
+                                    </span>
+                                    <span class="ql-formats">
+                                        <button class="ql-bold"></button>
+                                        <button class="ql-italic"></button>
+                                        <button class="ql-underline"></button>
+                                        <button class="ql-strike"></button>
+                                        <button class="ql-list" value="bullet"></button>
+                                    </span>
+                                    <span class="ql-formats">
+                                        <button class="ql-indent" value="-1"></button>
+                                        <button class="ql-indent" value="+1"></button>
+                                    </span>
+
+                                    <span class="ql-formats">
+                                        <select class="ql-color">
+                                            <option value="grey-925-125"></option>
+                                            <option value="blue-france-sun-113-625"></option>
+                                            <option value="success-425-625"></option>
+                                            <option value="purple-glycine-main-494"></option>
+                                            <option value="error-425-625"></option>
+                                        </select>
+                                        <select class="ql-background">
+                                            <option value="yellow-tournesol-925-125"></option>
+                                            <option value="green-emeraude-950-100"></option>
+                                            <option value="green-archipel-950-100"></option>
+                                            <option value="pink-macaron-925-125"></option>
+                                            <option value="purple-glycine-925-125"></option>
+                                            <option value="blue-ecume-925-125"></option>
+                                        </select>
+                                    </span>
+                                </div>
                                 <div data-rich-text-editor-target="container" id="rich-text-editor"></div>
                             </div>
-
                         </div>
                     {% else %}
                         {% for field in form %}

--- a/core/tests/generic_tests/messages.py
+++ b/core/tests/generic_tests/messages.py
@@ -49,10 +49,14 @@ def generic_test_can_add_and_see_message_with_rich_text_editor(live_server, page
 
     message_page.message_title.fill("Title of the message")
     message_page.page.locator(".ql-bold").click()
-    message_page.message_content_in_rich_text_editor.type("My content \n with a line return")
+    message_page.message_content_in_rich_text_editor.type("My content \n with a line return\n")
     message_page.page.locator(".ql-color.ql-picker.ql-color-picker").click()
     message_page.page.locator(".ql-primary").first.click()
-    message_page.message_content_in_rich_text_editor.type("Text in color")
+    message_page.message_content_in_rich_text_editor.type("Text in color\n")
+    message_page.page.locator(".ql-list").click()
+    message_page.message_content_in_rich_text_editor.type("Item 1\n")
+    message_page.message_content_in_rich_text_editor.type("Item 2\n")
+
     message_page.submit_message()
 
     page.wait_for_url(f"**{object.get_absolute_url()}#tabpanel-messages-panel")
@@ -66,10 +70,33 @@ def generic_test_can_add_and_see_message_with_rich_text_editor(live_server, page
     message_page.page.wait_for_timeout(20000)
     expect(new_page.get_by_text("Title of the message", exact=True)).to_be_visible()
     assert (
-        '<p><strong>My content </strong></p><p> with a line return<span class="text-color-grey-925-125">Text in color</span></p>'
+        '<p><strong>My content </strong></p><p> with a line return</p><p><span class="text-color-grey-925-125">Text in color</span></p><ul><li><span class="ql-ui"></span>Item 1</li><li><span class="ql-ui"></span>Item 2</li><li><span class="ql-ui"></span><br></li></ul>'
         in new_page.content()
     )
     assert object.messages.get().status == Message.Status.FINALISE
+
+
+def generic_test_can_send_draft_message_with_rich_text_editor(
+    live_server, page: Page, mocked_authentification_user, object
+):
+    contact = mocked_authentification_user.agent.structure.contact_set.get()
+    object.contacts.add(contact)
+    MessageFactory(
+        content_object=object,
+        status=Message.Status.BROUILLON,
+        sender=mocked_authentification_user.agent.contact_set.get(),
+        message_type=Message.MESSAGE,
+        content="<p><strong>My content </strong></p>",
+    )
+
+    page.goto(f"{live_server.url}{object.get_absolute_url()}")
+    message_page = UpdateMessagePage(page, "#message-form")
+    message_page.open_message()
+
+    message_page.submit_message()
+    expect(page.get_by_text("Le message a bien été ajouté.")).to_be_visible()
+    new_page = message_page.open_message()
+    assert "<p><strong>My content </strong></p>" in new_page.content()
 
 
 def generic_test_can_update_draft_message_in_new_tab(

--- a/ssa/tests/test_evenement_produit_message.py
+++ b/ssa/tests/test_evenement_produit_message.py
@@ -22,6 +22,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_search_in_message_list,
     generic_test_can_see_delete_and_modify_documents_from_draft_message_in_new_tab,
     generic_test_can_send_draft_message_in_new_tab,
+    generic_test_can_send_draft_message_with_rich_text_editor,
     generic_test_can_update_draft_note_in_new_tab,
     generic_test_can_update_draft_point_situation_in_new_tab,
     generic_test_cant_see_drafts_from_other_users,
@@ -44,6 +45,14 @@ def test_can_add_and_see_message_without_document(live_server, page: Page, choic
 def test_can_add_and_see_message_with_rich_text_editor(live_server, page: Page, choice_js_fill):
     evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
     generic_test_can_add_and_see_message_with_rich_text_editor(live_server, page, choice_js_fill, evenement_produit)
+
+
+@override_flag("rich_text_editor", active=True)
+def test_can_send_draft_message_with_rich_text_editor(live_server, page: Page, mocked_authentification_user):
+    evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    generic_test_can_send_draft_message_with_rich_text_editor(
+        live_server, page, mocked_authentification_user, evenement_produit
+    )
 
 
 def test_can_add_and_see_message_in_new_tab_without_document(

--- a/ssa/tests/test_investigation_cas_humain_message.py
+++ b/ssa/tests/test_investigation_cas_humain_message.py
@@ -21,6 +21,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_search_in_message_list,
     generic_test_can_see_delete_and_modify_documents_from_draft_message_in_new_tab,
     generic_test_can_send_draft_message_in_new_tab,
+    generic_test_can_send_draft_message_with_rich_text_editor,
     generic_test_can_update_draft_note_in_new_tab,
     generic_test_can_update_draft_point_situation_in_new_tab,
     generic_test_cant_see_drafts_from_other_users,
@@ -43,6 +44,14 @@ def test_can_add_and_see_message_without_document(live_server, page: Page, choic
 def test_can_add_and_see_message_with_rich_text_editor(live_server, page: Page, choice_js_fill):
     evenement = InvestigationCasHumainFactory(etat=EvenementInvestigationCasHumain.Etat.EN_COURS)
     generic_test_can_add_and_see_message_with_rich_text_editor(live_server, page, choice_js_fill, evenement)
+
+
+@override_flag("rich_text_editor", active=True)
+def test_can_send_draft_message_with_rich_text_editor(live_server, page: Page, mocked_authentification_user):
+    evenement = InvestigationCasHumainFactory(etat=EvenementInvestigationCasHumain.Etat.EN_COURS)
+    generic_test_can_send_draft_message_with_rich_text_editor(
+        live_server, page, mocked_authentification_user, evenement
+    )
 
 
 def test_can_add_and_see_message_in_new_tab_without_document(

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -36,6 +36,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_search_in_message_list,
     generic_test_can_see_delete_and_modify_documents_from_draft_message_in_new_tab,
     generic_test_can_send_draft_message_in_new_tab,
+    generic_test_can_send_draft_message_with_rich_text_editor,
     generic_test_can_update_draft_demande_intervention_in_new_tab,
     generic_test_can_update_draft_message_in_new_tab,
     generic_test_can_update_draft_note_in_new_tab,
@@ -63,6 +64,14 @@ def test_can_add_and_see_message_without_document(live_server, page: Page, choic
 def test_can_add_and_see_message_with_rich_text_editor(live_server, page: Page, choice_js_fill):
     evenement = EvenementFactory()
     generic_test_can_add_and_see_message_with_rich_text_editor(live_server, page, choice_js_fill, evenement)
+
+
+@override_flag("rich_text_editor", active=True)
+def test_can_send_draft_message_with_rich_text_editor(live_server, page: Page, mocked_authentification_user):
+    evenement = EvenementFactory()
+    generic_test_can_send_draft_message_with_rich_text_editor(
+        live_server, page, mocked_authentification_user, evenement
+    )
 
 
 def test_can_add_and_see_message_in_new_tab_without_document(

--- a/tiac/tests/test_evenement_simple_message.py
+++ b/tiac/tests/test_evenement_simple_message.py
@@ -21,6 +21,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_search_in_message_list,
     generic_test_can_see_delete_and_modify_documents_from_draft_message_in_new_tab,
     generic_test_can_send_draft_message_in_new_tab,
+    generic_test_can_send_draft_message_with_rich_text_editor,
     generic_test_can_update_draft_demande_intervention_in_new_tab,
     generic_test_can_update_draft_note_in_new_tab,
     generic_test_can_update_draft_point_situation_in_new_tab,
@@ -45,6 +46,14 @@ def test_can_add_and_see_message_without_document(live_server, page: Page, choic
 def test_can_add_and_see_message_with_rich_text_editor(live_server, page: Page, choice_js_fill):
     evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
     generic_test_can_add_and_see_message_with_rich_text_editor(live_server, page, choice_js_fill, evenement)
+
+
+@override_flag("rich_text_editor", active=True)
+def test_can_send_draft_message_with_rich_text_editor(live_server, page: Page, mocked_authentification_user):
+    evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_send_draft_message_with_rich_text_editor(
+        live_server, page, mocked_authentification_user, evenement
+    )
 
 
 def test_can_add_and_see_message_in_new_tab_without_document(

--- a/tiac/tests/test_investigation_message.py
+++ b/tiac/tests/test_investigation_message.py
@@ -22,6 +22,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_search_in_message_list,
     generic_test_can_see_delete_and_modify_documents_from_draft_message_in_new_tab,
     generic_test_can_send_draft_message_in_new_tab,
+    generic_test_can_send_draft_message_with_rich_text_editor,
     generic_test_can_update_draft_demande_intervention_in_new_tab,
     generic_test_can_update_draft_message_in_new_tab,
     generic_test_can_update_draft_note_in_new_tab,
@@ -46,6 +47,14 @@ def test_can_add_and_see_message_without_document(live_server, page: Page, choic
 def test_can_add_and_see_message_with_rich_text_editor(live_server, page: Page, choice_js_fill):
     evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
     generic_test_can_add_and_see_message_with_rich_text_editor(live_server, page, choice_js_fill, evenement)
+
+
+@override_flag("rich_text_editor", active=True)
+def test_can_send_draft_message_with_rich_text_editor(live_server, page: Page, mocked_authentification_user):
+    evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
+    generic_test_can_send_draft_message_with_rich_text_editor(
+        live_server, page, mocked_authentification_user, evenement
+    )
 
 
 def test_can_add_and_see_message_in_new_tab_without_document(


### PR DESCRIPTION
- Use a custom toolbar instead of the default one, this gives us more control on the way we want to use colors (CSS variables instead of values) and we can name heading levels as we want.
- Allow some specific classes in the editor. This is needed to make sure our own classes are not removed when we update a draft or reply to an existing message. By default Quill will remove all the "extra" markup.
- Make sure we can use the list / ul element