### PR TITLE
Change format of TIAC csv export

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -87,7 +87,7 @@ fileignoreconfig:
 - filename: core/diffs.py
   checksum: aa005df583bb90c6e3318e74b1f63c103053728ffd99da0e85031c0fc61aaed9
 - filename: tiac/tests/test_evenement_export.py
-  checksum: 81fc205d819a3c14459b42424a400d3f8ab55d3ad1e3116f6dcc83bfa299393f
+  checksum: c4a90bce455298c458c6938aa944f2f293bfef4780719ba02e0bf5678bb85356
 - filename: tiac/export.py
   checksum: f13f0a927917a063b11ccb4e13c29d3e705d27ca3f80394e5671043c7e5fa23e
 - filename: tiac/factories.py

--- a/tiac/export.py
+++ b/tiac/export.py
@@ -1,24 +1,19 @@
 import csv
+from itertools import zip_longest
 import tempfile
 
 from django.apps import apps
 from django.core.files import File
-from django.db.models import Count, Max
 from queryset_sequence import QuerySetSequence
 
 from core.export import BaseExport
 from core.models import Export
 from core.notifications import notify_export_is_ready
 
-from .models import InvestigationTiac
+from .models import EvenementSimple, InvestigationTiac
 
 
 class TiacExport(BaseExport):
-    REPAS_KEY = "Repas"
-    ETABLISSEMENT_KEY = "Etablissement"
-    ALIMENT_KEY = "Aliment"
-    ANALYSE_KEY = "Analyse alimentaire"
-
     evenement_fields = [
         ("numero", "Numéro de fiche"),
         ("get_readable_etat_for_csv", "État"),
@@ -54,91 +49,79 @@ class TiacExport(BaseExport):
     ]
 
     etablissement_fields = [
-        ("siret", "Numéro SIRET"),
-        ("numero_agrement", "Numéro d'agrément"),
-        ("autre_identifiant", "Autre identifiant"),
-        ("raison_sociale", "Raison sociale"),
-        ("enseigne_usuelle", "Enseigne usuelle"),
-        ("adresse_lieu_dit", "Adresse ou lieu-dit"),
-        ("commune_and_cp", "Commune"),
-        ("departement", "Département"),
-        ("pays", "Pays établissement"),
-        ("type_etablissement", "Type d'établissement"),
-        ("has_inspection", "Inspection"),
-        ("numero_resytal", "Numéro RESYTAL"),
-        ("date_inspection", "Date d'inspection"),
-        ("evaluation", "Évaluation"),
-        ("commentaire", "Commentaire"),
+        ("siret", "Etablissement - Numéro SIRET"),
+        ("numero_agrement", "Etablissement - Numéro d'agrément"),
+        ("autre_identifiant", "Etablissement - Autre identifiant"),
+        ("raison_sociale", "Etablissement - Raison sociale"),
+        ("enseigne_usuelle", "Etablissement - Enseigne usuelle"),
+        ("adresse_lieu_dit", "Etablissement - Adresse ou lieu-dit"),
+        ("commune_and_cp", "Etablissement - Commune"),
+        ("departement", "Etablissement - Département"),
+        ("pays", "Etablissement - Pays établissement"),
+        ("type_etablissement", "Etablissement - Type d'établissement"),
+        ("has_inspection", "Etablissement - Inspection"),
+        ("numero_resytal", "Etablissement - Numéro RESYTAL"),
+        ("date_inspection", "Etablissement - Date d'inspection"),
+        ("evaluation", "Etablissement - Évaluation"),
+        ("commentaire", "Etablissement - Commentaire"),
     ]
 
     repas_fields = [
-        ("denomination", "Dénomination"),
-        ("menu", "Menu"),
-        ("motif_suspicion", "Motif de suspicion du repas"),
-        ("datetime_repas", "Date et heure du repas"),
-        ("nombre_participant", "Nombre de participant(e)s"),
-        ("departement", "Département"),
-        ("type_repas", "Type de repas"),
-        ("type_collectivite", "Type de collectivité"),
+        ("denomination", "Repas - Dénomination"),
+        ("menu", "Repas - Menu"),
+        ("motif_suspicion", "Repas - Motif de suspicion du repas"),
+        ("datetime_repas", "Repas - Date et heure du repas"),
+        ("nombre_participant", "Repas - Nombre de participant(e)s"),
+        ("departement", "Repas - Département"),
+        ("type_repas", "Repas - Type de repas"),
+        ("type_collectivite", "Repas - Type de collectivité"),
     ]
 
     analyses_fields = [
-        ("reference_prelevement", "Référence du prélèvement"),
-        ("etat_prelevement", "État du prélèvement"),
-        ("categorie_danger", "Catégorie de danger"),
-        ("comments", "Commentaires liés à l’analyse"),
-        ("sent_to_lnr_cnr", "Envoyé au LNR/CNR"),
-        ("reference_souche", "Référence souche"),
+        ("reference_prelevement", "Analyse - Référence du prélèvement"),
+        ("etat_prelevement", "Analyse - État du prélèvement"),
+        ("categorie_danger", "Analyse - Catégorie de danger"),
+        ("comments", "Analyse - Commentaires liés à l’analyse"),
+        ("sent_to_lnr_cnr", "Analyse - Envoyé au LNR/CNR"),
+        ("reference_souche", "Analyse - Référence souche"),
     ]
 
     aliments_fields = [
-        ("denomination", "Dénomination"),
-        ("type_aliment", "Type d'aliment"),
-        ("description_composition", "Description de la composition de l'aliment"),
-        ("categorie_produit", "Catégorie de produit"),
-        ("description_produit", "Description produit et emballage"),
-        ("motif_suspicion", "Motif de suspicion de l'aliment"),
+        ("denomination", "Aliment - Dénomination"),
+        ("type_aliment", "Aliment - Type d'aliment"),
+        ("description_composition", "Aliment - Description de la composition de l'aliment"),
+        ("categorie_produit", "Aliment - Catégorie de produit"),
+        ("description_produit", "Aliment - Description produit et emballage"),
+        ("motif_suspicion", "Aliment - Motif de suspicion de l'aliment"),
     ]
 
