### PR TITLE
Fix map when editing an existing lieu

### DIFF
--- a/sv/templates/sv/_fichedetection_form__lieux_modal.html
+++ b/sv/templates/sv/_fichedetection_form__lieux_modal.html
@@ -19,7 +19,7 @@
                             >
                                 Ajouter un lieu
                             </h1>
-                            {% if delete %}
+                            {% if existing_object %}
                                 <p class="fr-hidden">{{ form.DELETE }}</p>
                             {% endif %}
 
@@ -35,8 +35,7 @@
                             <fieldset>
                                 <legend class="fr-fieldset__legend fr-m-0 fr-p-0">Localisation</legend>
                                 <span class="fr-hint-text fr-mb-1w">Placez votre repère en double cliquant sur la zone correspondante, en recherchant une adresse ou renseignez manuellement les coordonnées GPS</span>
-
-                                <div class="map-container"
+                                <div class="map-container" {% if existing_object %}data-controller="map"{% endif %}
                                      data-map-json-file-value="{% static 'core/style_ign.json' %}"
                                      data-map-reverse-api-value="{{ REVERSE_GEO_API }}"
                                      data-map-geo-api-root-value="{{ GEO_API_ROOT }}"

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -139,7 +139,7 @@
                     {% for form in lieu_formset %}
                         {% if form.instance.pk %}
                             {{ form.id }}
-                            {% include 'sv/_fichedetection_form__lieux_modal.html' with id=form.instance.pk delete=True %}
+                            {% include 'sv/_fichedetection_form__lieux_modal.html' with id=form.instance.pk existing_object=True %}
                         {% endif %}
                     {% endfor %}
 

--- a/sv/tests/test_fichedetection_update.py
+++ b/sv/tests/test_fichedetection_update.py
@@ -355,6 +355,7 @@ def test_update_lieu(
 
     page.goto(f"{live_server.url}{fiche_detection.get_update_url()}")
     page.get_by_test_id("lieu-edit-btn").click()
+    expect(lieu_form_elements.map_canvas).to_be_visible()
     lieu_form_elements.nom_input.fill(new_lieu.nom)
     lieu_form_elements.force_adresse(lieu_form_elements.adresse_choicesjs, new_lieu.adresse_lieu_dit)
     lieu_form_elements.force_commune()

--- a/sv/tests/test_utils.py
+++ b/sv/tests/test_utils.py
@@ -227,6 +227,10 @@ class LieuFormDomElements:
         return self.page.locator('[id^="id_lieux-"][id$="-nom"]').locator("visible=true")
 
     @property
+    def map_canvas(self) -> Locator:
+        return self.page.locator(".maplibregl-canvas").locator("visible=true")
+
+    @property
     def adresse_label(self) -> Locator:
         return self.page.get_by_text("Adresse ou lieu-dit").locator("visible=true")
 


### PR DESCRIPTION
Fix map display when we edit an existing lieu.
Do it this way only for existing lieu to avoid loading the map when not necessary (done in showLieuModal for a new lieu when needed).