### PR TITLE
Revert partiel de #1898

### DIFF
--- a/sv/templates/sv/evenement_list.html
+++ b/sv/templates/sv/evenement_list.html
@@ -1,5 +1,5 @@
 {% extends 'sv/base.html' %}
-{% load and_more_ellipsis_tooltip etat_tags or_empty_value_tag render_field static %}
+{% load etat_tags or_empty_value_tag render_field static %}
 
 {% block extrahead %}
     <link rel="stylesheet" href="{% static 'sv/evenement_list.css' %}">
@@ -75,7 +75,7 @@
                                     <a href="{{ evenement.get_absolute_url }}" class="fr-link">{{ evenement.numero }}</a>
                                 </td>
                                 <td class="evenement__list-organisme">
-                                    {{ evenement.organisme_nuisible|or_empty_value_tag }}
+                                    {{ evenement.organisme_nuisible|default:"nc." }}
                                 </td>
                                 <td>
                                     {{ evenement.date_publication|date:"d/m/Y" }}
@@ -85,7 +85,21 @@
                                     {{ evenement.createur|truncatechars:30 }}
                                 </td>
                                 <td>
-                                    {% and_more_ellipsis_tooltip evenement.communes_uniques %}
+                                    {% with evenement.communes_uniques|length as nb_communes %}
+                                        {% if nb_communes == 0 %}
+                                            {% empty_value_tag %}
+                                        {% endif %}
+                                        {% if nb_communes <= 3 %}
+                                            {% for commune in evenement.communes_uniques %}
+                                                {{ commune|or_empty_value_tag }}{% if not forloop.last %}, {% endif %}
+                                            {% endfor %}
+                                        {% else %}
+                                            {% for commune in evenement.communes_uniques|slice:":3" %}
+                                                {{ commune|or_empty_value_tag }}{% if not forloop.last %}, {% endif %}
+                                            {% endfor %}
+                                            ... +{{ nb_communes|add:"-3" }}
+                                        {% endif %}
+                                    {% endwith %}
                                 </td>
                                 <td>
                                     <span class="fr-badge fr-badge--{{evenement.etat|etat_color}} fr-badge--no-icon">{{ evenement.readable_etat }}</span>

--- a/sv/tests/test_evenement_list.py
+++ b/sv/tests/test_evenement_list.py
@@ -12,7 +12,7 @@ def test_commune_column_with_multiple_communes(live_server, page: Page):
     LieuFactory(fiche_detection=fiche, commune="Marseille")
 
     page.goto(f"{live_server}{reverse('sv:evenement-liste')}")
-    expect(page.get_by_text("Paris et 2 autres Lyon, Marseille", exact=True)).to_be_visible()
+    expect(page.get_by_text("Paris, Lyon, Marseille", exact=True)).to_be_visible()
 
 
 def test_commune_column_with_some_empty_communes(live_server, page: Page):
@@ -22,8 +22,7 @@ def test_commune_column_with_some_empty_communes(live_server, page: Page):
     LieuFactory(fiche_detection=fiche, commune="")
 
     page.goto(f"{live_server}{reverse('sv:evenement-liste')}")
-
-    expect(page.get_by_text("Paris et 1 autre Lyon", exact=True)).to_be_visible()
+    expect(page.get_by_text("Paris, Lyon", exact=True)).to_be_visible()
 
 
 def test_commune_column_with_empty_commune(live_server, page: Page):
@@ -48,7 +47,7 @@ def test_duplicate_commune_appears_only_once(live_server, page: Page):
 
     page.goto(f"{live_server}{reverse('sv:evenement-liste')}")
 
-    expect(page.get_by_text("La Rochelle et 1 autre Bordeaux", exact=True)).to_be_visible()
+    expect(page.get_by_text("La Rochelle, Bordeaux", exact=True)).to_be_visible()
 
 
 def test_list_ordered_by_most_recent_date_derniere_modification(live_server, page: Page):


### PR DESCRIPTION
#1898 a remplacé toutes les occurences de « nc. » par un texte standard mais est allée un cran trop loin en réutilisant le tag `and_more_ellipsis_tooltip` pour remplacer « nc. » dans le tableau des évènements SV.