-    def get_fieldnames(self, nb_etablissement, nb_repas, nb_aliment, nb_prelevement):
-        base_headers = [header for _, header in self.evenement_fields]
-        etablissement_headers = [f"{self.ETABLISSEMENT_KEY} {i}" for i in range(1, nb_etablissement + 1)]
-        repas_headers = [f"{self.REPAS_KEY} {i}" for i in range(1, nb_repas + 1)]
-        aliment_headers = [f"{self.ALIMENT_KEY} {i}" for i in range(1, nb_aliment + 1)]
-        prelevement_headers = [f"{self.ANALYSE_KEY} {i}" for i in range(1, nb_prelevement + 1)]
-        return base_headers + etablissement_headers + repas_headers + aliment_headers + prelevement_headers
-
-    def get_related_object_as_str(self, obj, fields):
-        lines = []
-        for field, display_name in fields:
-            lines.append(f"{display_name} : {self.get_field_value(obj, field)}")
-        return "\n".join(lines)
-
-    def get_data_from_instance(self, object):
-        result = {}
-        self.add_data(result, object, self.evenement_fields)
-        for idx, related_obj in enumerate(object.etablissements.all()):
-            result[f"{self.ETABLISSEMENT_KEY} {idx + 1}"] = self.get_related_object_as_str(
-                related_obj, self.etablissement_fields
+    def get_fieldnames(self):
+        return [
+            header
+            for _, header in (
+                self.evenement_fields
+                + self.etablissement_fields
+                + self.repas_fields
+                + self.aliments_fields
+                + self.analyses_fields
             )
-        try:
-            for idx, related_obj in enumerate(object.repas.all()):
-                result[f"{self.REPAS_KEY} {idx + 1}"] = self.get_related_object_as_str(related_obj, self.repas_fields)
-            for idx, related_obj in enumerate(object.analyses_alimentaires.all()):
-                result[f"{self.ANALYSE_KEY} {idx + 1}"] = self.get_related_object_as_str(
-                    related_obj, self.analyses_fields
-                )
-            for idx, related_obj in enumerate(object.aliments.all()):
-                result[f"{self.ALIMENT_KEY} {idx + 1}"] = self.get_related_object_as_str(
-                    related_obj, self.aliments_fields
-                )
-        except AttributeError:
-            pass  # EvenementSimple object does not have those related fields
+        ]
+
+    def get_evenement_data(self, instance, etablissement, repas, aliment, analyse):
+        result = {}
+        result = self.add_data(result, instance, self.evenement_fields)
+        if etablissement:
+            result = self.add_data(result, etablissement, self.etablissement_fields)
+        if repas:
+            result = self.add_data(result, repas, self.repas_fields)
+        if aliment:
+            result = self.add_data(result, aliment, self.aliments_fields)
+        if analyse:
+            result = self.add_data(result, analyse, self.analyses_fields)
         return result
 
-    def get_queryset_and_nb_objects(self, task):
+    def get_queryset(self, task):
         querysets = []
-        max_etablissement = max_repas = max_aliment = max_analyses = 0
         for entry in task.queryset_sequence:
             entries = entry["ids"]
             if not entries:
@@ -165,43 +148,32 @@ class TiacExport(BaseExport):
                     .select_related("createur")
                     .with_fin_de_suivi(contact)
                 )
