### PR TITLE
Adapations Europhyt, partie 3.2 : modification de l'API de `ChoiceJSPage` pour la rendre réutilisable

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -91,9 +91,9 @@ def choice_js_fill():
     ):
         from core.tests.pages import ChoiceJSPage
 
-        ChoiceJSPage(
-            page, sel_or_locator, fill_content, exact_name, check_selection=check_selection
-        ).try_select_option()
+        ChoiceJSPage(page, sel_or_locator).try_select_option(
+            exact_name, search=fill_content, check_selection=check_selection
+        )
 
     return _choice_js_fill
 

--- a/core/tests/pages.py
+++ b/core/tests/pages.py
@@ -54,13 +54,8 @@ class ChoiceJSPage:
         result = self.choice_widget.locator(".choices__list.choices__list--multiple + .choices__input")
         return result.first if result.count() > 0 else self.choice_widget
 
-    def __init__(
-        self, page: Page, sel_or_locator: str | Locator, search_token, exact_name=None, *, check_selection=None
-    ):
+    def __init__(self, page: Page, sel_or_locator: str | Locator):
         self.locator = sel_or_locator if isinstance(sel_or_locator, Locator) else page.locator(sel_or_locator)
-        self._search_token = search_token
-        self._exact_name = exact_name or search_token
-        self._user_check_selection = check_selection
 
     def _try_open(self):
         if self.dropdown.is_visible():
@@ -74,20 +69,22 @@ class ChoiceJSPage:
             ".choices__list.choices__list--single,.choices__list.choices__list--multiple"
         ).get_by_role("option", name=exact_name)
 
-    def _check_selection(self):
-        if callable(self._user_check_selection):
-            return self._user_check_selection()
-        return expect(self._get_selected_option(self._exact_name)).to_have_count(1)
+    def _check_selection(self, exact_name, check_selection):
+        if callable(check_selection):
+            return check_selection()
+        return expect(self._get_selected_option(exact_name)).to_have_count(1)
 
     @playwright_repeatable
-    def try_select_option(self):
+    def try_select_option(self, exact_name, *, search=None, check_selection=None):
+        search = search or exact_name
+
         self._try_open()
-        if len(self._get_selected_option(self._exact_name).all()) > 0:
+        if len(self._get_selected_option(exact_name).all()) > 0:
             # Option already selected
             return
 
-        self.choice_widget.locator("input.choices__input").fill(self._search_token)
+        self.choice_widget.locator("input.choices__input").fill(search)
         self.choice_widget.locator(".choices__list.choices__list--dropdown").get_by_role(
-            "option", name=self._exact_name, exact=True
+            "option", name=exact_name, exact=True
         ).locator("visible=true").click()
-        self._check_selection()
+        self._check_selection(exact_name, check_selection)

