### PR TITLE
Adapations Europhyt, partie 3.1 : déplacement de `ChoiceJSPage` dans `core/tests/pages.py`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,5 @@
 import contextlib
 from datetime import datetime
-import functools
-from functools import cached_property
 import os
 import random
 from typing import Any, Iterable
@@ -14,7 +12,7 @@ from django.urls import resolve
 from django.urls.base import reverse
 from django.utils import timezone
 from django.utils.timezone import localdate
-from playwright.sync_api import Error as PlaywrightError, Page, expect
+from playwright.sync_api import Page, expect
 import pytest
 
 from core.constants import AC_STRUCTURE, DEPARTEMENTS, MUS_STRUCTURE
@@ -22,31 +20,6 @@ from core.factories import ContactStructureFactory, StructureFactory, UserFactor
 from core.models import Agent, Contact, Departement, Region, Structure
 
 User = get_user_model()
-
-
-def playwright_repeatable(maybe_func=None, timeout=None, retries=10):
-    def decorator(func):
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            error = None
-            old_timeout = expect._timeout
-            new_timeout = timeout or (old_timeout or 5_000 / retries)
-            for i in range(retries):
-                try:
-                    expect.set_options(timeout=new_timeout)
-                    return func(*args, **kwargs)
-                except (PlaywrightError, AssertionError) as e:
-                    if error is not None:
-                        e.__cause__ = error
-                    error = e
-                    continue
-                finally:
-                    expect.set_options(timeout=old_timeout)
-            raise error
-
-        return wrapper
-
-    return decorator(maybe_func) if callable(maybe_func) else decorator
 
 
 class E2ETestNetworkError(Exception):
@@ -105,75 +78,6 @@ def mocked_authentification_user(db, request):
             yield user
 
 
-class _ChoiceJSPage:
-    @cached_property
-    def _choice_widget_locator(self):
-        locator = self.page.locator(self.sel_or_locator).locator(
-            "xpath=descendant-or-self::*[contains(concat(' ',normalize-space(@class),' '),' choices ')]"
-        )
-        if len(locator.all()) == 0:
-            return self.page.locator(self.sel_or_locator).locator(
-                "xpath=ancestor-or-self::*[contains(concat(' ',normalize-space(@class),' '),' choices ')]"
-            )
-        return locator
-
-    @property
-    def choice_widget(self):
-        return self._choice_widget_locator.first
-
-    @property
-    def dropdown(self):
-        return self.choice_widget.locator(".choices__list.choices__list--dropdown")
-
-    @property
-    def click_zone(self):
-        result = self.choice_widget.locator(".choices__list.choices__list--multiple + .choices__input")
-        return result.first if result.count() > 0 else self.choice_widget
-
-    def __init__(self, page: Page, sel_or_locator, fill_content, exact_name, *, check_selection=None):
-        self.page = page
-        self.sel_or_locator = sel_or_locator
-        self.fill_content = fill_content
-        self.exact_name = exact_name
-        self._check_selection = check_selection
-
-    def try_open(self):
-        if self.dropdown.is_visible():
-            return
-
-        self.click_zone.click()
-        expect(self.dropdown).to_be_visible()
-
-    def get_selected_option(self, exact_name):
-        return self.choice_widget.locator(
-            ".choices__list.choices__list--single,.choices__list.choices__list--multiple"
-        ).get_by_role("option", name=exact_name)
-
-    def select_option(self, exact_name):
-        self.choice_widget.locator(".choices__list.choices__list--dropdown").get_by_role(
-            "option", name=exact_name, exact=True
-        ).locator("visible=true").click()
-        expect(self.get_selected_option(exact_name)).to_have_count(1)
-
-    @playwright_repeatable
-    def try_select_option(self):
-        self.try_open()
-        if len(self.get_selected_option(self.exact_name).all()) > 0:
-            # Option already selected
-            return
-
-        self.choice_widget.locator("input.choices__input").fill(self.fill_content)
-        self.choice_widget.locator(".choices__list.choices__list--dropdown").get_by_role(
-            "option", name=self.exact_name, exact=True
-        ).locator("visible=true").click()
-        self.check_selection()
-
-    def check_selection(self):
-        if callable(self._check_selection):
-            return self._check_selection()
-        return expect(self.get_selected_option(self.exact_name)).to_have_count(1)
-
-
 @pytest.fixture
 def choice_js_fill():
     def _choice_js_fill(
@@ -185,7 +89,9 @@ def choice_js_fill():
         *,
         check_selection=None,
     ):
