### PR TITLE
Fix PDF preview for Brave

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -14,6 +14,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
+from django.core.files.storage import default_storage
 from django.db import models, transaction
 from django.forms import BaseModelFormSet, Media
 from django.forms.utils import RenderableMixin
@@ -124,6 +125,13 @@ class WithDocumentListInContextMixin:
         allowed_document_types = self.get_object().get_allowed_document_types()
         for document in document_filter.qs:
             document.edit_form = DocumentEditForm(instance=document, allowed_document_types=allowed_document_types)
+            if document.can_pdf_be_viewed:
+                document.file.pdf_url = default_storage.url(
+                    document.file.name,
+                    parameters={
+                        "ResponseContentDisposition": "inline",
+                    },
+                )
         context["document_count"] = documents.exclude(is_deleted=True).count()
         context["document_filter"] = document_filter
         return context

--- a/core/templates/core/_documents.html
+++ b/core/templates/core/_documents.html
@@ -129,7 +129,7 @@
                                                                                         <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-document-image-table-{{ document.pk }}">Fermer</button>
                                                                                     </div>
                                                                                     <div class="fr-modal__content pdf-modal">
-                                                                                        <object data="" data-src="{{ document.file.url }}" data-object-lazy-load-target="objectTag" type="application/pdf" width="100%" height="100%">
+                                                                                        <object data="" data-src="{{ document.file.pdf_url }}" data-object-lazy-load-target="objectTag" type="application/pdf" width="100%" height="100%">
                                                                                             Votre navigateur ne supporte pas l'aperçu des fichiers PDF.
                                                                                         </object>
                                                                                     </div>

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -315,6 +315,10 @@ SECURE_CSP = {
         "s3.rbx.io.cloud.ovh.net",
         "s3.eu-west-par.io.cloud.ovh.net",
     ),
+    "frame-src": (
+        "s3.rbx.io.cloud.ovh.net",
+        "s3.eu-west-par.io.cloud.ovh.net",
+    ),
     "connect-src": (
         CSP.SELF,
         "geo.api.gouv.fr",
@@ -328,6 +332,7 @@ SECURE_CSP = {
 if DEBUG:
     SECURE_CSP["img-src"] = (CSP.SELF, "data:", "127.0.0.1:9000")
     SECURE_CSP["object-src"] = (CSP.SELF, "data:", "127.0.0.1:9000")
+    SECURE_CSP["frame-src"] = (CSP.SELF, "data:", "127.0.0.1:9000")
 
 if ENVIRONMENT != "test":
     SENTRY_REPORT_URL = env("SENTRY_REPORT_URL", None)


### PR DESCRIPTION
- Force the storage to respond with an inline file to make sure the browser does not download the file
- Change CSP policies