### PR TITLE
Fix the date of the files in Zip download

### DIFF
--- a/core/tests/generic_tests/documents.py
+++ b/core/tests/generic_tests/documents.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from threading import Lock
 from unittest.mock import patch
 import zipfile
@@ -248,11 +249,14 @@ def generic_test_can_download_zip_of_documents_with_filter(live_server, page: Pa
     download = download_info.value
     assert download.suggested_filename.endswith(".zip") is True
     download_path = download.path()
-    with zipfile.ZipFile(download_path, "r") as z:
-        files = z.namelist()
+    with zipfile.ZipFile(download_path, "r") as zip:
+        files = zip.namelist()
         expected = [document_1.file.name, document_2.file.name]
         expected = sorted([e.replace("documents/", "") for e in expected])
         assert sorted(files) == expected, f"Expected {expected} and got {files}"
+
+        for info in zip.infolist():
+            assert datetime(*info.date_time).date() == datetime.now().date()
 
 
 def generic_test_cant_download_zip_when_no_documents(live_server, page: Page, object):

--- a/core/views.py
+++ b/core/views.py
@@ -13,6 +13,7 @@ from django.db import transaction
 from django.http import HttpResponseRedirect
 from django.http.response import HttpResponse, HttpResponseServerError, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.translation import ngettext
 from django.views import View
@@ -652,11 +653,15 @@ class ZipDownloadView(UserPassesTestMixin, View):
         buffer = io.BytesIO()
 
         with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+            now = timezone.localtime(timezone.now()).timetuple()[:6]
             for obj in queryset:
                 f = obj.file
                 f.open("rb")
 
-                with zip_file.open(f.name.split("/")[-1], "w") as dest:
+                filename = f.name.split("/")[-1]
+                info = zipfile.ZipInfo(filename)
+                info.date_time = now
+                with zip_file.open(info, "w") as dest:
                     for chunk in f.chunks():
                         dest.write(chunk)
 


### PR DESCRIPTION
Make sure the date of the file is set to today when we download a Zip file with multiple documents.