### PR TITLE
Ajout d'un timeout aux requêtes OIDC

### DIFF
--- a/seves/settings.py
+++ b/seves/settings.py
@@ -231,6 +231,7 @@ OIDC_CALLBACK_CLASS = "core.auth_views.CustomOIDCAuthenticationCallbackView"
 OIDC_CREATE_USER = False
 LOGIN_REDIRECT_URL = "/"
 OIDC_RP_SIGN_ALGO = "RS256"
+OIDC_TIMEOUT = env("OIDC_RP_TIMEOUT", int, default=20)
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 


### PR DESCRIPTION
De temps en temps on a un worker qui se fait tuer par gunicorn au cours d'une transaction OIDC. Mon hypothèse est que le backend OIDC met trop de temps à répondre et `requests` attend indéfiniement. Mais gunicorn a lui-même un timeout après lequel il SIGABRT le worker. Ça se voit dans Sentry par des exceptions `SystemExit`.  Cette PR rajoute un timeout pour gérer un peu plus gracieusement ce cas. Django répondra juste une 500 après un timeout de `requests` au lieu de juste mourir, ce qui est un peu plus gracieux. Le timeout est configuré à 20 secondes par défaut ce qui laisse largement le temps au backend OIDC pour répondre. 