### PR TITLE
Désactiver les avertissements Python dans la CI pour améliorer la lisibilité

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Run tests
         run: >-
           pytest
+          --disable-warnings
           --tracing=retain-on-failure
           --splits ${{ strategy.job-total }}
           --group ${{ matrix.group }}


### PR DESCRIPTION
Je viens de réaliser que les warning Python polluent énormément les logs dans la CI, ce qui la rend difficile à lire lorsqu'il y a des erreurs. Cette PR les désactivent uniquement dans la CI.