### PR TITLE
Nouveau Treeselect SSA, partie 1 : suppression de l'implémentation TIAC

### DIFF
--- a/tiac/forms.py
+++ b/tiac/forms.py
@@ -14,7 +14,6 @@ from core.form_mixins import WithFreeLinksMixin, WithLatestVersionLocking, js_mo
 from core.forms import BaseCompteRenduDemandeInterventionForm, BaseEtablissementForm
 from core.mixins import WithEtatMixin
 from core.models import Contact, Departement, Structure
-from core.widgets import Treeselect
 from ssa.constants import CategorieDanger, CategorieProduit
 from ssa.models import EvenementProduit
 from tiac.constants import (
@@ -459,17 +458,6 @@ class InvestigationTiacForm(DsfrBaseForm, WithFreeLinksMixin, WithLatestVersionL
                 ("Événement produit", queryset_evenement_produit),
             ],
         )
-
-
-class InvestigationTiacFormNewTreeslect(InvestigationTiacForm):
-    selected_hazard = forms.MultipleChoiceField(label="Dangers retenus", widget=Treeselect)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.fields["selected_hazard"].choices = {
-            "Dangers les plus courants": {"__can_expand__": False, **{it.value: str(it) for it in DANGERS_COURANTS}},
-            "Liste complète des dangers": {"__can_expand__": False, **{it.value: it.label for it in CategorieDanger}},
-        }
 
 
 class RepasSuspectForm(DsfrBaseForm, forms.ModelForm):

--- a/tiac/templates/tiac/investigation.html
+++ b/tiac/templates/tiac/investigation.html
@@ -1,5 +1,5 @@
 {% extends "tiac/base.html" %}
-{% load dsfr_tags widget_tweaks static render_field_with_inline_label waffle_tags %}
+{% load dsfr_tags widget_tweaks static render_field_with_inline_label %}
 
 {% block extrahead %}
     <link rel="stylesheet" href="{% static 'core/_etablissement_card.css' %}">
@@ -225,42 +225,38 @@
                 <div class="fr-grid-row fr-grid-row--gutters fr-my-0">
                     <div class="fr-col-6 needs-required">
                         {% dsfr_form_field form.suspicion_conclusion|set_data:"action:conclusion-form#onSuspicionConclusionChanged:prevent:default"|set_data:"conclusion-form-target:suspicionConclusion" %}
-                        {% flag "new_treeselect" %}
-                            {% dsfr_form_field form.selected_hazard %}
-                        {% else %}
-                            <div id="selected_hazard-treeselect" class="fr-input-group">
-                                {{ form.selected_hazard.label_tag }}
-                                <div
-                                    data-conclusion-form-target="selectedHazardTreeselect"
-                                    data-action="input->conclusion-form#onTreeselectInput update-dom->conclusion-form#onUpdateDom"
-                                ></div>
-                                {{ form.selected_hazard|set_data:"conclusion-form-target:selectedHazardTreeselectInput" }}
-                                <template data-conclusion-form-target="selectedHazardTreeselectHeader">
-                                    <div class="categorie-danger-header">
-                                        <div class="fr-ml-1v">Dangers les plus courants</div>
-                                        {% for danger in form.common_danger %}
-                                            <div
-                                                class="treeselect-list__item"
-                                                level="0"
-                                                group="false"
-                                                data-action="mousedown->conclusion-form#onShortcut:prevent:stop"
+                        <div id="selected_hazard-treeselect" class="fr-input-group">
+                            {{ form.selected_hazard.label_tag }}
+                            <div
+                                data-conclusion-form-target="selectedHazardTreeselect"
+                                data-action="input->conclusion-form#onTreeselectInput update-dom->conclusion-form#onUpdateDom"
+                            ></div>
+                            {{ form.selected_hazard|set_data:"conclusion-form-target:selectedHazardTreeselectInput" }}
+                            <template data-conclusion-form-target="selectedHazardTreeselectHeader">
+                                <div class="categorie-danger-header">
+                                    <div class="fr-ml-1v">Dangers les plus courants</div>
+                                    {% for danger in form.common_danger %}
+                                        <div
+                                            class="treeselect-list__item"
+                                            level="0"
+                                            group="false"
+                                            data-action="mousedown->conclusion-form#onShortcut:prevent:stop"
+                                        >
+                                            <input
+                                                type="checkbox"
+                                                id="shortcut_{{ forloop.counter0 }}"
+                                                class="treeselect-list__item-checkbox-container"
                                             >
-                                                <input
-                                                    type="checkbox"
-                                                    id="shortcut_{{ forloop.counter0 }}"
-                                                    class="treeselect-list__item-checkbox-container"
-                                                >
-                                                <label
-                                                    class="treeselect-list__item-label shortcut"
-                                                    for="shortcut_{{ forloop.counter0 }}"
-                                                >{{ danger }}</label>
-                                            </div>
-                                        {% endfor %}
-                                        <div class="fr-ml-1v">Liste complète des dangers</div>
-                                    </div>
-                                </template>
-                            </div>
-                        {% endflag %}
+                                            <label
+                                                class="treeselect-list__item-label shortcut"
+                                                for="shortcut_{{ forloop.counter0 }}"
+                                            >{{ danger }}</label>
+                                        </div>
+                                    {% endfor %}
+                                    <div class="fr-ml-1v">Liste complète des dangers</div>
+                                </div>
+                            </template>
+                        </div>
                     </div>
                     <div class="fr-col-6 conclusion-comment">
                         {% dsfr_form_field form.conclusion_comment|remove_attr:"cols"|remove_attr:"rows" %}

--- a/tiac/views.py
+++ b/tiac/views.py
@@ -15,7 +15,6 @@ from django.views.generic import CreateView, DetailView, ListView, UpdateView
 from django.views.generic.edit import ModelFormMixin, ProcessFormView
 from docxtpl import DocxTemplate
 from reversion.models import Version
-from waffle import flag_is_active
 
 from core.audit import audit_log
 from core.diffs import create_manual_version
@@ -47,7 +46,7 @@ from tiac.tasks import export_tiac_task
 from .constants import DangersSyndromiques, EvenementFollowUp
 from .display import DisplayItem
 from .filters import TiacFilter
-from .forms import EvenementSimpleTransferForm, InvestigationTiacFormNewTreeslect
+from .forms import EvenementSimpleTransferForm
 from .formsets import (
     AlimentFormSet,
     AnalysesAlimentairesFormSet,
@@ -371,11 +370,6 @@ class InvestigationTiacBaseView(
     @cached_property
     def analyse_alimentaire_formset(self):
         return AnalysesAlimentairesFormSet(**self.get_formset_kwargs())
-
-    def get_form_class(self):
-        if flag_is_active(self.request, "new_treeselect"):
-            return InvestigationTiacFormNewTreeslect
-        return super().get_form_class()
 
     def get_formset_kwargs(self, **kwargs):
         result = kwargs.copy()


### PR DESCRIPTION
Comme décidé en réunion d'équipe il y a 2 semaines, la page produit SSA est un meilleur endroit pour implémenter le nouveau Treeselect. Cette PR est la première partie de la découpe de #1901. Elle supprime simplement l'implémentation actuelle du nouveau treeselect sur TIAC.