### PR TITLE
Allow to download documents in Zip archive

### DIFF
--- a/core/factories.py
+++ b/core/factories.py
@@ -141,6 +141,10 @@ class DocumentFactory(DjangoModelFactory):
         return Agent.objects.get(user__email="test@example.com")
 
     @factory.lazy_attribute
+    def is_deleted(self):
+        return False
+
+    @factory.lazy_attribute
     def created_by_structure(self):
         return Structure.objects.get(libelle="Structure Test")
 

--- a/core/mixins.py
+++ b/core/mixins.py
@@ -125,6 +125,8 @@ class WithDocumentListInContextMixin:
         for document in document_filter.qs:
             document.edit_form = DocumentEditForm(instance=document, allowed_document_types=allowed_document_types)
         context["document_count"] = documents.exclude(is_deleted=True).count()
+        downloadable_documents = [d for d in document_filter.qs if (d.is_deleted is False and d.is_infected is False)]
+        context["document_count_for_download"] = len(downloadable_documents)
         context["document_filter"] = document_filter
         return context
 

--- a/core/pages.py
+++ b/core/pages.py
@@ -337,6 +337,10 @@ class WithDocumentsPage(BaseDocumentPage):
     def add_document_button(self):
         return self.page.get_by_role("button", name="Ajouter des documents")
 
+    @property
+    def download_documents_zip(self):
+        return self.page.get_by_test_id("document-download-zip")
+
     def open_document_tab(self):
         if not self.page.locator(self.container_id).is_visible():
             self.page.get_by_test_id("documents").click()

--- a/core/static/core/message.css
+++ b/core/static/core/message.css
@@ -9,6 +9,10 @@
     word-break: break-all;
     background-color: var(--background-default-grey);
 }
+.zip-download {
+    display: flex;
+    justify-content: center;
+}
 .message-document-container .fr-btn--tertiary {
     margin-bottom: 0;
 }

--- a/core/templates/core/_documents.html
+++ b/core/templates/core/_documents.html
@@ -1,3 +1,4 @@
+{% load waffle_tags %}
 <div class="fr-container--fluid fr-mb-4w" id="documents">
     <div class="fr-grid-row">
         <div class="fr-col-12 fr-col-md-6">
@@ -9,18 +10,36 @@
             </form>
 
         </div>
-        {% if can_add_document %}
+        {% if document_count_for_download > 1 or can_add_document %}
             <div class="fr-col-12 fr-col-md-6 fr-flex--align-end">
                 <div class="fr-btns-group fr-btns-group--icon-left fr-btns-group--right fr-btns-group--inline-md">
-                    <button
-                        class="fr-btn fr-btn--secondary fr-icon-add-circle-line"
-                        type="button"
-                        aria-controls="document-modal"
-                        data-fr-opened="false"
-                        data-testid="add-document-btn"
-                    >
-                        Ajouter des documents
-                    </button>
+                    {% flag "download_zip" %}
+                        {% if document_count_for_download > 1  %}
+                            <form method="post" action="{% url 'document-zip' %}?{{ request.GET.urlencode }}">
+                                {% csrf_token %}
+                                <input type="hidden" name="content_type" value="{{ content_type.pk }}">
+                                <input type="hidden" name="pk" value="{{ object.pk }}">
+                                <button
+                                    class="fr-btn fr-btn--secondary fr-icon-download-line"
+                                    type="submit"
+                                    data-testid="document-download-zip"
+                                >
+                                    Télécharger les {{ document_count_for_download}} documents (.zip)
+                                </button>
+                            </form>
+                        {% endif %}
+                    {% endflag %}
+                    {% if can_add_document %}
+                        <button
+                            class="fr-btn fr-btn--secondary fr-icon-add-circle-line"
+                            type="button"
+                            aria-controls="document-modal"
+                            data-fr-opened="false"
+                            data-testid="add-document-btn"
+                        >
+                            Ajouter des documents
+                        </button>
+                    {% endif %}
                 </div>
             </div>
         {% endif %}

--- a/core/templates/core/message_detail.html
+++ b/core/templates/core/message_detail.html
@@ -7,7 +7,7 @@
     {% endflag %}
 {% endblock %}
 {% block content %}
