### PR TITLE
Change default order of TIAC and Alim

### DIFF
--- a/ssa/tests/test_evenements_list.py
+++ b/ssa/tests/test_evenements_list.py
@@ -19,16 +19,16 @@ def test_old_url_redirects(client):
 
 
 def test_list_table_order_by_default(live_server, mocked_authentification_user, page: Page):
-    EvenementProduitFactory(numero_annee=2025, numero_evenement=2, last_updated=datetime.datetime.now())
-    EvenementProduitFactory(numero_annee=2025, numero_evenement=1, last_updated=datetime.datetime.now())
-    InvestigationCasHumainFactory(numero_annee=2025, numero_evenement=22, last_updated=datetime.datetime.now())
-    InvestigationCasHumainFactory(numero_annee=2024, numero_evenement=22, last_updated=datetime.datetime.now())
+    EvenementProduitFactory(numero_annee=2025, numero_evenement=2)
+    EvenementProduitFactory(numero_annee=2025, numero_evenement=1)
+    InvestigationCasHumainFactory(numero_annee=2025, numero_evenement=22)
+    InvestigationCasHumainFactory(numero_annee=2024, numero_evenement=22)
     search_page = EvenementProduitListPage(page, live_server.url)
     search_page.navigate()
-    assert search_page.numero_cell(line_index=1).text_content() == "A-2024.22"
-    assert search_page.numero_cell(line_index=2).text_content() == "A-2025.22"
+    assert search_page.numero_cell(line_index=1).text_content() == "A-2025.22"
+    assert search_page.numero_cell(line_index=2).text_content() == "A-2025.2"
     assert search_page.numero_cell(line_index=3).text_content() == "A-2025.1"
-    assert search_page.numero_cell(line_index=4).text_content() == "A-2025.2"
+    assert search_page.numero_cell(line_index=4).text_content() == "A-2024.22"
 
 
 def test_list_filtered_by_visibilite(live_server, mocked_authentification_user, page: Page):
@@ -85,8 +85,8 @@ def test_list_can_filter_by_numero(live_server, mocked_authentification_user, pa
 
     search_page.annee_field.fill("2025")
     search_page.submit_search()
-    assert search_page.numero_cell().text_content() == "A-2025.1"
-    assert search_page.numero_cell(line_index=2).text_content() == "A-2025.2"
+    assert search_page.numero_cell().text_content() == "A-2025.2"
+    assert search_page.numero_cell(line_index=2).text_content() == "A-2025.1"
     expect(search_page.page.get_by_text("2024.22")).not_to_be_visible()
 
 

--- a/ssa/views/mixins.py
+++ b/ssa/views/mixins.py
@@ -21,7 +21,7 @@ class WithFilteredListMixin(WithOrderingMixin):
         }
 
     def get_default_order_by(self):
-        return "last_update"
+        return "numero_evenement"
 
     def get_raw_queryset(self):
         user = self.request.user

--- a/tiac/mixins.py
+++ b/tiac/mixins.py
@@ -16,7 +16,7 @@ class WithFilteredListMixin(WithOrderingMixin):
         }
 
     def get_default_order_by(self):
-        return "last_update"
+        return "numero_evenement"
 
     @property
     def get_raw_queryset(self):

--- a/tiac/tests/test_evenement_list.py
+++ b/tiac/tests/test_evenement_list.py
@@ -26,10 +26,10 @@ def test_list_table_order(live_server, mocked_authentification_user, page: Page)
     search_page = EvenementListPage(page, live_server.url)
     search_page.navigate()
 
-    assert search_page.numero_cell(line_index=1).text_content() == "T-2024.22"
-    assert search_page.numero_cell(line_index=2).text_content() == "T-2025.22"
+    assert search_page.numero_cell(line_index=1).text_content() == "T-2025.22"
+    assert search_page.numero_cell(line_index=2).text_content() == "T-2025.2"
     assert search_page.numero_cell(line_index=3).text_content() == "T-2025.1"
-    assert search_page.numero_cell(line_index=4).text_content() == "T-2025.2"
+    assert search_page.numero_cell(line_index=4).text_content() == "T-2024.22"
 
 
 def test_row_content_evenement_simple(live_server, mocked_authentification_user, page: Page):
@@ -84,8 +84,8 @@ def test_list_can_filter_by_numero(live_server, mocked_authentification_user, pa
 
     search_page.annee_field.fill("2025")
     search_page.submit_search()
-    assert search_page.numero_cell().text_content() == "T-2025.1"
-    assert search_page.numero_cell(line_index=2).text_content() == "T-2025.2"
+    assert search_page.numero_cell().text_content() == "T-2025.2"
+    assert search_page.numero_cell(line_index=2).text_content() == "T-2025.1"
     expect(search_page.page.get_by_text("2024.22")).not_to_be_visible()
     expect(search_page.page.get_by_text("2024.2")).not_to_be_visible()
 
@@ -102,8 +102,8 @@ def test_list_can_filter_by_date_publication(live_server, mocked_authentificatio
     search_page.start_date_field.fill("2024-06-17")
     search_page.end_date_field.fill("2024-06-20")
     search_page.submit_search()
-    assert search_page.numero_cell().text_content() == "T-2025.2"
-    assert search_page.numero_cell(line_index=2).text_content() == "T-2025.3"
+    assert search_page.numero_cell().text_content() == "T-2025.3"
+    assert search_page.numero_cell(line_index=2).text_content() == "T-2025.2"
     expect(search_page.page.get_by_text("2025.1")).not_to_be_visible()
     expect(search_page.page.get_by_text("2025.4")).not_to_be_visible()
 
@@ -122,8 +122,8 @@ def test_list_can_filter_by_date_reception(live_server, mocked_authentification_
     search_page.end_date_reception_field.fill("2024-06-20")
     search_page.add_filters()
     search_page.submit_search()
-    assert search_page.numero_cell().text_content() == "T-2025.2"
-    assert search_page.numero_cell(line_index=2).text_content() == "T-2025.3"
+    assert search_page.numero_cell().text_content() == "T-2025.3"
+    assert search_page.numero_cell(line_index=2).text_content() == "T-2025.2"
     expect(search_page.page.get_by_text("2025.1")).not_to_be_visible()
     expect(search_page.page.get_by_text("2025.4")).not_to_be_visible()
 


### PR DESCRIPTION
Back to the number to avoid messing with the way various users uses the application.