### PR TITLE
Improve history for SV

### DIFF
--- a/core/diffs.py
+++ b/core/diffs.py
@@ -406,9 +406,12 @@ class CompareMixin(CompareMethodsMixin, OriginalCompareMixin):
                     change = obj_compare.get_m2o_change_info()
                 for item in change["deleted_items"]:
                     klass = item._object_version.object.__class__
+                    if (item.object_id, item.content_type_id) in self.handled_deleted_objects:
+                        continue
                     if getattr(klass, "show_deleted_state_in_revision_list", True):
                         new = f"Objet supprimé : {klass.__name__} {item}"
                         diff.append(Diff(self._get_pretty_field(field), "", new, version2.revision))
+                        self.handled_deleted_objects.append((item.object_id, item.content_type_id))
                 for item in change["added_items"]:
                     klass = item._object_version.object.__class__
                     if getattr(klass, "show_class_name_in_added_items", True):

--- a/core/views.py
+++ b/core/views.py
@@ -547,6 +547,7 @@ class RevisionsListView(UserPassesTestMixin, CompareMixin, ListView):
         self.object = content_type.model_class().objects.get(pk=kwargs["pk"])
         self.handled_qs = []
         self.handled_revision_comments = []
+        self.handled_deleted_objects = []
         return super().dispatch(request, *args, **kwargs)
 
     def test_func(self):

--- a/sv/models/prelevements.py
+++ b/sv/models/prelevements.py
@@ -150,7 +150,10 @@ class Prelevement(models.Model):
     date_rapport_analyse = models.DateField(verbose_name="Date rapport d'analyse", blank=True, null=True)
 
     def __str__(self):
-        return f"Prélèvement n° {self.id}"
+        result = f"réalisé par {self.structure_preleveuse.nom}"
+        if self.numero_echantillon:
+            result += f" (numéro d'échantillon : {self.numero_echantillon})"
+        return result
 
     def clean(self):
         super().clean()

--- a/sv/tests/test_evenement_history.py
+++ b/sv/tests/test_evenement_history.py
@@ -177,11 +177,12 @@ def test_evenement_history_content_prelevement_shows_even_when_no_modification_o
     url = reverse("revision-list", kwargs={"content_type": content_type.pk, "pk": evenement.pk})
     page.goto(f"{live_server.url}{url}")
 
-    creation_text = f"Objet ajouté : Prelevement Prélèvement n° {prelevement.id}"
-    update_text = f"Fiche Détection ({detection.numero}) - Lieu (Mon Lieu) - Prélèvement (Prélèvement N° {prelevement.id}) - N° D'Échantillon"
-
-    expect(page.get_by_text(creation_text, exact=True)).to_be_visible()
-    expect(page.get_by_text(update_text, exact=True)).to_be_visible()
+    creation_text = f"Objet ajouté : Prelevement {str(prelevement)}"
+    update_text = (
+        f"Fiche Détection ({detection.numero}) - Lieu (Mon Lieu) - Prélèvement ({str(prelevement)}) - N° D'Échantillon"
+    )
+    expect(page.get_by_text(creation_text)).to_be_visible()
+    expect(page.get_by_text(update_text)).to_be_visible()
 
 
 def test_evenement_history_content_add_and_edit_zone_infestee(
@@ -223,3 +224,39 @@ def test_evenement_history_content_add_and_edit_zone_infestee(
     update_text = f"Fiche Zone Délimitée ({evenement.numero}) - Zone Infestée (Old Value) - Nom De La Zone Infestée"
     expect(page.get_by_text(creation_text, exact=True)).to_be_visible()
     expect(page.get_by_text(update_text, exact=True)).to_be_visible()
+
+
+def test_evenement_history_only_one_entry_when_lieu_is_deleted(
+    live_server, page, form_elements: FicheDetectionFormDomElements, lieu_form_elements, choice_js_fill
+):
+    statut, _ = StatutReglementaire.objects.get_or_create(libelle="organisme quarantaine prioritaire")
+    StructurePreleveuseFactory()
+    organisme_nuisible = OrganismeNuisibleFactory()
+    page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
+    choice_js_fill(
+        page,
+        "#organisme-nuisible .choices__list--single",
+        organisme_nuisible.libelle_court,
+        organisme_nuisible.libelle_court,
+    )
+    page.get_by_label("Statut réglementaire").select_option(value=str(statut.id))
+    form_elements.add_lieu_btn.click()
+    lieu_form_elements.nom_input.fill("Mon lieu")
+    lieu_form_elements.save_btn.click()
+    page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").click()
+
+    evenement = Evenement.objects.get()
+    detection = evenement.detections.get()
+
+    page.goto(f"{live_server.url}{detection.get_update_url()}")
+    page.get_by_test_id("lieu-delete-btn").click()
+    page.get_by_test_id("submit-delete").locator("visible=true").click()
+    page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").click()
+
+    content_type = ContentType.objects.get_for_model(Evenement)
+    url = reverse("revision-list", kwargs={"content_type": content_type.pk, "pk": evenement.pk})
+    page.goto(f"{live_server.url}{url}")
+
+    deletion_text = "Objet supprimé : Lieu Mon lieu"
+    expect(page.get_by_text(deletion_text, exact=True)).to_be_visible()
+    expect(page.get_by_text(deletion_text, exact=True)).to_have_count(1)


### PR DESCRIPTION
- Avoid showing duplicate entries for sub objects when they are deleted
- Make which prelevement was impacted more explicit, the exact=True was removed to avoid issue with capitalization of text.