-    {% for document in message.documents.all %}
+    {% for document in documents %}
         {% if document.can_be_viewed or document.can_pdf_be_viewed %}
             <dialog aria-labelledby="fr-modal-title-modal-document-{{ document.pk }}" role="dialog" id="fr-document-image-table-{{ document.pk }}" class="fr-modal" data-fr-concealing-backdrop="true">
                 <div class="fr-container fr-container--fluid fr-container-md">
@@ -96,9 +96,19 @@
                             </div>
                             <div class="fr-col-4 white-container">
                                 <h5>Documents</h5>
-                                {% if message.documents.all %}
+                                {% if documents %}
                                     <p class="fr-hint-text">Pièces jointes. Retrouvez l'ensemble des documents dans l'onglet "Documents" du bloc de suivi.</p>
-                                    {% for document in message.documents.all %}
+                                    {% flag "download_zip" %}
+                                        {% if document_count_for_download > 1 %}
+                                            <form method="post" action="{% url 'document-zip' %}" class="zip-download">
+                                                {% csrf_token %}
+                                                <input type="hidden" name="content_type" value="{{ content_type.pk }}">
+                                                <input type="hidden" name="pk" value="{{ message.pk }}">
+                                                <button type="submit" class="fr-btn fr-icon-download-line fr-btn--icon-left fr-mb-4v fr-btn--secondary">Télécharger les pièces jointes (zip)</button>
+                                            </form>
+                                        {% endif %}
+                                    {% endflag %}
+                                    {% for document in documents %}
                                         <div class="fr-card--shadow fr-mb-1w">
                                             <div class="fr-px-2w fr-py-1w message-document-container">
                                                 {% if document.is_deleted %}

--- a/core/tests/generic_tests/documents.py
+++ b/core/tests/generic_tests/documents.py
@@ -1,5 +1,6 @@
 from threading import Lock
 from unittest.mock import patch
+import zipfile
 
 from django.core.exceptions import ValidationError
 from django.forms import FileField, Form
@@ -7,7 +8,7 @@ from django.urls import reverse
 from playwright.sync_api import Page, Route, expect
 import pytest
 
-from core.factories import DocumentFactory
+from core.factories import DocumentFactory, MessageFactory, StructureFactory
 from core.models import Document
 from core.pages import WithDocumentsPage
 from seves import settings
