### PR TITLE
Fix CSP issue for Brave/Chromium

### DIFF
--- a/core/static/core/object_lazy_load.mjs
+++ b/core/static/core/object_lazy_load.mjs
@@ -5,7 +5,12 @@ class ObjectLazyLoad extends Controller {
     static targets = ["objectTag"]
 
     onPDFPreviewed() {
-        this.objectTagTarget.setAttribute("data", this.objectTagTarget.dataset.src)
+        const obj = document.createElement("object")
+        obj.setAttribute("type", this.objectTagTarget.dataset.type)
+        obj.setAttribute("width", this.objectTagTarget.dataset.width)
+        obj.setAttribute("height", this.objectTagTarget.dataset.height)
+        obj.setAttribute("data", this.objectTagTarget.dataset.src)
+        this.objectTagTarget.replaceWith(obj)
     }
 }
 

--- a/core/templates/core/_documents.html
+++ b/core/templates/core/_documents.html
@@ -148,9 +148,9 @@
                                                                                         <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-document-image-table-{{ document.pk }}">Fermer</button>
                                                                                     </div>
                                                                                     <div class="fr-modal__content pdf-modal">
-                                                                                        <object data="" data-src="{{ document.file.pdf_url }}" data-object-lazy-load-target="objectTag" type="application/pdf" width="100%" height="100%">
+                                                                                        <div data-src="{{ document.file.pdf_url }}" data-object-lazy-load-target="objectTag" data-type="application/pdf" data-width="100%" data-height="100%">
                                                                                             Votre navigateur ne supporte pas l'aperçu des fichiers PDF.
-                                                                                        </object>
+                                                                                        </div>
                                                                                     </div>
                                                                                 </div>
                                                                             </div>

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -331,8 +331,8 @@ SECURE_CSP = {
 
 if DEBUG:
     SECURE_CSP["img-src"] = (CSP.SELF, "data:", "127.0.0.1:9000")
-    SECURE_CSP["object-src"] = (CSP.SELF, "data:", "127.0.0.1:9000")
-    SECURE_CSP["frame-src"] = (CSP.SELF, "data:", "127.0.0.1:9000")
+    SECURE_CSP["object-src"] = (CSP.SELF, "127.0.0.1:9000")
+    SECURE_CSP["frame-src"] = (CSP.SELF, "127.0.0.1:9000")
 
 if ENVIRONMENT != "test":
     SENTRY_REPORT_URL = env("SENTRY_REPORT_URL", None)


### PR DESCRIPTION
Having data="" is not accepted by Brave/Chromium as it will raise a CSP error.
It used to work on localhost due to the addition of data: in the accepted URI (which seems to loosen the verification ?).