### PR TITLE
Avoid document download on Chrome

### DIFF
--- a/core/mixins.py
+++ b/core/mixins.py
@@ -14,7 +14,6 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.core.files.storage import default_storage
 from django.db import models, transaction
 from django.forms import BaseModelFormSet, Media
 from django.forms.utils import RenderableMixin
@@ -125,13 +124,6 @@ class WithDocumentListInContextMixin:
         allowed_document_types = self.get_object().get_allowed_document_types()
         for document in document_filter.qs:
             document.edit_form = DocumentEditForm(instance=document, allowed_document_types=allowed_document_types)
-            if document.can_pdf_be_viewed:
-                document.file.pdf_url = default_storage.url(
-                    document.file.name,
-                    parameters={
-                        "ResponseContentDisposition": "inline",
-                    },
-                )
         context["document_count"] = documents.exclude(is_deleted=True).count()
         downloadable_documents = [d for d in document_filter.qs if (d.is_deleted is False and d.is_infected is False)]
         context["document_count_for_download"] = len(downloadable_documents)

--- a/core/models.py
+++ b/core/models.py
@@ -7,6 +7,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelatio
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
+from django.core.files.storage import default_storage
 from django.core.validators import FileExtensionValidator, RegexValidator
 from django.db import models
 from django.db.models import CheckConstraint, Q
@@ -405,6 +406,15 @@ class Document(models.Model):
             )
         if self.file and self.document_type:
             self.validate_file_extention_for_document_type(self.file, self.document_type)
+
+    @property
+    def pdf_preview_url(self):
+        return default_storage.url(
+            self.file.name,
+            parameters={
+                "ResponseContentDisposition": "inline",
+            },
+        )
 
 
 @reversion.register()

--- a/core/templates/core/_documents.html
+++ b/core/templates/core/_documents.html
@@ -148,7 +148,7 @@
                                                                                         <button class="fr-btn--close fr-btn" title="Fermer la fenêtre modale" aria-controls="fr-document-image-table-{{ document.pk }}">Fermer</button>
                                                                                     </div>
                                                                                     <div class="fr-modal__content pdf-modal">
-                                                                                        <div data-src="{{ document.file.pdf_url }}" data-object-lazy-load-target="objectTag" data-type="application/pdf" data-width="100%" data-height="100%">
+                                                                                        <div data-src="{{ document.pdf_preview_url }}" data-object-lazy-load-target="objectTag" data-type="application/pdf" data-width="100%" data-height="100%">
                                                                                             Votre navigateur ne supporte pas l'aperçu des fichiers PDF.
                                                                                         </div>
                                                                                     </div>

--- a/core/templates/core/message_detail.html
+++ b/core/templates/core/message_detail.html
@@ -20,7 +20,7 @@
                                 <div class="fr-modal__content">
                                     {% if document.can_pdf_be_viewed %}
                                         <div class="pdf-modal">
-                                            <object data="{{ document.file.url }}" type="application/pdf" width="100%" height="100%">
+                                            <object data="{{ document.pdf_preview_url }}" type="application/pdf" width="100%" height="100%">
                                                 Votre navigateur ne supporte pas l'aperçu des fichiers PDF.
                                             </object>
                                         </div>


### PR DESCRIPTION
When going on a message details page with a valid PDF using Chrome, the PDF file was downloaded due to the missing header. The header was already there in the document list mixin.