@@ -198,3 +199,64 @@ def generic_test_document_modal_front_behavior(live_server, page: Page, content_
 
     content_object.refresh_from_db()
     assert content_object.documents.count() == previous + 3
+
+
+def generic_test_can_download_zip_of_documents(live_server, page: Page, object):
+    expected_1 = DocumentFactory(content_object=object)
+    expected_2 = DocumentFactory(content_object=object)
+    expected_3 = DocumentFactory(content_object=object)
+    infected = DocumentFactory(content_object=object)
+    Document.objects.filter(pk=infected.pk).update(is_infected=True)
+    to_be_scanned = DocumentFactory(content_object=object)
+    Document.objects.filter(pk=to_be_scanned.pk).update(is_infected=None)
+    DocumentFactory(content_object=object, is_deleted=True)
+
+    message = MessageFactory(content_object=object)
+    expected_4 = DocumentFactory(content_object=message)
+
+    page.goto(f"{live_server.url}{object.get_absolute_url()}")
+    document_page = WithDocumentsPage(page)
+    document_page.open_document_tab()
+    with page.expect_download() as download_info:
+        document_page.download_documents_zip.click()
+
+    download = download_info.value
+    assert download.suggested_filename.endswith(".zip") is True
+    download_path = download.path()
+    with zipfile.ZipFile(download_path, "r") as z:
+        files = z.namelist()
+        expected = [expected_1.file.name, expected_2.file.name, expected_3.file.name, expected_4.file.name]
+        expected = sorted([e.replace("documents/", "") for e in expected])
+        assert sorted(files) == expected, f"Expected {expected} and got {files}"
+
+
+def generic_test_can_download_zip_of_documents_with_filter(live_server, page: Page, object):
+    structure = StructureFactory()
+    document_1 = DocumentFactory(content_object=object, created_by_structure=structure)
+    document_2 = DocumentFactory(content_object=object, created_by_structure=structure)
+    DocumentFactory(content_object=object)
+
+    page.goto(
+        f"{live_server.url}{object.get_absolute_url()}?created_by_structure={structure.pk}#tabpanel-documents-panel"
+    )
+    document_page = WithDocumentsPage(page)
+    document_page.open_document_tab()
+    expect(page.get_by_text("Télécharger les 2 documents (.zip)"))
+    with page.expect_download() as download_info:
+        document_page.download_documents_zip.click()
+
+    download = download_info.value
+    assert download.suggested_filename.endswith(".zip") is True
+    download_path = download.path()
+    with zipfile.ZipFile(download_path, "r") as z:
+        files = z.namelist()
+        expected = [document_1.file.name, document_2.file.name]
+        expected = sorted([e.replace("documents/", "") for e in expected])
+        assert sorted(files) == expected, f"Expected {expected} and got {files}"
+
+
+def generic_test_cant_download_zip_when_no_documents(live_server, page: Page, object):
+    page.goto(f"{live_server.url}{object.get_absolute_url()}")
+    document_page = WithDocumentsPage(page)
+    document_page.open_document_tab()
+    expect(document_page.download_documents_zip).not_to_be_visible()

--- a/core/tests/generic_tests/messages.py
+++ b/core/tests/generic_tests/messages.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from typing import Literal
+import zipfile
 
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -8,7 +9,7 @@ from playwright.sync_api import Page, expect
 
 from core.constants import AC_STRUCTURE, MUS_STRUCTURE
 from core.factories import ContactAgentFactory, ContactStructureFactory, DocumentFactory, MessageFactory
-from core.models import Contact, FinSuiviContact, Message, Structure
+from core.models import Contact, Document, FinSuiviContact, Message, Structure
 from core.pages import CreateMessagePage, ListOfMessagesPage, UpdateMessagePage
 
 
@@ -892,3 +893,28 @@ def generic_test_can_preview_image_from_message_details(live_server, page: Page,
     new_page.locator(".fr-icon-eye-line").click()
     img = new_page.locator('img[src*="_test.png"]')
     expect(img).to_be_visible()
+
+
+def generic_test_can_download_zip_attachments_of_message(live_server, page: Page, object):
+    message = MessageFactory(content_object=object)
+    expected_1 = DocumentFactory(content_object=message)
+    expected_2 = DocumentFactory(content_object=message)
+    _not_expected_1 = DocumentFactory(content_object=MessageFactory(content_object=object))
+    _not_expected_2 = DocumentFactory(content_object=object)
+    _not_expected_3 = DocumentFactory(content_object=message, is_deleted=True)
+    not_expected_4 = DocumentFactory(content_object=message)
+    Document.objects.filter(pk=not_expected_4.pk).update(is_infected=True)
+
+    page.goto(f"{live_server.url}{message.get_absolute_url()}")
+
+    with page.expect_download() as download_info:
+        page.get_by_role("button", name="Télécharger les pièces jointes (zip)").click()
+
+    download = download_info.value
+    assert download.suggested_filename.endswith(".zip") is True
+    download_path = download.path()
+    with zipfile.ZipFile(download_path, "r") as z:
+        files = z.namelist()
+        expected = [expected_1.file.name, expected_2.file.name]
+        expected = sorted([e.replace("documents/", "") for e in expected])
+        assert sorted(files) == expected, f"Expected {expected} and got {files}"

--- a/core/urls.py
+++ b/core/urls.py
@@ -20,6 +20,7 @@ from .views import (
     RevisionsListView,
     SoftDeleteView,
     StructureAddView,
+    ZipDownloadView,
     sirene_api,
 )
 
@@ -118,6 +119,11 @@ urlpatterns = [
         "revisions/<int:content_type>/<int:pk>/",
         RevisionsListView.as_view(),
         name="revision-list",
+    ),
+    path(
+        "documents/zip/",
+        ZipDownloadView.as_view(),
+        name="document-zip",
     ),
     path(
         "message/<int:pk>/",

--- a/core/views.py
+++ b/core/views.py
@@ -1,6 +1,8 @@
 import contextlib
+import io
 import json
 import logging
+import zipfile
 
 from django.conf import settings
 from django.contrib import messages
@@ -23,6 +25,7 @@ from reversion.models import Version
 
 from core.diffs import CompareMixin, Diff, get_diff_from_comment_version
 
+from .filters import DocumentFilter
 from .forms import (
     AgentAddForm,
     BasicMessageForm,
@@ -279,7 +282,6 @@ class MessageDetailsView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTest
             "recipients_copy__agent",
             "recipients_copy__structure",
             "recipients_copy__agent__structure",
-            "documents",
         )
 
     def dispatch(self, request, *args, **kwargs):
@@ -297,6 +299,10 @@ class MessageDetailsView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTest
         context = super().get_context_data(**kwargs)
         context["can_download_document"] = self.fiche.can_download_document(self.request.user)
         context["can_reply_to"] = self.message.can_reply_to(self.request.user)
+        context["content_type"] = ContentType.objects.get_for_model(self.message)
+        context["documents"] = self.message.documents.all()
+        downloadable_documents = [d for d in context["documents"] if (d.is_deleted is False and d.is_infected is False)]
+        context["document_count_for_download"] = len(downloadable_documents)
         return context
 
 
@@ -616,3 +622,46 @@ class RevisionsListView(UserPassesTestMixin, CompareMixin, ListView):
 
         context["patches"] = patches
         return context
+
+
+class ZipDownloadView(UserPassesTestMixin, View):
+    def dispatch(self, request, *args, **kwargs):
+        content_type = ContentType.objects.get(id=request.POST["content_type"])
+        self.object = content_type.model_class().objects.get(pk=request.POST["pk"])
+        if isinstance(self.object, Message):
+            self.fiche_object = self.object.content_object
+            self.is_message = True
+        else:
+            self.fiche_object = self.object
+            self.is_message = False
+        return super().dispatch(request, *args, **kwargs)
+
+    def test_func(self):
+        return self.fiche_object.can_user_access(self.request.user)
+
+    def post(self, request, *args, **kwargs):
+        if self.is_message:
+            queryset = self.object.documents.all()
+        else:
+            documents = Document.objects.for_fiche(self.object)
+            queryset = DocumentFilter(self.request.GET, queryset=documents).qs
+
+        queryset = queryset.exclude(is_deleted=True).exclude(is_infected=None)
+
+        buffer = io.BytesIO()
+
+        with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+            for obj in queryset:
+                f = obj.file
+                f.open("rb")
+
+                with zip_file.open(f.name.split("/")[-1], "w") as dest:
+                    for chunk in f.chunks():
+                        dest.write(chunk)
+
+                f.close()
+        buffer.seek(0)
+
+        response = HttpResponse(buffer.getvalue(), content_type="application/zip")
+        response["Content-Disposition"] = f'attachment; filename="documents_{str(self.object)}.zip"'
+        return response

--- a/ssa/tests/test_evenement_produit_documents.py
+++ b/ssa/tests/test_evenement_produit_documents.py
@@ -1,9 +1,13 @@
 from playwright.sync_api import Page, expect
+from waffle.testutils import override_flag
 
 from core.factories import DocumentFactory
 from core.pages import WithDocumentsPage
 from core.tests.generic_tests.documents import (
     generic_test_can_add_document_to_evenement,
+    generic_test_can_download_zip_of_documents,
+    generic_test_can_download_zip_of_documents_with_filter,
+    generic_test_cant_download_zip_when_no_documents,
     generic_test_cant_see_document_type_from_other_app,
     generic_test_cant_see_document_type_from_other_app_when_editing_document,
     generic_test_document_modal_front_behavior,
@@ -67,3 +71,21 @@ def test_document_modal_xss_mitigated(live_server, page: Page):
 def test_document_modal_front_behavior(live_server, page: Page):
     evenement = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
     generic_test_document_modal_front_behavior(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_of_documents(live_server, page: Page):
+    evenement = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    generic_test_can_download_zip_of_documents(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_of_documents_with_filter(live_server, page: Page):
+    evenement = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    generic_test_can_download_zip_of_documents_with_filter(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_cant_download_zip_when_no_documents(live_server, page: Page):
+    evenement = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    generic_test_cant_download_zip_when_no_documents(live_server, page, evenement)

--- a/ssa/tests/test_evenement_produit_message.py
+++ b/ssa/tests/test_evenement_produit_message.py
@@ -17,6 +17,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_add_see_message_in_new_tab_without_document_in_draft,
     generic_test_can_delete_my_own_draft_message,
     generic_test_can_delete_my_own_message,
+    generic_test_can_download_zip_attachments_of_message,
     generic_test_can_only_see_own_document_types_in_message_form,
     generic_test_can_preview_image_from_message_details,
     generic_test_can_reply_to_message,
@@ -134,6 +135,12 @@ def test_message_ordering(live_server, page: Page, mocked_authentification_user)
 def test_can_preview_image_from_message_details(live_server, page: Page, mocked_authentification_user):
     evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
     generic_test_can_preview_image_from_message_details(live_server, page, evenement_produit)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_attachments_of_message(live_server, page: Page, mocked_authentification_user):
+    evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
+    generic_test_can_download_zip_attachments_of_message(live_server, page, evenement_produit)
 
 
 def test_can_update_draft_note_in_new_tab(

--- a/ssa/tests/test_investigation_cas_humain_documents.py
+++ b/ssa/tests/test_investigation_cas_humain_documents.py
@@ -1,9 +1,13 @@
 from playwright.sync_api import Page, expect
+from waffle.testutils import override_flag
 
 from core.factories import DocumentFactory
 from core.pages import WithDocumentsPage
 from core.tests.generic_tests.documents import (
     generic_test_can_add_document_to_evenement,
+    generic_test_can_download_zip_of_documents,
+    generic_test_can_download_zip_of_documents_with_filter,
+    generic_test_cant_download_zip_when_no_documents,
     generic_test_cant_see_document_type_from_other_app,
     generic_test_cant_see_document_type_from_other_app_when_editing_document,
     generic_test_document_modal_front_behavior,
@@ -68,3 +72,21 @@ def test_document_modal_xss_mitigated(live_server, page: Page):
 def test_document_modal_front_behavior(live_server, page: Page):
     evenement = InvestigationCasHumainFactory(etat=EvenementInvestigationCasHumain.Etat.EN_COURS)
     generic_test_document_modal_front_behavior(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_of_documents(live_server, page: Page):
+    evenement = InvestigationCasHumainFactory(etat=EvenementInvestigationCasHumain.Etat.EN_COURS)
+    generic_test_can_download_zip_of_documents(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_of_documents_with_filter(live_server, page: Page):
+    evenement = InvestigationCasHumainFactory(etat=EvenementInvestigationCasHumain.Etat.EN_COURS)
+    generic_test_can_download_zip_of_documents_with_filter(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_cant_download_zip_when_no_documents(live_server, page: Page):
+    evenement = InvestigationCasHumainFactory(etat=EvenementInvestigationCasHumain.Etat.EN_COURS)
+    generic_test_cant_download_zip_when_no_documents(live_server, page, evenement)

--- a/ssa/tests/test_investigation_cas_humain_message.py
+++ b/ssa/tests/test_investigation_cas_humain_message.py
@@ -16,6 +16,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_add_see_message_in_new_tab_without_document_in_draft,
     generic_test_can_delete_my_own_draft_message,
     generic_test_can_delete_my_own_message,
+    generic_test_can_download_zip_attachments_of_message,
     generic_test_can_only_see_own_document_types_in_message_form,
     generic_test_can_preview_image_from_message_details,
     generic_test_can_reply_to_message,
@@ -104,6 +105,12 @@ def test_message_ordering(live_server, page: Page, mocked_authentification_user)
 def test_can_preview_image_from_message_details(live_server, page: Page, mocked_authentification_user):
     evenement = InvestigationCasHumainFactory(etat=EvenementInvestigationCasHumain.Etat.EN_COURS)
     generic_test_can_preview_image_from_message_details(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_attachments_of_message(live_server, page: Page, mocked_authentification_user):
+    evenement = InvestigationCasHumainFactory(etat=EvenementInvestigationCasHumain.Etat.EN_COURS)
+    generic_test_can_download_zip_attachments_of_message(live_server, page, evenement)
 
 
 def test_can_update_draft_note_in_new_tab(

--- a/sv/tests/test_evenement_documents.py
+++ b/sv/tests/test_evenement_documents.py
@@ -9,12 +9,16 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from playwright.sync_api import Page, expect
 import pytest
+from waffle.testutils import override_flag
 
 from core.factories import DocumentFactory, MessageFactory, StructureFactory
 from core.models import Document, Message, Structure
 from core.pages import WithDocumentsPage
 from core.tests.generic_tests.documents import (
     generic_test_can_add_document_to_evenement,
+    generic_test_can_download_zip_of_documents,
+    generic_test_can_download_zip_of_documents_with_filter,
+    generic_test_cant_download_zip_when_no_documents,
     generic_test_cant_see_document_type_from_other_app,
     generic_test_cant_see_document_type_from_other_app_when_editing_document,
     generic_test_document_modal_front_behavior,
@@ -666,3 +670,21 @@ def test_document_modal_xss_mitigated(live_server, page: Page):
 def test_document_modal_front_behavior(live_server, page: Page):
     evenement = EvenementFactory()
     generic_test_document_modal_front_behavior(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_of_documents(live_server, page: Page):
+    evenement = EvenementFactory()
+    generic_test_can_download_zip_of_documents(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_of_documents_with_filter(live_server, page: Page):
+    evenement = EvenementFactory()
+    generic_test_can_download_zip_of_documents_with_filter(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_cant_download_zip_when_no_documents(live_server, page: Page):
+    evenement = EvenementFactory()
+    generic_test_cant_download_zip_when_no_documents(live_server, page, evenement)

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -29,6 +29,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_add_see_message_in_new_tab_without_document_in_draft,
     generic_test_can_delete_my_own_draft_message,
     generic_test_can_delete_my_own_message,
+    generic_test_can_download_zip_attachments_of_message,
     generic_test_can_only_see_own_document_types_in_message_form,
     generic_test_can_preview_image_from_message_details,
     generic_test_can_reply_to_message,
@@ -1018,6 +1019,12 @@ def test_message_ordering(live_server, page: Page, mocked_authentification_user)
 def test_can_preview_image_from_message_details(live_server, page: Page, mocked_authentification_user):
     evenement = EvenementFactory()
     generic_test_can_preview_image_from_message_details(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_attachments_of_message(live_server, page: Page, mocked_authentification_user):
+    evenement = EvenementFactory()
+    generic_test_can_download_zip_attachments_of_message(live_server, page, evenement)
 
 
 def test_can_update_draft_message_in_new_tab(

--- a/sv/tests/test_evenement_performance_details.py
+++ b/sv/tests/test_evenement_performance_details.py
@@ -10,7 +10,7 @@ from sv.factories import (
     ZoneInfesteeFactory,
 )
 
-BASE_NUM_QUERIES = 25  # Please note a first call is made without assertion to warm up any possible cache
+BASE_NUM_QUERIES = 26  # Please note a first call is made without assertion to warm up any possible cache
 
 
 @pytest.mark.django_db

--- a/tiac/tests/test_evenement_simple_documents.py
+++ b/tiac/tests/test_evenement_simple_documents.py
@@ -1,7 +1,11 @@
 from playwright.sync_api import Page
+from waffle.testutils import override_flag
 
 from core.tests.generic_tests.documents import (
     generic_test_can_add_document_to_evenement,
+    generic_test_can_download_zip_of_documents,
+    generic_test_can_download_zip_of_documents_with_filter,
+    generic_test_cant_download_zip_when_no_documents,
     generic_test_cant_see_document_type_from_other_app,
     generic_test_cant_see_document_type_from_other_app_when_editing_document,
     generic_test_document_modal_front_behavior,
@@ -38,3 +42,21 @@ def test_document_modal_xss_mitigated(live_server, page: Page):
 def test_document_modal_front_behavior(live_server, page: Page):
     evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
     generic_test_document_modal_front_behavior(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_of_documents(live_server, page: Page):
+    evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_download_zip_of_documents(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_of_documents_with_filter(live_server, page: Page):
+    evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_download_zip_of_documents_with_filter(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_cant_download_zip_when_no_documents(live_server, page: Page):
+    evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_cant_download_zip_when_no_documents(live_server, page, evenement)

--- a/tiac/tests/test_evenement_simple_message.py
+++ b/tiac/tests/test_evenement_simple_message.py
@@ -16,6 +16,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_add_see_message_in_new_tab_without_document_in_draft,
     generic_test_can_delete_my_own_draft_message,
     generic_test_can_delete_my_own_message,
+    generic_test_can_download_zip_attachments_of_message,
     generic_test_can_only_see_own_document_types_in_message_form,
     generic_test_can_preview_image_from_message_details,
     generic_test_can_reply_to_message,
@@ -134,6 +135,12 @@ def test_message_ordering(live_server, page: Page, mocked_authentification_user)
 def test_can_preview_image_from_message_details(live_server, page: Page, mocked_authentification_user):
     evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
     generic_test_can_preview_image_from_message_details(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_attachments_of_message(live_server, page: Page, mocked_authentification_user):
+    evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
+    generic_test_can_download_zip_attachments_of_message(live_server, page, evenement)
 
 
 def test_can_update_draft_note_in_new_tab(

--- a/tiac/tests/test_investigation_documents.py
+++ b/tiac/tests/test_investigation_documents.py
@@ -1,7 +1,11 @@
 from playwright.sync_api import Page
+from waffle.testutils import override_flag
 
 from core.tests.generic_tests.documents import (
     generic_test_can_add_document_to_evenement,
+    generic_test_can_download_zip_of_documents,
+    generic_test_can_download_zip_of_documents_with_filter,
+    generic_test_cant_download_zip_when_no_documents,
     generic_test_cant_see_document_type_from_other_app,
     generic_test_cant_see_document_type_from_other_app_when_editing_document,
     generic_test_document_modal_front_behavior,
@@ -38,3 +42,21 @@ def test_document_modal_xss_mitigated(live_server, page: Page):
 def test_document_modal_front_behavior(live_server, page: Page):
     evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
     generic_test_document_modal_front_behavior(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_of_documents(live_server, page: Page):
+    evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
+    generic_test_can_download_zip_of_documents(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_of_documents_with_filter(live_server, page: Page):
+    evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
+    generic_test_can_download_zip_of_documents_with_filter(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_cant_download_zip_when_no_documents(live_server, page: Page):
+    evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
+    generic_test_cant_download_zip_when_no_documents(live_server, page, evenement)

--- a/tiac/tests/test_investigation_message.py
+++ b/tiac/tests/test_investigation_message.py
@@ -17,6 +17,7 @@ from core.tests.generic_tests.messages import (
     generic_test_can_add_see_message_in_new_tab_without_document_in_draft,
     generic_test_can_delete_my_own_draft_message,
     generic_test_can_delete_my_own_message,
+    generic_test_can_download_zip_attachments_of_message,
     generic_test_can_only_see_own_document_types_in_message_form,
     generic_test_can_preview_image_from_message_details,
     generic_test_can_reply_to_message,
@@ -140,6 +141,12 @@ def test_message_ordering(live_server, page: Page, mocked_authentification_user)
 def test_can_preview_image_from_message_details(live_server, page: Page, mocked_authentification_user):
     evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
     generic_test_can_preview_image_from_message_details(live_server, page, evenement)
+
+
+@override_flag("download_zip", active=True)
+def test_can_download_zip_attachments_of_message(live_server, page: Page, mocked_authentification_user):
+    evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
+    generic_test_can_download_zip_attachments_of_message(live_server, page, evenement)
 
 
 def test_can_update_draft_message_in_new_tab(


### PR DESCRIPTION
On the list of documents and on the message details allow to download of zip archive containing all the documents (except deleted and infected documents).