-        _ChoiceJSPage(
+        from core.tests.pages import ChoiceJSPage
+
+        ChoiceJSPage(
             page, sel_or_locator, fill_content, exact_name, check_selection=check_selection
         ).try_select_option()
 

--- a/core/pages.py
+++ b/core/pages.py
@@ -8,8 +8,8 @@ from django.conf import settings
 from playwright.sync_api import Locator, Page, expect
 import pytest
 
-from conftest import playwright_repeatable
 from core.models import Agent, Structure
+from core.tests.pages import playwright_repeatable
 
 
 class BaseDocumentPage(ABC):

--- a/core/tests/pages.py
+++ b/core/tests/pages.py
@@ -1,0 +1,93 @@
+import functools
+from functools import cached_property
+
+from playwright.sync_api import Error as PlaywrightError, Locator, Page, expect
+
+
+def playwright_repeatable(maybe_func=None, timeout=None, retries=10):
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            error = None
+            old_timeout = expect._timeout
+            new_timeout = timeout or (old_timeout or 5_000 / retries)
+            for i in range(retries):
+                try:
+                    expect.set_options(timeout=new_timeout)
+                    return func(*args, **kwargs)
+                except (PlaywrightError, AssertionError) as e:
+                    if error is not None:
+                        e.__cause__ = error
+                    error = e
+                    continue
+                finally:
+                    expect.set_options(timeout=old_timeout)
+            raise error
+
+        return wrapper
+
+    return decorator(maybe_func) if callable(maybe_func) else decorator
+
+
+class ChoiceJSPage:
+    @cached_property
+    def _choice_widget_locator(self):
+        locator = self.locator.locator(
+            "xpath=descendant-or-self::*[contains(concat(' ',normalize-space(@class),' '),' choices ')]"
+        )
+        if len(locator.all()) == 0:
+            return self.locator.locator(
+                "xpath=ancestor-or-self::*[contains(concat(' ',normalize-space(@class),' '),' choices ')]"
+            )
+        return locator
+
+    @property
+    def choice_widget(self):
+        return self._choice_widget_locator.first
+
+    @property
+    def dropdown(self):
+        return self.choice_widget.locator(".choices__list.choices__list--dropdown")
+
+    @property
+    def click_zone(self):
+        result = self.choice_widget.locator(".choices__list.choices__list--multiple + .choices__input")
+        return result.first if result.count() > 0 else self.choice_widget
+
+    def __init__(
+        self, page: Page, sel_or_locator: str | Locator, search_token, exact_name=None, *, check_selection=None
+    ):
+        self.locator = sel_or_locator if isinstance(sel_or_locator, Locator) else page.locator(sel_or_locator)
+        self._search_token = search_token
+        self._exact_name = exact_name or search_token
+        self._user_check_selection = check_selection
+
+    def _try_open(self):
+        if self.dropdown.is_visible():
+            return
+
+        self.click_zone.click()
+        expect(self.dropdown).to_be_visible()
+
+    def _get_selected_option(self, exact_name):
+        return self.choice_widget.locator(
+            ".choices__list.choices__list--single,.choices__list.choices__list--multiple"
+        ).get_by_role("option", name=exact_name)
+
+    def _check_selection(self):
+        if callable(self._user_check_selection):
+            return self._user_check_selection()
+        return expect(self._get_selected_option(self._exact_name)).to_have_count(1)
+
+    @playwright_repeatable
+    def try_select_option(self):
+        self._try_open()
+        if len(self._get_selected_option(self._exact_name).all()) > 0:
+            # Option already selected
+            return
+
+        self.choice_widget.locator("input.choices__input").fill(self._search_token)
+        self.choice_widget.locator(".choices__list.choices__list--dropdown").get_by_role(
+            "option", name=self._exact_name, exact=True
+        ).locator("visible=true").click()
+        self._check_selection()

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -10,6 +10,7 @@ import pytest
 from core.constants import Visibilite
 from core.factories import DepartementFactory, StructureFactory
 from core.models import Contact
+from core.tests.pages import ChoiceJSPage
 from sv.constants import CONTEXTES, STATUTS_EVENEMENT, STATUTS_REGLEMENTAIRES
 
 from ..factories import (
@@ -148,7 +149,10 @@ def test_update_detection_form_show_date_creation(
 
 @pytest.mark.django_db
 def test_fiche_detection_create_without_lieux_and_prelevement(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, mocked_authentification_user, choice_js_fill
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
+    mocked_authentification_user,
 ):
     statut_evenement = StatutEvenement.objects.first()
     organisme_nuisible = OrganismeNuisible.objects.get(libelle_court="Xylella fastidiosa (maladie de Pierce)")
@@ -158,7 +162,7 @@ def test_fiche_detection_create_without_lieux_and_prelevement(
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
     """Test que les informations de la fiche de détection sont bien enregistrées après création."""
     page.get_by_label("Statut évènement").select_option(value=str(statut_evenement.id))
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Xylella", organisme_nuisible.libelle_court)
+    ChoiceJSPage(page, "#organisme-nuisible", "Xylella", organisme_nuisible.libelle_court).try_select_option()
     page.get_by_label("Statut réglementaire").select_option(value=str(statut_reglementaire.id))
     page.get_by_label("Contexte").select_option(value=str(contexte.id))
     page.get_by_label("Date 1er signalement").fill("2024-04-21")
@@ -194,7 +198,6 @@ def test_create_fiche_detection_with_lieu(
     form_elements: FicheDetectionFormDomElements,
     lieu_form_elements: LieuFormDomElements,
     mocked_authentification_user,
-    choice_js_fill,
     ensure_departements,
 ):
     ensure_departements("Nord")
@@ -212,7 +215,7 @@ def test_create_fiche_detection_with_lieu(
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
     expect(form_elements.add_prelevement_btn).to_be_disabled()
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     page.wait_for_timeout(200)
@@ -264,19 +267,13 @@ def test_create_fiche_detection_with_lieu_in_corsica(
     page: Page,
     form_elements: FicheDetectionFormDomElements,
     lieu_form_elements: LieuFormDomElements,
-    choice_js_fill,
     ensure_departements,
 ):
     ensure_departements("Corse-du-Sud")
     organisme_nuisible = OrganismeNuisibleFactory()
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
     expect(form_elements.add_prelevement_btn).to_be_disabled()
-    choice_js_fill(
-        page,
-        "#organisme-nuisible .choices__list--single",
-        organisme_nuisible.libelle_court,
-        organisme_nuisible.libelle_court,
-    )
+    ChoiceJSPage(page, "#organisme-nuisible", organisme_nuisible.libelle_court).try_select_option()
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     page.wait_for_timeout(200)
@@ -318,7 +315,6 @@ def test_create_fiche_detection_with_lieu_not_etablissement(
     form_elements: FicheDetectionFormDomElements,
     lieu_form_elements: LieuFormDomElements,
     mocked_authentification_user,
-    choice_js_fill,
     ensure_departements,
 ):
     ensure_departements("Nord")
@@ -332,7 +328,7 @@ def test_create_fiche_detection_with_lieu_not_etablissement(
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
     expect(form_elements.add_prelevement_btn).to_be_disabled()
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     page.wait_for_timeout(200)
@@ -371,7 +367,7 @@ def test_create_fiche_detection_with_lieu_not_etablissement(
 
 
 def test_structure_contact_is_add_to_contacts_list_when_fiche_detection_is_created(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, mocked_authentification_user, choice_js_fill
+    live_server, page: Page, form_elements: FicheDetectionFormDomElements, mocked_authentification_user
 ):
     """Test que lors de la création d'une fiche de détection, le contact correspondant à la structure de l'utilisateur connecté
     est ajouté dans la liste des contacts de l'événement"""
@@ -380,7 +376,7 @@ def test_structure_contact_is_add_to_contacts_list_when_fiche_detection_is_creat
         libelle_long="Mon ON",
     )
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.publish_btn.click()
 
@@ -403,7 +399,7 @@ def test_structure_contact_is_add_to_contacts_list_when_fiche_detection_is_creat
 
 
 def test_agent_contact_is_add_to_contacts_list_when_fiche_detection_is_created(
-    live_server, page: Page, choice_js_fill, form_elements: FicheDetectionFormDomElements, mocked_authentification_user
+    live_server, page: Page, form_elements: FicheDetectionFormDomElements, mocked_authentification_user
 ):
     """Test que lors de la création d'une fiche de détection, le contact correspondant à l'agent de l'utilisateur connecté
     est ajouté dans la liste des contacts de l'événement"""
@@ -412,7 +408,7 @@ def test_agent_contact_is_add_to_contacts_list_when_fiche_detection_is_created(
         libelle_long="Mon ON",
     )
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.publish_btn.click()
 
@@ -427,7 +423,6 @@ def test_add_lieu_with_name_only_and_save(
     live_server,
     page: Page,
     form_elements: FicheDetectionFormDomElements,
-    choice_js_fill,
     lieu_form_elements: LieuFormDomElements,
 ):
     organisme_nuisible, _ = OrganismeNuisible.objects.get_or_create(
@@ -435,7 +430,7 @@ def test_add_lieu_with_name_only_and_save(
         libelle_long="Mon ON",
     )
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     lieu_form_elements.nom_input.click()
@@ -454,7 +449,9 @@ def test_add_lieu_with_name_only_and_save(
 @pytest.mark.django_db
 @mock.patch.dict("sv.constants.KNOWN_OEPP_CODES_FOR_STATUS_REGLEMENTAIRES", {"OQ": ["XYLEFM"]}, clear=True)
 def test_fiche_detection_status_reglementaire_is_pre_selected(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, choice_js_fill
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
 ):
     statut = StatutReglementaire.objects.get(code="OQ")
     organisme_nuisible, _ = OrganismeNuisible.objects.get_or_create(
@@ -467,7 +464,7 @@ def test_fiche_detection_status_reglementaire_is_pre_selected(
     organisme_nuisible.save()
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     expect(form_elements.statut_reglementaire_input).to_have_value(str(statut.id))
     page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").click()
 
@@ -481,7 +478,9 @@ def test_fiche_detection_status_reglementaire_is_pre_selected(
 @pytest.mark.django_db
 @mock.patch.dict("sv.constants.KNOWN_OEPP_CODES_FOR_STATUS_REGLEMENTAIRES", {"OQ": ["XYLEFM"]}, clear=True)
 def test_fiche_detection_status_reglementaire_is_emptied_when_unknown(
-    live_server, page: Page, form_elements: FicheDetectionFormDomElements, choice_js_fill
+    live_server,
+    page: Page,
+    form_elements: FicheDetectionFormDomElements,
 ):
     statut = StatutReglementaire.objects.get(code="OQ")
     organisme_nuisible, _ = OrganismeNuisible.objects.get_or_create(
@@ -500,9 +499,9 @@ def test_fiche_detection_status_reglementaire_is_emptied_when_unknown(
     organisme_nuisible_no_status.save()
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     expect(form_elements.statut_reglementaire_input).to_have_value(str(statut.id))
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Pas mon ON", "Pas mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Pas mon ON").try_select_option()
     expect(form_elements.statut_reglementaire_input).to_have_value("")
 
 
@@ -512,7 +511,6 @@ def test_prelevements_are_always_linked_to_lieu(
     form_elements: FicheDetectionFormDomElements,
     lieu_form_elements: LieuFormDomElements,
     prelevement_form_elements: PrelevementFormDomElements,
-    choice_js_fill,
 ):
     organisme_nuisible, _ = OrganismeNuisible.objects.get_or_create(
         libelle_court="Mon ON",
@@ -521,7 +519,7 @@ def test_prelevements_are_always_linked_to_lieu(
     structures = StructurePreleveuseFactory.create_batch(2)
     page.wait_for_timeout(600)
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     lieu_form_elements.nom_input.fill("un lieu")
@@ -544,15 +542,13 @@ def test_prelevements_are_always_linked_to_lieu(
 
 
 @pytest.mark.django_db
-def test_one_fiche_detection_is_created_when_double_click_on_save_btn(
-    live_server, form_elements, choice_js_fill, page: Page
-):
+def test_one_fiche_detection_is_created_when_double_click_on_save_btn(live_server, form_elements, page: Page):
     organisme_nuisible, _ = OrganismeNuisible.objects.get_or_create(
         libelle_court="Mon ON",
         libelle_long="Mon ON",
     )
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").dblclick()
     page.wait_for_timeout(600)
@@ -565,7 +561,6 @@ def test_laboratoire_disable_in_prelevement_confirmation(
     page: Page,
     form_elements: FicheDetectionFormDomElements,
     prelevement_form_elements: PrelevementFormDomElements,
-    choice_js_fill,
 ):
     """Test que les laboratoires non officiels sont désactivés quand le type d'analyse est confirmation"""
     LaboratoireFactory.create_batch(3)
@@ -601,7 +596,6 @@ def test_laboratoire_enable_for_analyse_premiere_intention(
     page: Page,
     form_elements: FicheDetectionFormDomElements,
     prelevement_form_elements: PrelevementFormDomElements,
-    choice_js_fill,
 ):
     """Test que tous les laboratoires sont actifs quand le type d'analyse est première intention"""
     LaboratoireFactory.create_batch(3)
@@ -643,14 +637,13 @@ def test_can_add_fiche_detection_when_open_and_closed_prelevement_form_modal(
     page: Page,
     form_elements: FicheDetectionFormDomElements,
     prelevement_form_elements: PrelevementFormDomElements,
-    choice_js_fill,
 ):
     organisme_nuisible, _ = OrganismeNuisible.objects.get_or_create(
         libelle_court="Mon ON",
         libelle_long="Mon ON",
     )
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     lieu_form_elements = LieuFormDomElements(page)
@@ -671,7 +664,6 @@ def test_create_fiche_detection_with_lieu_using_siret(
     form_elements: FicheDetectionFormDomElements,
     lieu_form_elements: LieuFormDomElements,
     mocked_authentification_user,
-    choice_js_fill,
     settings,
     ensure_departements,
 ):
@@ -714,7 +706,7 @@ def test_create_fiche_detection_with_lieu_using_siret(
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
     expect(form_elements.add_prelevement_btn).to_be_disabled()
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
 
     form_elements.add_lieu_btn.click()
@@ -722,7 +714,7 @@ def test_create_fiche_detection_with_lieu_using_siret(
     lieu_form_elements.lieu_site_inspection_input.select_option("INCONNU")
     lieu_form_elements.is_etablissement_checkbox.click()
     lieu_form_elements.sirene_btn.click()
-    choice_js_fill(
+    ChoiceJSPage(
         page,
         "#header-search-0 .fr-select .choices__list--single",
         "120 079 017",
@@ -730,7 +722,7 @@ def test_create_fiche_detection_with_lieu_using_siret(
         check_selection=lambda: expect(
             page.locator('#lieu-form [name$="siret_etablissement"]').locator("visible=true")
         ).to_have_value(siret),
-    )
+    ).try_select_option()
     assert call_count["count"] == 1
 
     lieu_form_elements.save_btn.click()
@@ -764,19 +756,14 @@ def test_fiche_detection_without_organisme_nuisible_shows_error(
 
 
 def test_can_create_evenement_if_last_evenement_is_deleted(
-    live_server, page: Page, mocked_authentification_user, choice_js_fill, form_elements: FicheDetectionFormDomElements
+    live_server, page: Page, mocked_authentification_user, form_elements: FicheDetectionFormDomElements
 ):
     EvenementFactory(numero_annee=datetime.now().year, numero_evenement=1, is_deleted=True)
     organisme_nuisible = OrganismeNuisibleFactory()
     statut_reglementaire = StatutReglementaireFactory()
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    choice_js_fill(
-        page,
-        "#organisme-nuisible .choices__list--single",
-        organisme_nuisible.libelle_court,
-        organisme_nuisible.libelle_court,
-    )
+    ChoiceJSPage(page, "#organisme-nuisible", organisme_nuisible.libelle_court).try_select_option()
     form_elements.statut_reglementaire_input.select_option(statut_reglementaire.libelle)
     page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").click()
 
@@ -872,7 +859,6 @@ def test_can_add_lieu_with_adresse_auto_complete(
     page: Page,
     form_elements: FicheDetectionFormDomElements,
     lieu_form_elements: LieuFormDomElements,
-    choice_js_fill,
     choice_js_fill_from_element,
     ensure_departements,
 ):
@@ -909,7 +895,7 @@ def test_can_add_lieu_with_adresse_auto_complete(
     )
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     lieu_form_elements.nom_input.fill("un lieu")
@@ -937,7 +923,6 @@ def test_lieu_map(
     page: Page,
     form_elements: FicheDetectionFormDomElements,
     lieu_form_elements: LieuFormDomElements,
-    choice_js_fill,
     choice_js_fill_from_element,
     ensure_departements,
 ):
@@ -971,7 +956,7 @@ def test_lieu_map(
     )
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     lieu_form_elements.nom_input.fill("un lieu")
@@ -1002,7 +987,6 @@ def test_can_add_lieu_with_adresse_etablissement_autocomplete(
     page: Page,
     form_elements: FicheDetectionFormDomElements,
     lieu_form_elements: LieuFormDomElements,
-    choice_js_fill,
     choice_js_fill_from_element,
     ensure_departements,
 ):
@@ -1039,7 +1023,7 @@ def test_can_add_lieu_with_adresse_etablissement_autocomplete(
     )
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     lieu_form_elements.nom_input.fill("un lieu")
@@ -1064,7 +1048,6 @@ def test_add_lieu_with_supply_chain(
     live_server,
     page: Page,
     form_elements: FicheDetectionFormDomElements,
-    choice_js_fill,
     lieu_form_elements: LieuFormDomElements,
 ):
     organisme_nuisible, _ = OrganismeNuisible.objects.get_or_create(
@@ -1073,7 +1056,7 @@ def test_add_lieu_with_supply_chain(
     )
     supply_chain_position = PositionChaineDistributionFactory()
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    choice_js_fill(page, "#organisme-nuisible .choices__list--single", "Mon ON", "Mon ON")
+    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     lieu_form_elements.nom_input.click()


### PR DESCRIPTION
La panneau des éléments infestés implémente un widget ChoiceJS donc les tests utilisent le `ChoiceJSPage` en plus de la fonction `choice_js_fill` existante. Il est donc intéressant de le déplecer dans un endroit plus adapté. Cette PR modifie des tests dans `test_fichedetection_create.py` pour utiliser directement `ChoiceJSPage` afin de s'assurer que la refacto est saine.