--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -162,7 +162,7 @@ def test_fiche_detection_create_without_lieux_and_prelevement(
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
     """Test que les informations de la fiche de détection sont bien enregistrées après création."""
     page.get_by_label("Statut évènement").select_option(value=str(statut_evenement.id))
-    ChoiceJSPage(page, "#organisme-nuisible", "Xylella", organisme_nuisible.libelle_court).try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option(organisme_nuisible.libelle_court, search="Xylella")
     page.get_by_label("Statut réglementaire").select_option(value=str(statut_reglementaire.id))
     page.get_by_label("Contexte").select_option(value=str(contexte.id))
     page.get_by_label("Date 1er signalement").fill("2024-04-21")
@@ -215,7 +215,7 @@ def test_create_fiche_detection_with_lieu(
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
     expect(form_elements.add_prelevement_btn).to_be_disabled()
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option("Mon ON")
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     page.wait_for_timeout(200)
@@ -273,7 +273,7 @@ def test_create_fiche_detection_with_lieu_in_corsica(
     organisme_nuisible = OrganismeNuisibleFactory()
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
     expect(form_elements.add_prelevement_btn).to_be_disabled()
-    ChoiceJSPage(page, "#organisme-nuisible", organisme_nuisible.libelle_court).try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option(organisme_nuisible.libelle_court)
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     page.wait_for_timeout(200)
@@ -328,7 +328,7 @@ def test_create_fiche_detection_with_lieu_not_etablissement(
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
     expect(form_elements.add_prelevement_btn).to_be_disabled()
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option("Mon ON")
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     page.wait_for_timeout(200)
@@ -376,7 +376,7 @@ def test_structure_contact_is_add_to_contacts_list_when_fiche_detection_is_creat
         libelle_long="Mon ON",
     )
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option("Mon ON")
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.publish_btn.click()
 
@@ -408,7 +408,7 @@ def test_agent_contact_is_add_to_contacts_list_when_fiche_detection_is_created(
         libelle_long="Mon ON",
     )
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option("Mon ON")
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.publish_btn.click()
 
@@ -430,7 +430,7 @@ def test_add_lieu_with_name_only_and_save(
         libelle_long="Mon ON",
     )
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option("Mon ON")
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     lieu_form_elements.nom_input.click()
@@ -464,7 +464,7 @@ def test_fiche_detection_status_reglementaire_is_pre_selected(
     organisme_nuisible.save()
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option("Mon ON")
     expect(form_elements.statut_reglementaire_input).to_have_value(str(statut.id))
     page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").click()
 
@@ -498,10 +498,11 @@ def test_fiche_detection_status_reglementaire_is_emptied_when_unknown(
     organisme_nuisible_no_status.libelle_court = "Pas mon ON"
     organisme_nuisible_no_status.save()
 
+    choice_js_page = ChoiceJSPage(page, "#organisme-nuisible")
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    choice_js_page.try_select_option("Mon ON")
     expect(form_elements.statut_reglementaire_input).to_have_value(str(statut.id))
-    ChoiceJSPage(page, "#organisme-nuisible", "Pas mon ON").try_select_option()
+    choice_js_page.try_select_option("Pas mon ON")
     expect(form_elements.statut_reglementaire_input).to_have_value("")
 
 
@@ -519,7 +520,7 @@ def test_prelevements_are_always_linked_to_lieu(
     structures = StructurePreleveuseFactory.create_batch(2)
     page.wait_for_timeout(600)
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option("Mon ON")
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     lieu_form_elements.nom_input.fill("un lieu")
@@ -548,7 +549,7 @@ def test_one_fiche_detection_is_created_when_double_click_on_save_btn(live_serve
         libelle_long="Mon ON",
     )
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option("Mon ON")
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").dblclick()
     page.wait_for_timeout(600)
@@ -643,7 +644,7 @@ def test_can_add_fiche_detection_when_open_and_closed_prelevement_form_modal(
         libelle_long="Mon ON",
     )
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option("Mon ON")
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     lieu_form_elements = LieuFormDomElements(page)
@@ -706,7 +707,7 @@ def test_create_fiche_detection_with_lieu_using_siret(
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
     expect(form_elements.add_prelevement_btn).to_be_disabled()
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option("Mon ON")
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
 
     form_elements.add_lieu_btn.click()
@@ -714,15 +715,13 @@ def test_create_fiche_detection_with_lieu_using_siret(
     lieu_form_elements.lieu_site_inspection_input.select_option("INCONNU")
     lieu_form_elements.is_etablissement_checkbox.click()
     lieu_form_elements.sirene_btn.click()
-    ChoiceJSPage(
-        page,
-        "#header-search-0 .fr-select .choices__list--single",
-        "120 079 017",
+    ChoiceJSPage(page, "#header-search-0").try_select_option(
         "DIRECTION GENERALE DE L'ALIMENTATION DIRECTION GENERALE DE L'ALIMENTATION   12007901700030 - 175 RUE DU CHEVALERET - 75013 PARIS",
+        search="120 079 017",
         check_selection=lambda: expect(
             page.locator('#lieu-form [name$="siret_etablissement"]').locator("visible=true")
         ).to_have_value(siret),
-    ).try_select_option()
+    )
     assert call_count["count"] == 1
 
     lieu_form_elements.save_btn.click()
@@ -763,7 +762,7 @@ def test_can_create_evenement_if_last_evenement_is_deleted(
     statut_reglementaire = StatutReglementaireFactory()
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    ChoiceJSPage(page, "#organisme-nuisible", organisme_nuisible.libelle_court).try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option(organisme_nuisible.libelle_court)
     form_elements.statut_reglementaire_input.select_option(statut_reglementaire.libelle)
     page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").click()
 
@@ -895,7 +894,7 @@ def test_can_add_lieu_with_adresse_auto_complete(
     )
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option("Mon ON")
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     lieu_form_elements.nom_input.fill("un lieu")
@@ -956,7 +955,7 @@ def test_lieu_map(
     )
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option("Mon ON")
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     lieu_form_elements.nom_input.fill("un lieu")
@@ -1023,7 +1022,7 @@ def test_can_add_lieu_with_adresse_etablissement_autocomplete(
     )
 
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option("Mon ON")
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     lieu_form_elements.nom_input.fill("un lieu")
@@ -1056,7 +1055,7 @@ def test_add_lieu_with_supply_chain(
     )
     supply_chain_position = PositionChaineDistributionFactory()
     page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
-    ChoiceJSPage(page, "#organisme-nuisible", "Mon ON").try_select_option()
+    ChoiceJSPage(page, "#organisme-nuisible").try_select_option("Mon ON")
     form_elements.statut_reglementaire_input.select_option("organisme quarantaine")
     form_elements.add_lieu_btn.click()
     lieu_form_elements.nom_input.click()


### PR DESCRIPTION
C'est mieux de passer les éléments concernant l'option à sélectionner dans `try_select_option` plutôt que dans le constructeur. Ça permet de rendre le composant réutilisable. 