-
             querysets.append(queryset)
-            if model == InvestigationTiac:
-                queryset = queryset.annotate(
-                    nb_repas=Count("repas", distinct=True),
-                    nb_aliment=Count("aliments", distinct=True),
-                    nb_analyses=Count("analyses_alimentaires", distinct=True),
-                    nb_etablissement=Count("etablissements", distinct=True),
-                ).aggregate(
-                    max_repas=Max("nb_repas"),
-                    max_aliment=Max("nb_aliment"),
-                    max_analyses=Max("nb_analyses"),
-                    max_etablissements=Max("nb_etablissement"),
-                )
-                max_repas = queryset["max_repas"]
-                max_aliment = queryset["max_aliment"]
-                max_analyses = queryset["max_analyses"]
-            else:
-                queryset = queryset.annotate(
-                    nb_etablissement=Count("etablissements", distinct=True),
-                ).aggregate(
-                    max_etablissements=Max("nb_etablissement"),
-                )
+        return QuerySetSequence(*querysets)
 
-            if queryset["max_etablissements"] > max_etablissement:
-                max_etablissement = queryset["max_etablissements"]
+    def get_lines_from_instance(self, instance):
+        etablissements = instance.etablissements.all()
+        if isinstance(instance, EvenementSimple):
+            repas, aliments, analyses = [], [], []
+        else:
+            repas = instance.repas.all()
+            aliments = instance.aliments.all()
+            analyses = instance.analyses_alimentaires.all()
 
-        queryset = QuerySetSequence(*querysets)
-        return queryset, max_etablissement, max_repas, max_aliment, max_analyses
+        if not any([etablissements, repas, aliments, analyses]):
+            yield self.get_evenement_data(instance, None, None, None, None)
+        else:
+            for etablissement, repas, aliment, analyse in zip_longest(etablissements, repas, aliments, analyses):
+                yield self.get_evenement_data(instance, etablissement, repas, aliment, analyse)
+                continue
 
     def export(self, task_id):
         task = Export.objects.select_related("user__agent__structure").get(id=task_id)
         if task.task_done is True:
             return
 
