### PR TITLE
Utilisation du tag `and_more_ellipsis_tooltip` sur la liste des évènements et la synthèse de la page détail sur TIAC pour uniformiser avec SV

### DIFF
--- a/tiac/templates/tiac/_investigation_tiac_informations_conclusion.html
+++ b/tiac/templates/tiac/_investigation_tiac_informations_conclusion.html
@@ -1,4 +1,4 @@
-{% load or_empty_value_tag %}
+{% load and_more_ellipsis_tooltip or_empty_value_tag %}
 
 <div class="white-container fr-mt-2w">
     <h2 class="fr-h6">Conclusion</h2>
@@ -7,25 +7,12 @@
             <div class="bold">Conclusion de la suspicion de TIAC</div>
             {{ object.get_suspicion_conclusion_display|or_empty_value_tag }}
 
-            <div class="bold fr-mt-2w">Dangers retenus</div>
-            <div>
-                {% if object.short_conclusion_selected_hazard|length == 0 %}
-                    -
-                {% else %}
-                    {{ object.short_conclusion_selected_hazard.0 }}
-                {% endif %}
-                {% with rest=object.short_conclusion_selected_hazard|slice:"1:" aria_describedby="message-tooltip-dangers}" %}
-                    {% if rest %}
-                        <p class="fr-tag" aria-describedby="{{ aria_describedby }}">+{{ rest|length }}</p>
-                        <span
-                            class="fr-tooltip fr-placement"
-                            id="{{ aria_describedby }}"
-                            role="tooltip"
-                            aria-hidden="true"
-                        >Autres dangers : {{ rest|join:", " }}</span>
-                    {% endif %}
-                {% endwith %}
-            </div>
+            {% with selected_hazard_len=object.short_conclusion_selected_hazard %}
+                <div class="bold fr-mt-2w">Danger{{ selected_hazard_len|pluralize }} retenu{{ selected_hazard_len|pluralize }}</div>
+                <div>
+                    {% and_more_ellipsis_tooltip object.short_conclusion_selected_hazard %}
+                </div>
+            {% endwith %}
         </div>
         <div class="fr-col-6">
             <div class="bold">Commentaire</div>

--- a/tiac/templates/tiac/tiac_list.html
+++ b/tiac/templates/tiac/tiac_list.html
@@ -1,5 +1,5 @@
 {% extends "tiac/base.html" %}
-{% load static etat_tags dsfr_tags widget_tweaks %}
+{% load and_more_ellipsis_tooltip static etat_tags dsfr_tags widget_tweaks %}
 {% block extrahead %}
     <link rel="stylesheet" href="{% static 'core/list.css' %}">
     <link rel="stylesheet" href="{% static 'core/has_sidebar.css' %}">
@@ -87,46 +87,11 @@
                                 <td>{{ evenement.createur }}</td>
                                 <td>{{ evenement.date_publication }}</td>
                                 <td>{{ evenement.last_update|date:"d/m/Y" }}</td>
-                                <td>{{ evenement.etablissement }}
-
-                                    {% if evenement.etablissements|length == 0 %}
-                                        -
-                                    {% else %}
-                                        {{ evenement.etablissements.0 }}
-                                    {% endif %}
-                                    {% with rest=evenement.etablissements|slice:"1:" aria_describedby=evenement.numero|strfmt:"message-tooltip-etablissement-{}" %}
-                                        {% if rest %}
-                                            <p class="fr-tag" aria-describedby="{{ aria_describedby }}">+{{ rest|length }}</p>
-                                            <span
-                                                class="fr-tooltip fr-placement"
-                                                id="{{ aria_describedby }}"
-                                                role="tooltip"
-                                                aria-hidden="true"
-                                            >Autres établissements : {{ rest|join:", " }}</span>
-                                        {% endif %}
-                                    {% endwith %}
-                                </td>
+                                <td>{% and_more_ellipsis_tooltip evenement.etablissements empty_type="table" %}</td>
                                 <td>{{ evenement.nb_sick_persons }}</td>
                                 <td>{{ evenement.type_evenement }}</td>
                                 <td>{{ evenement.conclusion }}</td>
-                                <td>
-                                    {% if evenement.danger_retenu|length == 0 %}
-                                        -
-                                    {% else %}
-                                        {{ evenement.danger_retenu.0 }}
-                                    {% endif %}
-                                    {% with rest=evenement.danger_retenu|slice:"1:" aria_describedby=evenement.numero|strfmt:"message-tooltip-dangers-{}" %}
-                                        {% if rest %}
-                                            <p class="fr-tag" aria-describedby="{{ aria_describedby }}">+{{ rest|length }}</p>
-                                            <span
-                                                class="fr-tooltip fr-placement"
-                                                id="{{ aria_describedby }}"
-                                                role="tooltip"
-                                                aria-hidden="true"
-                                            >Autres dangers : {{ rest|join:", " }}</span>
-                                        {% endif %}
-                                    {% endwith %}
-                                </td>
+                                <td>{% and_more_ellipsis_tooltip evenement.danger_retenu empty_type="table" %}</td>
                                 <td><span class="fr-badge fr-badge--{{evenement.etat|etat_color}} fr-badge--no-icon">{{ evenement.readable_etat }}</span></td>
                             </tr>
                         {% endfor %}


### PR DESCRIPTION
<img width="1422" height="1000" alt="image" src="https://github.com/user-attachments/assets/5c0599dd-4c02-491c-a15d-dd5eaf38b41e" />
<img width="1422" height="800" alt="image" src="https://github.com/user-attachments/assets/8f3d6663-b848-43ed-8229-15df953a05d8" />
