### PR TITLE
Correction d'un conflit de migration entre  `0121_lieu_site_inspection_new` et `0121_add_on_phytophthora_kernoviae`

### DIFF
--- a/sv/migrations/0122_add_on_phytophthora_kernoviae.py
+++ b/sv/migrations/0122_add_on_phytophthora_kernoviae.py
@@ -16,7 +16,7 @@ def reverse_add_organisme_nuisible(apps, _):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("sv", "0120_auto_20260424_1058"),
+        ("sv", "0121_lieu_site_inspection_new"),
     ]
 
     operations = [


### PR DESCRIPTION
Le merge de #1952 et #1901 sans rebase provoque un conflit de migration qui casse le déploiment en recette.