### PR TITLE
Improve history for SV

### DIFF
--- a/sv/models/fiches_zone_delimitee.py
+++ b/sv/models/fiches_zone_delimitee.py
@@ -14,7 +14,7 @@ from sv.managers import FicheZoneManager
 from sv.models.models_mixins import WithDerniereMiseAJourMixin
 
 
-@reversion.register()
+@reversion.register(follow=["zones_infestees"])
 class FicheZoneDelimitee(WithDerniereMiseAJourMixin, models.Model):
     class UnitesRayon(TextChoices):
         METRE = UnitesMesure.METRE
@@ -190,3 +190,6 @@ class ZoneInfestee(models.Model):
             with reversion.create_revision():
                 super().save(*args, **kwargs)
             FicheZoneDelimitee.objects.update_date_derniere_mise_a_jour(self.fiche_zone_delimitee.id)
+
+    def __str__(self):
+        return self.nom or "Zone infestée sans nom"

--- a/sv/tests/test_evenement_history.py
+++ b/sv/tests/test_evenement_history.py
@@ -2,10 +2,11 @@ from unittest import mock
 
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
+from playwright.sync_api import expect
 
-from sv.factories import FicheZoneFactory, OrganismeNuisibleFactory
-from sv.models import Evenement, FicheZoneDelimitee, StatutReglementaire
-from sv.tests.test_utils import FicheDetectionFormDomElements, FicheZoneDelimiteeFormPage
+from sv.factories import FicheZoneFactory, OrganismeNuisibleFactory, StructurePreleveuseFactory, ZoneInfesteeFactory
+from sv.models import Evenement, FicheZoneDelimitee, Lieu, Prelevement, StatutReglementaire, StructurePreleveuse
+from sv.tests.test_utils import FicheDetectionFormDomElements, FicheZoneDelimiteeFormPage, PrelevementFormDomElements
 
 
 def test_evenement_history_content(
@@ -128,3 +129,97 @@ def test_evenement_history_content(
     assert len(texts) == len(expected_rows)
     for expected in expected_rows:
         assert expected in texts, f"{expected} not found in {texts}"
+
+
+def test_evenement_history_content_prelevement_shows_even_when_no_modification_on_lieu(
+    live_server, page, form_elements: FicheDetectionFormDomElements, lieu_form_elements, choice_js_fill
+):
+    statut, _ = StatutReglementaire.objects.get_or_create(libelle="organisme quarantaine prioritaire")
+    StructurePreleveuseFactory()
+    organisme_nuisible = OrganismeNuisibleFactory()
+    page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
+    choice_js_fill(
+        page,
+        "#organisme-nuisible .choices__list--single",
+        organisme_nuisible.libelle_court,
+        organisme_nuisible.libelle_court,
+    )
+    page.get_by_label("Statut réglementaire").select_option(value=str(statut.id))
+    form_elements.add_lieu_btn.click()
+    lieu_form_elements.nom_input.fill("Mon lieu")
+    lieu_form_elements.save_btn.click()
+    page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").click()
+
+    evenement = Evenement.objects.get()
+    detection = evenement.detections.get()
+    Lieu.objects.get()
+
+    page.goto(f"{live_server.url}{detection.get_update_url()}")
+    form_elements.add_prelevement_btn.click()
+    prelevement_form_elements = PrelevementFormDomElements(page)
+    prelevement_form_elements.date_prelevement_input.click()
+    prelevement_form_elements.structure_input.select_option(value=str(StructurePreleveuse.objects.first().id))
+    prelevement_form_elements.date_prelevement_input.fill("2021-01-01")
+    prelevement_form_elements.resultat_input(Prelevement.Resultat.DETECTE).click()
+    prelevement_form_elements.type_analyse_input("première intention").click()
+    prelevement_form_elements.save_btn.click()
+    page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").click()
+
+    prelevement = Prelevement.objects.get()
+    page.goto(f"{live_server.url}{detection.get_update_url()}")
+    prelevement_form_elements = PrelevementFormDomElements(page)
+    page.locator(".prelevement-edit-btn").click()
+    page.locator(f"#id_prelevements-{prelevement.id}-numero_echantillon").fill("Test")
+    prelevement_form_elements.save_btn.click()
+    page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").click()
+
+    content_type = ContentType.objects.get_for_model(Evenement)
+    url = reverse("revision-list", kwargs={"content_type": content_type.pk, "pk": evenement.pk})
+    page.goto(f"{live_server.url}{url}")
+
+    creation_text = f"Objet ajouté : Prelevement Prélèvement n° {prelevement.id}"
+    update_text = f"Fiche Détection ({detection.numero}) - Lieu (Mon Lieu) - Prélèvement (Prélèvement N° {prelevement.id}) - N° D'Échantillon"
+
+    expect(page.get_by_text(creation_text, exact=True)).to_be_visible()
+    expect(page.get_by_text(update_text, exact=True)).to_be_visible()
+
+
+def test_evenement_history_content_add_and_edit_zone_infestee(
+    live_server, page, form_elements: FicheDetectionFormDomElements, lieu_form_elements, choice_js_fill
+):
+    statut, _ = StatutReglementaire.objects.get_or_create(libelle="organisme quarantaine prioritaire")
+    organisme_nuisible = OrganismeNuisibleFactory()
+    page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
+    choice_js_fill(
+        page,
+        "#organisme-nuisible .choices__list--single",
+        organisme_nuisible.libelle_court,
+        organisme_nuisible.libelle_court,
+    )
+    page.get_by_label("Statut réglementaire").select_option(value=str(statut.id))
+    page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").click()
+
+    evenement = Evenement.objects.get()
+
+    page.get_by_role("tab", name="Zone").click()
+    page.get_by_role("button", name="Ajouter une zone").click()
+    page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").click()
+
+    fiche_zone = FicheZoneDelimitee.objects.get()
+    form_page = FicheZoneDelimiteeFormPage(page, choice_js_fill)
+    page.goto(f"{live_server.url}{fiche_zone.get_update_url()}")
+    form_page.add_new_zone_infestee(ZoneInfesteeFactory.build(nom="Old value"), ())
+    form_page.submit_update_form()
+
+    form_page.page.goto(f"{live_server.url}{fiche_zone.get_update_url()}")
+    form_page.page.locator("#id_zones_infestees-0-nom").fill("New value")
+    form_page.submit_update_form()
+
+    content_type = ContentType.objects.get_for_model(Evenement)
+    url = reverse("revision-list", kwargs={"content_type": content_type.pk, "pk": evenement.pk})
+    page.goto(f"{live_server.url}{url}")
+
+    creation_text = "Objet ajouté : FicheZoneDelimitee"
+    update_text = f"Fiche Zone Délimitée ({evenement.numero}) - Zone Infestée (Old Value) - Nom De La Zone Infestée"
+    expect(page.get_by_text(creation_text, exact=True)).to_be_visible()
+    expect(page.get_by_text(update_text, exact=True)).to_be_visible()

--- a/sv/view_mixins.py
+++ b/sv/view_mixins.py
@@ -1,9 +1,13 @@
 from collections import defaultdict
+import json
 
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.exceptions import PermissionDenied, ValidationError
 from django.db.models import Prefetch
 from django.http import Http404
+from django.utils import timezone
+import reversion
+from reversion.models import Version
 
 from core.mixins import WithOrderingMixin
 from sv.forms import (
@@ -86,7 +90,19 @@ class WithPrelevementHandlingMixin:
             prelevement_form.fields["lieu"].queryset = allowed_lieux
 
             if prelevement_form.is_valid():
-                prelevement_form.save()
+                with reversion.create_revision():
+                    prelevement = prelevement_form.save()
+                    lieu = prelevement.lieu
+                    reversion.add_to_revision(lieu)
+                    reversion.set_user(self.request.user)
+
+                last_version = Version.objects.get_for_object(lieu).first()
+                if last_version:
+                    data = json.loads(last_version.serialized_data)
+                    if isinstance(data, list) and len(data) > 0:
+                        data[0]["fields"]["_forced_update_trigger"] = str(timezone.now())
+                        last_version.serialized_data = json.dumps(data)
+                        last_version.save(update_fields=["serialized_data"])
             else:
                 error_msg = ""
                 for field, error in prelevement_form.errors.items():


### PR DESCRIPTION
- Add test on a behavior that should already be working on main (test_evenement_history_content_add_and_edit_zone_infestee)
- Make sure we also have the diffs when a prelevement is updated without the lieu being changed. As we only look in the "changed items" if the prelevement is changed without the lieu being changed, the diff prelevement was not shown. Fix this by "forcing" a change in the lieu, this will be seen as changed when comparing two versions, forcing the diff of the prelevement to be shown.