### PR TITLE
chore(ci): fix reporter dorny/test-reporter@v1 sometimes failing

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,5 +1,7 @@
 name: Django application
 on: [push]
+permissions:
+  checks: write
 env:
   SECRET_KEY: NOT_A_REAL_SECRET
   DATABASE_URL: postgres://postgres:postgres@localhost/github_actions


### PR DESCRIPTION
De temps en temps la CI  se vautre non pas parce que les tests ne passent pas mais parce que l'étape « Publish test results » semble incapable d'envoyer les résultats. Voir dorny/test-reporter#229. Il est possible que ça ne résolve pas le problème qui semble aléatoire. J'ai testé en amandant #1949 qui présentait ce problème pour rajouter la permission et la CI est passée. Cependant, même après avori à nouveau amandé la PR pour retirer la permission, la CI a continué à passer donc ça ne confirme pas tout à fait que cette permission résout le problème. J'ai réitéré l'expérience avec #1948 et #1947 avec les mêmes résultats.

D'après la documentation, la permission est accordée au `GITHUB_TOKEN`. Il est possible que le même `GITHUB_TOKEN` soit accordé à la même PR y compris en cas de force push ce qui expliquerait que la PR continue de passer et pourquoi ce problème ne semble se poser que pour Dependabot qui a moins de droit que nous.

 [D'après la documentation](https://docs.github.com/fr/actions/reference/workflows-and-actions/workflow-syntax#permissions), cette permission ne donne le droit que de créer des checks, ce qui semble assez safe.