### PR TITLE
Adapations Europhyt, partie 3.5 : affichage des éléments infestés en page détails

### DIFF
--- a/core/static/core/base.css
+++ b/core/static/core/base.css
@@ -294,3 +294,10 @@ fieldset {
     .with-empty-placeholder--placeholder {
     display: none;
 }
+
+.seves-card .fr-card__end {
+    height: unset;
+}
+.seves-card .fr-card__desc {
+    flex-grow: 10;
+}

--- a/sv/models/fiches_detection.py
+++ b/sv/models/fiches_detection.py
@@ -181,3 +181,8 @@ class FicheDetection(
 
     def get_soft_delete_attribute_error_message(self):
         return f"La détection {self.numero} ne peut pas être supprimée"
+
+    def prelevements(self):
+        for lieu in self.lieux.all():
+            for prelevement in lieu.prelevements.all():
+                yield prelevement

--- a/sv/static/sv/elements_infestes.mjs
+++ b/sv/static/sv/elements_infestes.mjs
@@ -106,7 +106,7 @@ class ElementInfesteFormController extends BaseFormInModal {
         return `
             <section data-${this.identifier}-target="cardContainer">
                 ${invalidWarning}
-                <div class="fr-card" ${this.isValidValue ? "" : ` aria-labelledby="${id}--error-desc"`} data-testid="element-card">
+                <div class="fr-card seves-card"${this.isValidValue ? "" : ` aria-labelledby="${id}--error-desc"`} data-testid="element-card">
                     <div class="fr-card__body">
                         <div class="fr-card__content">
                             <h3
@@ -132,8 +132,9 @@ class ElementInfesteFormController extends BaseFormInModal {
                                     elementInfeste.quantite,
                                     `<p class="fr-mb-0">Quantité d’éléments infestés : ${elementInfeste.quantite} ${elementInfeste.quantite_unite}</p>`,
                                 )}
-
-                                <div class="fr-btns-group fr-btns-group--inline-lg fr-btns-group--icon-left fr-btns-group--sm fr-btns-group--right fr-mt-4v fr-mb-n4v">
+                            </div>
+                            <div class="fr-card__end">
+                                <div class="fr-btns-group fr-btns-group--sm fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left fr-mb-n4v">
                                     <button
                                         class="fr-btn fr-btn--secondary fr-icon-edit-line modify-button"
                                         type="button"

--- a/sv/templates/sv/_fichedetection_detail.html
+++ b/sv/templates/sv/_fichedetection_detail.html
@@ -33,7 +33,7 @@
         </div>
 
         <div class="fr-grid-row fr-mb-3w fr-grid-row--gutters fr-flex--align-stretch">
-            <div class="fr-col-12 fr-col-lg-4">
+            <div class="fr-col-12 fr-col-lg-6">
                 <div class="white-container">
                     <h2>Objet de l'évènement</h2>
                     <div class="fr-container--fluid">
@@ -48,15 +48,129 @@
                     </div>
                 </div>
             </div>
-
-            <div class="fr-col-12 fr-col-lg-4">
+            <div class="fr-col-12 fr-col-lg-6">
                 <div class="white-container">
-                    <h2>Lieux</h2>
+                    <h2>Éléments infestées</h2>
 
+                    <div class="fr-container--fluid">
+                        <div class="fr-grid-row fr-grid-row--gutters">
+                            {% for element_infeste in fichedetection.elements_infestes.all %}
+                                <dialog
+                                    id="fr-modal-element-infeste-{{ element_infeste.pk }}"
+                                    class="fr-modal"
+                                    aria-labelledby="fr-modal-title-modal-element-infeste-{{ element_infeste.pk }}"
+                                >
+                                    <div class="fr-container fr-container--fluid fr-container-md">
+                                        <div class="fr-grid-row fr-grid-row--center">
+                                            <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
+                                                <div class="fr-modal__body">
+                                                    <div class="fr-modal__header">
+                                                        <button
+                                                            class="fr-btn--close fr-btn"
+                                                            title="Fermer la fenêtre modale"
+                                                            aria-controls="fr-modal-element-infeste-{{ element_infeste.pk }}"
+                                                        >
+                                                            Fermer
+                                                        </button>
+                                                    </div>
+                                                    <div class="fr-modal__content">
+                                                        <h3
+                                                            id="fr-modal-title-modal-element-infeste-{{ element_infeste.pk }}"
+                                                            class="fr-modal__title fr-icon-arrow-right-line fr-icon--lg"
+                                                        >
+                                                            {{ element_infeste.get_type_display }}
+                                                        </h3>
+                                                        <div class="fr-container--fluid">
+                                                            <div class="fr-grid-row fr-grid-row--gutters">
+                                                                <div class="fr-col-5 bold">Espèce végétale</div>
+                                                                <div class="fr-col-7">
+                                                                    {{ element_infeste.espece|or_empty_value_tag }}
+                                                                </div>
+                                                            </div>
+                                                            <div class="fr-grid-row fr-grid-row--gutters">
+                                                                <div class="fr-col-5 bold">
+                                                                    Quantité d’éléments infestés
+                                                                </div>
+                                                                <div class="fr-col-7">
+                                                                    {{ element_infeste.quantite_with_unite|or_empty_value_tag }}
+                                                                </div>
+                                                            </div>
+                                                            <div class="fr-grid-row fr-grid-row--gutters">
+                                                                <div class="fr-col-5 bold">Commentaires</div>
+                                                                <div class="fr-col-7">
+                                                                    {{ element_infeste.comments|or_empty_value_tag }}
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </dialog>
+
+                                <div class="fr-col-12 fr-col-xl-6">
+                                    <section class="fr-card seves-card">
+                                        <div class="fr-card__body">
+                                            <div class="fr-card__content">
+                                                <h3 class="fr-card__title">
+                                                    <button
+                                                        class="fr-link"
+                                                        type="button"
+                                                        data-fr-opened="false"
+                                                        aria-controls="fr-modal-element-infeste-{{ element_infeste.pk }}"
+                                                    >
+                                                        {{ element_infeste.get_type_display }}
+                                                    </button>
+                                                </h3>
+                                                <div class="fr-card__desc fr-mt-4v fr-flex fr-flex--gap-2v">
+                                                    {% if element_infeste.espece %}
+                                                        <p class="fr-mb-0">
+                                                            Espèce végétale : {{ element_infeste.espece }}
+                                                        </p>
+                                                    {% endif %}
+                                                    {% if element_infeste.quantite %}
+                                                        <p class="fr-mb-0">
+                                                            Quantité d’éléments infestés :
+                                                            {{ element_infeste.quantite_with_unite }}
+                                                        </p>
+                                                    {% endif %}
+                                                </div>
+                                                <div class="fr-card__end">
+                                                    <div class="fr-btns-group fr-btns-group--sm fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left fr-mb-n4v">
+                                                        <button
+                                                            class="fr-btn fr-btn--tertiary fr-icon-search-line"
+                                                            type="button"
+                                                            data-fr-opened="false"
+                                                            aria-controls="fr-modal-element-infeste-{{ element_infeste.pk }}"
+                                                        >
+                                                            Voir le détail
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </section>
+                                </div>
+                            {% empty %}
+                                {% empty_value_tag %}
+                            {% endfor %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Lieux -->
+        <div class="fr-col-12 white-container">
+            <h2>Lieux</h2>
+
+            <div class="fr-container--fluid">
+                <div class="fr-grid-row fr-grid-row--gutters">
                     {% for lieu_initial in fichedetection.lieux.all %}
                         {% include "sv/fichedetection_detail_lieu.html" with lieu=lieu_initial lieu_index=lieu_initial.pk %}
-                        <div class="fr-col-6 fr-col-lg-12">
-                            <div class="lieu-initial fr-card fr-mb-4v">
+                        <div class="fr-col-12 fr-col-md-6 fr-col-lg-4 fr-col-xl-3">
+                            <div class="fr-card seves-card" data-testid="lieu-initial">
                                 <div class="fr-card__body">
                                     <div class="fr-card__content">
                                         <div>
@@ -71,17 +185,17 @@
                                             </h3>
                                         </div>
                                         <div class="fr-card__desc">
-                                            <section>
-                                                <address class="fr-card__detail fr-icon-map-pin-2-line">{{ lieu_initial.address_summary|or_empty_value_tag }}</address>
-                                                {% with extra_classes="fr-badge--info fr-badge--no-icon fr-mt-4v fr-mr-4v" %}
-                                                    {% dsfr_badge label=lieu_initial.site_inspection_label_with_group extra_classes=extra_classes %}
-                                                    {% if lieu_initial.position_chaine_distribution_etablissement %}
-                                                        {% dsfr_badge label=lieu_initial.position_chaine_distribution_etablissement extra_classes=extra_classes %}
-                                                    {% endif %}
-                                                {% endwith %}
-                                            </section>
+                                            <address class="fr-card__detail fr-icon-map-pin-2-line">{{ lieu_initial.address_summary|or_empty_value_tag }}</address>
+                                            {% with extra_classes="fr-badge--info fr-badge--no-icon fr-mt-4v fr-mr-4v" %}
+                                                {% dsfr_badge label=lieu_initial.site_inspection_label_with_group extra_classes=extra_classes %}
+                                                {% if lieu_initial.position_chaine_distribution_etablissement %}
+                                                    {% dsfr_badge label=lieu_initial.position_chaine_distribution_etablissement extra_classes=extra_classes %}
+                                                {% endif %}
+                                            {% endwith %}
+                                        </div>
 
-                                            <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-sm fr-btns-group--icon-left fr-mt-4v fr-mb-n4v">
+                                        <div class="fr-card__end">
+                                            <div class="fr-btns-group fr-btns-group--sm fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left fr-mb-n4v">
                                                 <button
                                                     type="button"
                                                     class="fr-btn fr-btn--tertiary fr-icon-search-line see-more-btn"
@@ -97,100 +211,103 @@
                                 </div>
                             </div>
                         </div>
+                    {% empty %}
+                        <div class="fr-col-12">{% empty_value_tag %}</div>
                     {% endfor %}
                 </div>
             </div>
+        </div>
 
-            <!-- Prélèvements et analyses -->
-            <div class="fr-col-12 fr-col-lg-4">
-                <div class="white-container">
-                    <h2>Prélèvements</h2>
-                    {% for lieu in fichedetection.lieux.all %}
-                        {% for prelevement in lieu.prelevements.all %}
-                            {% include "sv/fichedetection_detail_prelevement.html" with prelevement=prelevement prelevement_index=prelevement.pk %}
-                            <div class="fr-col-6 fr-col-lg-12">
-                                <div
-                                    id="add-edit-prelevement-{{ prelevement.pk }}"
-                                    class="prelevement fr-card fr-mb-4v"
-                                    data-testid="lieu-initial"
-                                >
-                                    <div class="fr-card__body">
-                                        <div class="fr-card__content">
-                                            <div>
-                                                <h3 class="fr-card__title lieu-nom">
-                                                    <button
-                                                        type="button"
-                                                        aria-controls="fr-modal-prelevement-{{ prelevement.pk }}"
-                                                        data-fr-opened="false"
-                                                        data-id="{{ prelevement.pk }}"
-                                                    >
-                                                        {{ prelevement.structure_preleveuse }}
-                                                    </button>
-                                                </h3>
-                                            </div>
-                                            <div class="fr-card__desc">
-                                                {% if prelevement.date_prelevement %}
-                                                    <p class="fr-card__detail fr-icon-calendar-2-line fr-mb-3v">
-                                                        {{ prelevement.date_prelevement }}
-                                                    </p>
+        <!-- Prélèvements et analyses -->
+        <div class="fr-col-12 white-container">
+            <h2>Prélèvements</h2>
+            <div class="fr-grid-row fr-grid-row--gutters">
+                {% for prelevement in fichedetection.prelevements %}
+                    {% include "sv/fichedetection_detail_prelevement.html" with prelevement=prelevement prelevement_index=prelevement.pk %}
+                    <div class="fr-col-12 fr-col-md-6 fr-col-lg-4 fr-col-xl-3">
+                        <div
+                            class="fr-card seves-card"
+                            id="add-edit-prelevement-{{ prelevement.pk }}"
+                            data-testid="prelevement"
+                        >
+                            <div class="fr-card__body">
+                                <div class="fr-card__content">
+                                    <div>
+                                        <h3 class="fr-card__title lieu-nom">
+                                            <button
+                                                type="button"
+                                                aria-controls="fr-modal-prelevement-{{ prelevement.pk }}"
+                                                data-fr-opened="false"
+                                                data-id="{{ prelevement.pk }}"
+                                            >
+                                                {{ prelevement.structure_preleveuse }}
+                                            </button>
+                                        </h3>
+                                    </div>
+                                    <div class="fr-card__desc">
+                                        {% if prelevement.date_prelevement %}
+                                            <p class="fr-card__detail fr-icon-calendar-2-line fr-mb-3v">
+                                                {{ prelevement.date_prelevement }}
+                                            </p>
+                                        {% endif %}
+                                        <address class="fr-card__detail fr-icon-map-pin-2-line">
+                                            {{ prelevement.lieu.nom }}
+                                        </address>
+
+                                        <section class="prelevement-other-infos">
+                                            {% if prelevement.numero_echantillon %}
+                                                <p class="prelevement-other-info">
+                                                    Numéro de l'échantillon : {{ prelevement.numero_echantillon }}
+                                                </p>
+                                            {% endif %}
+                                            {% if prelevement.espece_echantillon %}
+                                                <p class="prelevement-other-info">Espèce : {{ prelevement.espece_echantillon.libelle }}</p>
+                                            {% endif %}
+                                            {% if prelevement.laboratoire %}
+                                                <p class="prelevement-other-info">
+                                                    Laboratoire : {{ prelevement.laboratoire.nom }}
+                                                </p>
+                                            {% endif %}
+                                            {% if prelevement.date_prelevement %}
+                                                <p class="prelevement-other-info">
+                                                    Date de prélèvement : {{ prelevement.date_prelevement|date:"d/m/Y" }}
+                                                </p>
+                                            {% endif %}
+                                        </section>
+
+                                        <section class="fr-mt-1v">
+                                            <p class="fr-badge fr-badge--info fr-badge--no-icon fr-mt-3v fr-mr-2v">
+                                                {% if prelevement.is_officiel %}
+                                                    Prélèvement officiel
+                                                {% else %}
+                                                    Prélèvement non officiel
                                                 {% endif %}
-                                                <address class="fr-card__detail fr-icon-map-pin-2-line">
-                                                    {{ prelevement.lieu.nom }}
-                                                </address>
-
-                                                <section class="prelevement-other-infos">
-                                                    {% if prelevement.numero_echantillon %}
-                                                        <p class="prelevement-other-info">
-                                                            Numéro de l'échantillon : {{ prelevement.numero_echantillon }}
-                                                        </p>
-                                                    {% endif %}
-                                                    {% if prelevement.espece_echantillon %}
-                                                        <p class="prelevement-other-info">Espèce : {{ prelevement.espece_echantillon.libelle }}</p>
-                                                    {% endif %}
-                                                    {% if prelevement.laboratoire %}
-                                                        <p class="prelevement-other-info">
-                                                            Laboratoire : {{ prelevement.laboratoire.nom }}
-                                                        </p>
-                                                    {% endif %}
-                                                    {% if prelevement.date_prelevement %}
-                                                        <p class="prelevement-other-info">
-                                                            Date de prélèvement : {{ prelevement.date_prelevement|date:"d/m/Y" }}
-                                                        </p>
-                                                    {% endif %}
-                                                </section>
-
-                                                <section class="fr-mt-1v">
-                                                    <p class="fr-badge fr-badge--info fr-badge--no-icon fr-mt-3v fr-mr-2v">
-                                                        {% if prelevement.is_officiel %}
-                                                            Prélèvement officiel
-                                                        {% else %}
-                                                            Prélèvement non officiel
-                                                        {% endif %}
-                                                    </p>
-                                                    <p class="fr-badge fr-badge--info fr-badge--no-icon fr-mt-3v fr-mr-2v">
-                                                        {{ prelevement.get_resultat_display }}
-                                                    </p>
-                                                </section>
-
-                                                <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-sm fr-btns-group--icon-left fr-mt-4v fr-mb-n4v">
-                                                    <button
-                                                        class="fr-btn fr-btn--tertiary fr-icon-search-line see-more-btn"
-                                                        type="button"
-                                                        data-fr-opened="false"
-                                                        aria-controls="fr-modal-prelevement-{{ prelevement.pk }}"
-                                                        title="Consulter le détail du prélèvement {{ prelevement.numero_echantillon }}"
-                                                    >
-                                                        Voir le détail
-                                                    </button>
-                                                </div>
-                                            </div>
+                                            </p>
+                                            <p class="fr-badge fr-badge--info fr-badge--no-icon fr-mt-3v fr-mr-2v">
+                                                {{ prelevement.get_resultat_display }}
+                                            </p>
+                                        </section>
+                                    </div>
+                                    <div class="fr-card__end">
+                                        <div class="fr-btns-group fr-btns-group--sm fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left fr-mb-n4v">
+                                            <button
+                                                class="fr-btn fr-btn--tertiary fr-icon-search-line see-more-btn"
+                                                type="button"
+                                                data-fr-opened="false"
+                                                aria-controls="fr-modal-prelevement-{{ prelevement.pk }}"
+                                                title="Consulter le détail du prélèvement {{ prelevement.numero_echantillon }}"
+                                            >
+                                                Voir le détail
+                                            </button>
                                         </div>
                                     </div>
                                 </div>
                             </div>
-                        {% endfor %}
-                    {% endfor %}
-                </div>
+                        </div>
+                    </div>
+                {% empty %}
+                    <div class="fr-col-12">{% empty_value_tag %}</div>
+                {% endfor %}
             </div>
         </div>
 

--- a/sv/templates/sv/_fichedetection_form__lieu_card.html
+++ b/sv/templates/sv/_fichedetection_form__lieu_card.html
@@ -1,6 +1,6 @@
 <template id="lieu-carte-tpl">
-    <div class="fr-col fr-col-xl-3 fr-col-sm-6 with-empty-placeholder--item">
-        <div class="fr-card" data-testid="lieu-initial">
+    <div class="fr-col-12 fr-col-md-6 fr-col-xl-3 with-empty-placeholder--item">
+        <div class="fr-card seves-card" data-testid="lieu-initial">
             <div class="fr-card__body">
                 <div class="fr-card__content">
                     <div>
@@ -16,12 +16,11 @@
                         </h3>
                     </div>
                     <div class="fr-card__desc">
-                        <section>
-                            __lieu__
-                            __labels__
-                        </section>
-
-                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-sm fr-btns-group--icon-left fr-mt-4v fr-mb-n4v">
+                        __lieu__
+                        __labels__
+                    </div>
+                    <div class="fr-card__end">
+                        <div class="fr-btns-group fr-btns-group--sm fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left fr-mb-n4v">
                             <button
                                 type="button"
                                 class="fr-btn fr-btn--tertiary fr-icon-pencil-line lieu-edit-btn"

--- a/sv/templates/sv/_fichedetection_form__prelevement_card.html
+++ b/sv/templates/sv/_fichedetection_form__prelevement_card.html
@@ -11,7 +11,7 @@
 </template>
 
 <template id="prelevement-carte-tpl">
-    <div class="fr-col fr-col-xl-4 fr-col-sm-6">
+    <div class="fr-col-12 fr-col-md-6 fr-col-xl-3 with-empty-placeholder--item">
         <div
             id="add-edit-prelevement-__card_id__"
             class="fr-card"
@@ -32,14 +32,13 @@
                         </h3>
                     </div>
                     <div class="fr-card__desc">
-                        <section>
-                            __date_prelevement__
-                            <p class="fr-card__detail fr-icon-map-pin-2-line">__lieu__</p>
-                            <section class="prelevement-other-infos">__other_infos__</section>
-                            <section class="fr-mt-1v">__labels__</section>
-                        </section>
-
-                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-sm fr-btns-group--icon-left fr-mt-4v fr-mb-n4v">
+                        __date_prelevement__
+                        <p class="fr-card__detail fr-icon-map-pin-2-line">__lieu__</p>
+                        <section class="prelevement-other-infos">__other_infos__</section>
+                        <section class="fr-mt-1v">__labels__</section>
+                    </div>
+                    <div class="fr-card__end">
+                        <div class="fr-btns-group fr-btns-group--sm fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left fr-mb-n4v">
                             <button
                                 type="button"
                                 class="fr-btn fr-btn--tertiary fr-icon-pencil-line prelevement-edit-btn"

--- a/sv/templates/sv/fichedetection_form.html
+++ b/sv/templates/sv/fichedetection_form.html
@@ -83,7 +83,7 @@
             </div>
 
             <div class="fr-grid-row fr-grid-row--gutters fr-flex--align-stretch fr-mb-3v">
-                <div class="fr-col fr-col-md-6">
+                <div class="fr-col-12 fr-col-lg-6">
                     <div class="block block--full" data-testid="fiche-detection">
                         <h2 class="fr-h6">Objet de l'évènement</h2>
                         {% if form.organisme_nuisible %}
@@ -123,7 +123,7 @@
                         </p>
                     </div>
                 </div>
-                <div class="fr-col fr-col-md-6">
+                <div class="fr-col-12 fr-col-lg-6">
                     <div class="block block--full" data-testid="elements-infestes">
                         {{ element_infeste_formset }}
                     </div>
@@ -157,7 +157,7 @@
                 {% endfor %}
 
                 <div class="with-empty-placeholder">
-                    <div id="lieux-list" class="fr-flex fr-flex--row fr-grid-row--gutters"></div>
+                    <div id="lieux-list" class="fr-grid-row fr-grid-row--gutters"></div>
                     <p class="with-empty-placeholder--placeholder fr-m-0">Aucun lieu.</p>
                 </div>
             </div>
@@ -183,7 +183,7 @@
                     {% include 'sv/_fichedetection_form__prelevements_modal.html' with id=forloop.counter0 %}
                 {% endfor %}
 
-                <div id="prelevements-list" class="fr-flex fr-flex--row fr-grid-row--gutters"></div>
+                <div id="prelevements-list" class="fr-grid-row fr-grid-row--gutters"></div>
 
                 <div id="no-lieux-text">
                     <p>Aucun prélèvement.</p>
@@ -234,6 +234,5 @@
         {% include "sv/_fichedetection_form__lieu_delete_modal.html" %}
         {% include "sv/_fichedetection_form__lieu_cant_delete_modal.html" %}
         {% include "sv/_fichedetection_form_prelevement_en_attente_modal.html" %}
-
     </main>
 {% endblock %}

--- a/sv/tests/test_evenement_details.py
+++ b/sv/tests/test_evenement_details.py
@@ -334,7 +334,7 @@ def test_will_show_action_buttons_for_fiche_detection_after_showing_lieu_modal(l
     expect(page.get_by_role("button", name="Modifier la détection", exact=True)).to_be_visible()
     expect(page.get_by_role("button", name="Supprimer la détection", exact=True)).to_be_visible()
 
-    page.locator(".lieu-initial").get_by_text("Voir le détail", exact=True).click()
+    page.get_by_test_id("lieu-initial").get_by_text("Voir le détail", exact=True).click()
     page.keyboard.press("Escape")
 
     expect(page.get_by_role("button", name="Modifier la détection", exact=True)).to_be_visible()

--- a/sv/tests/test_evenement_performance_details.py
+++ b/sv/tests/test_evenement_performance_details.py
@@ -2,6 +2,7 @@ import pytest
 
 from core.factories import ContactStructureFactory, DocumentFactory, MessageFactory
 from sv.factories import (
+    ElementInfesteFactory,
     EvenementFactory,
     FicheDetectionFactory,
     FicheZoneFactory,
@@ -9,6 +10,7 @@ from sv.factories import (
     PrelevementFactory,
     ZoneInfesteeFactory,
 )
+from sv.models import FicheDetection
 
 BASE_NUM_QUERIES = 25  # Please note a first call is made without assertion to warm up any possible cache
 
@@ -72,11 +74,11 @@ def test_evenement_performances_with_lieux(client, django_assert_num_queries):
     fiche_detection = FicheDetectionFactory(evenement=evenement)
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 6):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 7):
         client.get(evenement.get_absolute_url())
 
     LieuFactory.create_batch(3, fiche_detection=fiche_detection)
-    with django_assert_num_queries(BASE_NUM_QUERIES + 11):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 12):
         client.get(evenement.get_absolute_url())
 
 
@@ -100,12 +102,31 @@ def test_evenement_performances_with_prelevement(client, django_assert_num_queri
     fiche_detection = FicheDetectionFactory(evenement=evenement)
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 6):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 7):
         client.get(evenement.get_absolute_url())
 
     PrelevementFactory.create_batch(3, lieu__fiche_detection=fiche_detection)
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 12):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 13):
+        client.get(evenement.get_absolute_url())
+
+
+@pytest.mark.django_db
+def test_evenement_performances_with_elements_infestes(client, django_assert_num_queries):
+    evenement = EvenementFactory()
+    fiche_detection: FicheDetection = FicheDetectionFactory(evenement=evenement)
+    assert fiche_detection.elements_infestes.count() == 0
+    client.get(evenement.get_absolute_url())
+
+    with django_assert_num_queries(BASE_NUM_QUERIES + 7):
+        client.get(evenement.get_absolute_url())
+
+    ElementInfesteFactory.create_batch(3, fiche_detection=fiche_detection)
+    fiche_detection.refresh_from_db()
+    assert fiche_detection.elements_infestes.count() == 3
+    client.get(evenement.get_absolute_url())
+
+    with django_assert_num_queries(BASE_NUM_QUERIES + 7):
         client.get(evenement.get_absolute_url())
 
 
@@ -146,5 +167,5 @@ def test_fiche_zone_delimitee_with_multiple_zone_infestee(
 
     client.get(evenement.get_absolute_url())
 
-    with django_assert_num_queries(BASE_NUM_QUERIES + 23):
+    with django_assert_num_queries(BASE_NUM_QUERIES + 24):
         client.get(evenement.get_absolute_url())

--- a/sv/tests/test_fichedetection_detail.py
+++ b/sv/tests/test_fichedetection_detail.py
@@ -109,11 +109,11 @@ def test_prelevement_card(live_server, page):
     prelevement = PrelevementFactory(is_officiel=False, resultat=Prelevement.Resultat.DETECTE)
     page.goto(f"{live_server.url}{prelevement.lieu.fiche_detection.get_absolute_url()}")
 
-    expect(page.locator(".prelevement").get_by_text(prelevement.numero_echantillon)).to_be_visible()
-    expect(page.locator(".prelevement").get_by_text(prelevement.espece_echantillon.libelle)).to_be_visible()
-    expect(page.locator(".prelevement").get_by_text(prelevement.laboratoire.nom)).to_be_visible()
-    expect(page.locator(".prelevement").get_by_text(prelevement.get_resultat_display())).to_be_visible()
-    expect(page.locator(".prelevement").get_by_text("Prélèvement non officiel")).to_be_visible()
+    expect(page.get_by_test_id("prelevement").get_by_text(prelevement.numero_echantillon)).to_be_visible()
+    expect(page.get_by_test_id("prelevement").get_by_text(prelevement.espece_echantillon.libelle)).to_be_visible()
+    expect(page.get_by_test_id("prelevement").get_by_text(prelevement.laboratoire.nom)).to_be_visible()
+    expect(page.get_by_test_id("prelevement").get_by_text(prelevement.get_resultat_display())).to_be_visible()
+    expect(page.get_by_test_id("prelevement").get_by_text("Prélèvement non officiel")).to_be_visible()
 
 
 def test_prelevement_non_officiel_details_with_no_data(live_server, page):

--- a/sv/view_mixins.py
+++ b/sv/view_mixins.py
@@ -15,6 +15,7 @@ from sv.forms import (
 from .constants import KNOWN_OEPP_CODES_FOR_STATUS_REGLEMENTAIRES, KNOWN_OEPPS
 from .filters import EvenementFilter
 from .models import (
+    ElementInfeste,
     Evenement,
     FicheDetection,
     Laboratoire,
@@ -132,6 +133,7 @@ class EvenementDetailMixin(UserPassesTestMixin):
                 "detections__lieux__departement",
                 "detections__lieux__departement__region",
                 "detections__lieux__position_chaine_distribution_etablissement",
+                Prefetch("detections__elements_infestes", queryset=ElementInfeste.objects.select_related("espece")),
             )
         )
 


### PR DESCRIPTION
Dernière étape du ticket des adaptations Europhyt : affichage sur la page de détail évènement. Il contient aussi quelques fix de design et de responsive. Toute la partie design a été validée avec Coralie hier en l'absence de maquettes Figma à jour.

## 1920px

<img width="1920" src="https://github.com/user-attachments/assets/f2378485-7938-443d-940b-ceeb23131632" />


## 1280px

<img width="1280px" src="https://github.com/user-attachments/assets/60ed8abe-81fa-468e-af7e-d8a18de5f00d" />

## 960px

<img width="960" src="https://github.com/user-attachments/assets/f53232fd-4897-44da-af51-66c147ab7386" />