-        queryset, max_etablissement, max_repas, max_aliment, max_analyses = self.get_queryset_and_nb_objects(task)
-        fieldnames = self.get_fieldnames(max_etablissement, max_repas, max_aliment, max_analyses)
+        queryset = self.get_queryset(task)
+        fieldnames = self.get_fieldnames()
         with tempfile.NamedTemporaryFile(mode="w+", newline="", delete=False) as tmp:
             writer = csv.DictWriter(
                 tmp,
@@ -212,7 +184,8 @@ class TiacExport(BaseExport):
             writer.writeheader()
 
             for obj in queryset:
-                writer.writerow(self.get_data_from_instance(obj))
+                for line in self.get_lines_from_instance(obj):
+                    writer.writerow(line)
 
             tmp.flush()
             with open(tmp.name, "rb") as read_file:

--- a/tiac/tests/test_evenement_export.py
+++ b/tiac/tests/test_evenement_export.py
@@ -24,7 +24,7 @@ def test_export_tiac_performances_scales_on_number_of_evenement_simple(
     ContactStructureFactory(structure=contact.agent.structure)
     task = Export.objects.create(user=contact.agent.user, queryset_sequence=data)
 
-    with django_assert_num_queries(15):
+    with django_assert_num_queries(14):
         TiacExport().export(task.id)
 
     task.refresh_from_db()
@@ -35,7 +35,7 @@ def test_export_tiac_performances_scales_on_number_of_evenement_simple(
     data = [{"model": "tiac.evenementsimple", "ids": [evenement.id, evenement_2.id, evenement_3.id]}]
     task = Export.objects.create(user=contact.agent.user, queryset_sequence=data)
 
-    with django_assert_num_queries(15):
+    with django_assert_num_queries(14):
         TiacExport().export(task.id)
 
     task.refresh_from_db()
@@ -51,7 +51,7 @@ def test_export_tiac_performances_scales_on_number_of_related_objects(
     ContactStructureFactory(structure=contact.agent.structure)
     task = Export.objects.create(user=contact.agent.user, queryset_sequence=data)
 
-    with django_assert_num_queries(21):
+    with django_assert_num_queries(20):
         TiacExport().export(task.id)
 
     task.refresh_from_db()
@@ -63,7 +63,7 @@ def test_export_tiac_performances_scales_on_number_of_related_objects(
     EtablissementFactory(investigation=evenement)
     task = Export.objects.create(user=contact.agent.user, queryset_sequence=data)
 
-    with django_assert_num_queries(25):
+    with django_assert_num_queries(24):
         TiacExport().export(task.id)
 
     task.refresh_from_db()
@@ -166,3 +166,53 @@ def test_export_etat_value_in_fin_de_suivi(live_server, mocked_authentification_
     assert task.task_done is True
     lines = task.file.read().decode("utf-8")
     assert lines.count("Fin de suivi pour ma structure") == 2
+
+
+def test_export_tiac_number_of_lines_and_content(
+    live_server, mocked_authentification_user, page: Page, django_assert_num_queries
+):
+    evenement_1 = InvestigationTiacFactory()
+    EtablissementFactory(investigation=evenement_1, raison_sociale="Etablissement 1")
+    RepasSuspectFactory(investigation=evenement_1, denomination="Repas 1")
+    RepasSuspectFactory(investigation=evenement_1, denomination="Repas 2")
+
+    evenement_2 = InvestigationTiacFactory()
+    EtablissementFactory(investigation=evenement_2, raison_sociale="Etablissement 2")
+    EtablissementFactory(investigation=evenement_2, raison_sociale="Etablissement 3")
+
+    evenement_3 = EvenementSimpleFactory()
+    EtablissementFactory(evenement_simple=evenement_3, raison_sociale="Etablissement 4")
+
+    evenement_4 = EvenementSimpleFactory()
+
+    data = [
+        {"model": "tiac.investigationtiac", "ids": [evenement_1.id, evenement_2.id]},
+        {"model": "tiac.evenementsimple", "ids": [evenement_3.id, evenement_4.id]},
+    ]
+    contact = ContactAgentFactory()
+    ContactStructureFactory(structure=contact.agent.structure)
+    task = Export.objects.create(user=contact.agent.user, queryset_sequence=data)
+
+    TiacExport().export(task.id)
+    task.refresh_from_db()
+    assert task.task_done is True
+
+    content = task.file.read().decode("utf-8")
+    lines = content.split("\n")
+    assert len(lines) == len(
+        [
+            "Headers",
+            "Evenement 1 + Etablissement 1 + Repas 1",
+            "Evenement 1 + Repas 2",
+            "Evenement 2 + Etablissement 2",
+            "Evenement 2 + Etablissement 3",
+            "Evenement 3 + Etablissement 4",
+            "Evenement 4",
+            "Blank line",
+        ]
+    )
+
+    assert lines[7] == ""
+    expected_values = ["Etablissement 1", "Etablissement 2", "Etablissement 3", "Etablissement 4", "Repas 1", "Repas 2"]
+    for value in expected_values:
+        assert value in content


### PR DESCRIPTION
Change the format of the TIAC CSV export, instead of scaling on the number of columns scales on the number of lines.
We make sure to "fill" the line as much as possible to reduce the number of lines added to the file.
This will allow for the number of columns to be fixed and ease any operation on the CSV.

- Change the prefix of the fields (dynamic prefix to static prefix)
- Add a test on the number of lines and check that all the sub objects are in the output file.