### PR TITLE
Remove feature flag for rich text editor

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -579,11 +579,11 @@ class Message(AllowsSoftDeleteMixin, WithDocumentPermissionMixin, WithLastUpdate
 
     def get_reply_intro_text(self):
         sender = self.sender.display_with_agent_unit if self.sender else self.sender_structure
-        intro = f"\n\n\n ******* Le {self.date_creation.strftime('%d/%m/%Y à %Hh%M')} {sender} a envoyé à {', '.join([r.display_with_agent_unit for r in self.recipients.all()])}"
+        intro = f"\n\n\n******* Le {self.date_creation.strftime('%d/%m/%Y à %Hh%M')} {sender} a envoyé à {', '.join([r.display_with_agent_unit for r in self.recipients.all()])}"
         if self.recipients_copy.all():
             intro += f" et à (en copie) {', '.join([r.display_with_agent_unit for r in self.recipients_copy.all()])}"
 
-        intro += f" le message suivant *******: \n\n {self.content}"
+        intro += f" le message suivant *******: \n\n{self.content}"
         return intro
 
     def _user_can_interact(self, user):

--- a/core/pages.py
+++ b/core/pages.py
@@ -172,7 +172,6 @@ class ListOfMessagesPage:
 
 class BaseMessagePage(BaseDocumentPage, ListOfMessagesPage, ABC):
     TITLE_ID = "#id_title"
-    CONTENT_ID = "#id_content"
     DRAFT_BTN_TEST_ID = "draft-fildesuivi-add-submit"
     SUBMIT_BTN_TEST_ID = "fildesuivi-add-submit"
 
@@ -264,11 +263,14 @@ class BaseMessagePage(BaseDocumentPage, ListOfMessagesPage, ABC):
 
     @property
     def message_content(self):
-        return self.page.locator(f"{self.CONTENT_ID}")
-
-    @property
-    def message_content_in_rich_text_editor(self):
         return self.page.locator("#rich-text-editor .ql-editor")
+
+    def erase_message_content(self):
+        self.message_content.click()
+        expect(self.message_content).to_be_focused()
+        self.page.keyboard.press("Control+A")
+        self.page.keyboard.press("Backspace")
+        expect(self.message_content).to_have_text("")
 
     @property
     def submit_button(self):

--- a/core/templates/core/message_detail.html
+++ b/core/templates/core/message_detail.html
@@ -1,10 +1,8 @@
 {% extends 'core/base.html' %}
 {% load static waffle_tags %}
 {% block extrahead %}
-    {% flag "rich_text_editor" %}
-        <link rel="stylesheet" href="{% static 'core/message_detail.css' %}">
-        <link rel="stylesheet" href="{% static 'core/message_colors.css' %}">
-    {% endflag %}
+    <link rel="stylesheet" href="{% static 'core/message_detail.css' %}">
+    <link rel="stylesheet" href="{% static 'core/message_colors.css' %}">
 {% endblock %}
 {% block content %}
     {% for document in documents %}
@@ -87,11 +85,7 @@
                                     </div>
 
                                     <hr class="fr-hr-or fr-mt-2w">
-                                    {% flag "rich_text_editor" %}
-                                        {{ message.safe_message_content|linebreaksbr }}
-                                    {% else %}
-                                        {{ message.content|linebreaksbr }}
-                                    {% endflag %}
+                                    {{ message.safe_message_content|linebreaksbr }}
                                 </div>
                             </div>
                             <div class="fr-col-4 white-container">

--- a/core/templates/core/message_form.html
+++ b/core/templates/core/message_form.html
@@ -3,18 +3,14 @@
 
 {% block extrahead %}
     <link rel="stylesheet" href="{% static 'core/message_page.css' %}">
-    {% flag "rich_text_editor" %}
-        <link href="https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.snow.css" rel="stylesheet">
-        <link rel="stylesheet" href="{% static 'core/rich_text_editor.css' %}">
-        <link rel="stylesheet" href="{% static 'core/message_colors.css' %}">
-    {% endflag %}
+    <link href="https://cdn.jsdelivr.net/npm/quill@2.0.3/dist/quill.snow.css" rel="stylesheet">
+    <link rel="stylesheet" href="{% static 'core/rich_text_editor.css' %}">
+    <link rel="stylesheet" href="{% static 'core/message_colors.css' %}">
 {% endblock %}
 {% block scripts %}
     <script type="module" src="{% static 'core/message_form_page.mjs' %}"></script>
 
-    {% flag "rich_text_editor" %}
-        <script type="module" src="{% static 'core/rich_text_editor.mjs' %}"></script>
-    {% endflag %}
+    <script type="module" src="{% static 'core/rich_text_editor.mjs' %}"></script>
 {% endblock %}
 
 {% block content %}
@@ -58,77 +54,67 @@
                 {% csrf_token %}
                 <input type="hidden" name="id" value="{{ form.instance.pk }}">
                 <div class="white-container">
-                    {% flag "rich_text_editor" %}
-                        <div data-controller="rich-text-editor">
-                            {% for field in form %}
-                                {% if field.name == "content" %}
-                                    <div class="fr-fieldset__element fr-hidden">
-                                        {% with data_target=field.name|strfmt:"message-form-target:{0}" %}
-                                            {% dsfr_form_field field|set_data:data_target|set_data:"rich-text-editor-target:textarea" %}
-                                        {% endwith %}
-                                    </div>
-                                {% else %}
-                                    <div class="fr-fieldset__element">
-                                        {% with data_target=field.name|strfmt:"message-form-target:{0}" %}
-                                            {% dsfr_form_field field|set_data:data_target %}
-                                        {% endwith %}
-                                    </div>
-                                {% endif %}
-                            {% endfor %}
-                            <div class="fr-fieldset__element">
-                                <label for="rich-text-editor" class="fr-label required-field fr-mb-2v">
-                                    Message<span class="fr-sr-only fr-required-marker">*</span>
-                                </label>
-                                <div id="toolbar">
-                                    <span class="ql-formats">
-                                        <select class="ql-header">
-                                            <option value="2">Titre</option>
-                                            <option selected>Normal</option>
-                                        </select>
-                                    </span>
-                                    <span class="ql-formats">
-                                        <button class="ql-bold"></button>
-                                        <button class="ql-italic"></button>
-                                        <button class="ql-underline"></button>
-                                        <button class="ql-strike"></button>
-                                        <button class="ql-list" value="bullet"></button>
-                                    </span>
-                                    <span class="ql-formats">
-                                        <button class="ql-indent" value="-1"></button>
-                                        <button class="ql-indent" value="+1"></button>
-                                    </span>
-
-                                    <span class="ql-formats">
-                                        <select class="ql-color">
-                                            <option value="grey-200-850" selected="selected"></option>
-                                            <option value="blue-france-sun-113-625"></option>
-                                            <option value="success-425-625"></option>
-                                            <option value="purple-glycine-main-494"></option>
-                                            <option value="error-425-625"></option>
-                                        </select>
-                                        <select class="ql-background">
-                                            <option selected="selected"></option>
-                                            <option value="yellow-tournesol-925-125"></option>
-                                            <option value="green-emeraude-950-100"></option>
-                                            <option value="green-archipel-950-100"></option>
-                                            <option value="pink-macaron-925-125"></option>
-                                            <option value="purple-glycine-925-125"></option>
-                                            <option value="blue-ecume-925-125"></option>
-                                        </select>
-                                    </span>
-                                </div>
-                                <div data-rich-text-editor-target="container" id="rich-text-editor"></div>
-                            </div>
-                        </div>
-                    {% else %}
+                    <div data-controller="rich-text-editor">
                         {% for field in form %}
-                            <div class="fr-fieldset__element">
-                                {% with data_target=field.name|strfmt:"message-form-target:{0}" %}
-                                    {% dsfr_form_field field|set_data:data_target %}
-                                {% endwith %}
-                            </div>
+                            {% if field.name == "content" %}
+                                <div class="fr-fieldset__element fr-hidden">
+                                    {% with data_target=field.name|strfmt:"message-form-target:{0}" %}
+                                        {% dsfr_form_field field|set_data:data_target|set_data:"rich-text-editor-target:textarea" %}
+                                    {% endwith %}
+                                </div>
+                            {% else %}
+                                <div class="fr-fieldset__element">
+                                    {% with data_target=field.name|strfmt:"message-form-target:{0}" %}
+                                        {% dsfr_form_field field|set_data:data_target %}
+                                    {% endwith %}
+                                </div>
+                            {% endif %}
                         {% endfor %}
-                    {% endflag %}
+                        <div class="fr-fieldset__element">
+                            <label for="rich-text-editor" class="fr-label required-field fr-mb-2v">
+                                Message<span class="fr-sr-only fr-required-marker">*</span>
+                            </label>
+                            <div id="toolbar">
+                                <span class="ql-formats">
+                                    <select class="ql-header">
+                                        <option value="2">Titre</option>
+                                        <option selected>Normal</option>
+                                    </select>
+                                </span>
+                                <span class="ql-formats">
+                                    <button class="ql-bold"></button>
+                                    <button class="ql-italic"></button>
+                                    <button class="ql-underline"></button>
+                                    <button class="ql-strike"></button>
+                                    <button class="ql-list" value="bullet"></button>
+                                </span>
+                                <span class="ql-formats">
+                                    <button class="ql-indent" value="-1"></button>
+                                    <button class="ql-indent" value="+1"></button>
+                                </span>
+
+                                <span class="ql-formats">
+                                    <select class="ql-color">
+                                        <option value="grey-200-850" selected="selected"></option>
+                                        <option value="blue-france-sun-113-625"></option>
+                                        <option value="success-425-625"></option>
+                                        <option value="purple-glycine-main-494"></option>
+                                        <option value="error-425-625"></option>
+                                    </select>
+                                    <select class="ql-background">
+                                        <option selected="selected"></option>
+                                        <option value="yellow-tournesol-925-125"></option>
+                                        <option value="green-emeraude-950-100"></option>
+                                        <option value="green-archipel-950-100"></option>
+                                        <option value="pink-macaron-925-125"></option>
+                                        <option value="purple-glycine-925-125"></option>
+                                        <option value="blue-ecume-925-125"></option>
+                                    </select>
+                                </span>
+                            </div>
+                            <div data-rich-text-editor-target="container" id="rich-text-editor"></div>
+                        </div>
+                    </div>
                 </div>
 
                 <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--right fr-mt-4v">

--- a/core/tests/generic_tests/messages.py
+++ b/core/tests/generic_tests/messages.py
@@ -24,7 +24,7 @@ def generic_test_can_add_and_see_message_without_document(live_server, page: Pag
     expect(message_page.message_form_title).to_have_text("Nouveau message")
 
     message_page.message_title.fill("Title of the message")
-    message_page.message_content.fill("My content \n with a line return")
+    message_page.message_content.type("My content \n with a line return")
     message_page.submit_message()
 
     page.wait_for_url(f"**{object.get_absolute_url()}#tabpanel-messages-panel")
@@ -37,7 +37,7 @@ def generic_test_can_add_and_see_message_without_document(live_server, page: Pag
     new_page = message_page.open_message()
 
     expect(new_page.get_by_text("Title of the message", exact=True)).to_be_visible()
-    assert "My content <br> with a line return" in new_page.content()
+    assert "<p>My content </p><p> with a line return</p>" in new_page.content()
     assert object.messages.get().status == Message.Status.FINALISE
 
 
@@ -53,13 +53,13 @@ def generic_test_can_add_and_see_message_with_rich_text_editor(live_server, page
 
     message_page.message_title.fill("Title of the message")
     message_page.page.locator(".ql-bold").click()
-    message_page.message_content_in_rich_text_editor.type("My content \n with a line return\n")
+    message_page.message_content.type("My content \n with a line return\n")
     message_page.page.locator(".ql-color.ql-picker.ql-color-picker").click()
     message_page.page.locator(".ql-primary").nth(1).click()
-    message_page.message_content_in_rich_text_editor.type("Text in color\n")
+    message_page.message_content.type("Text in color\n")
     message_page.page.locator(".ql-list").click()
-    message_page.message_content_in_rich_text_editor.type("Item 1\n")
-    message_page.message_content_in_rich_text_editor.type("Item 2\n")
+    message_page.message_content.type("Item 1\n")
+    message_page.message_content.type("Item 2\n")
 
     message_page.submit_message()
 
@@ -126,7 +126,8 @@ def generic_test_can_update_draft_message_in_new_tab(
     page.keyboard.press("Escape")
     message_page.pick_recipient_copy(contact_cc_to_add.agent, choice_js_fill)
     message_page.message_title.fill("Titre mis à jour")
-    message_page.message_content.fill("Contenu mis à jour")
+    message_page.erase_message_content()
+    message_page.message_content.type("Contenu mis à jour")
     message_page.save_as_draft_message()
 
     message.refresh_from_db()
@@ -137,7 +138,7 @@ def generic_test_can_update_draft_message_in_new_tab(
     assert set(message.recipients_copy.all()) == {contact_cc, contact_cc_to_add}
     assert message.status == Message.Status.BROUILLON
     assert message.title == "Titre mis à jour"
-    assert message.content == "Contenu mis à jour"
+    assert message.content == "<p>Contenu mis à jour</p>"
     assert len(mailoutbox) == 0
 
 
@@ -170,14 +171,15 @@ def generic_test_can_update_draft_note_in_new_tab(
     message_page.open_message()
 
     message_page.message_title.fill("Titre mis à jour")
-    message_page.message_content.fill("Contenu mis à jour")
+    message_page.erase_message_content()
+    message_page.message_content.type("Contenu mis à jour")
     message_page.save_as_draft_message()
 
     message.refresh_from_db()
     assert message.message_type == Message.NOTE
     assert message.status == Message.Status.BROUILLON
     assert message.title == "Titre mis à jour"
-    assert message.content == "Contenu mis à jour"
+    assert message.content == "<p>Contenu mis à jour</p>"
     assert len(mailoutbox) == 0
 
 
@@ -196,14 +198,15 @@ def generic_test_can_update_draft_point_situation_in_new_tab(
     message_page.open_message()
 
     message_page.message_title.fill("Titre mis à jour")
-    message_page.message_content.fill("Contenu mis à jour")
+    message_page.erase_message_content()
+    message_page.message_content.type("Contenu mis à jour")
     message_page.save_as_draft_message()
 
     message.refresh_from_db()
     assert message.message_type == Message.POINT_DE_SITUATION
     assert message.status == Message.Status.BROUILLON
     assert message.title == "Titre mis à jour"
-    assert message.content == "Contenu mis à jour"
+    assert message.content == "<p>Contenu mis à jour</p>"
     assert len(mailoutbox) == 0
 
 
@@ -230,7 +233,8 @@ def generic_test_can_update_draft_demande_intervention_in_new_tab(
     page.keyboard.press("Escape")
     message_page.pick_recipient_copy(contact_cc_to_add.structure, choice_js_fill)
     message_page.message_title.fill("Titre mis à jour")
-    message_page.message_content.fill("Contenu mis à jour")
+    message_page.erase_message_content()
+    message_page.message_content.type("Contenu mis à jour")
     message_page.save_as_draft_message()
 
     message.refresh_from_db()
@@ -241,7 +245,7 @@ def generic_test_can_update_draft_demande_intervention_in_new_tab(
     assert set(message.recipients_copy.all()) == {contact_cc, contact_cc_to_add}
     assert message.status == Message.Status.BROUILLON
     assert message.title == "Titre mis à jour"
-    assert message.content == "Contenu mis à jour"
+    assert message.content == "<p>Contenu mis à jour</p>", f"{message.content} différent de <p>Contenu mis à jour</p>"
     assert len(mailoutbox) == 0
 
 
@@ -359,7 +363,7 @@ def generic_test_handle_document_validation_error(live_server, page: Page, choic
     message_page.pick_recipient(active_contact, choice_js_fill)
     expect(message_page.message_form_title).to_have_text("Nouveau message")
     message_page.message_title.fill("Title of the message")
-    message_page.message_content.fill("My content \n with a line return")
+    message_page.message_content.type("My content \n with a line return")
 
     message_page.add_basic_document(close=False)
     message_page.document_type_input.select_option("Choisir dans la liste")
@@ -479,7 +483,7 @@ def generic_test_can_add_and_see_note_in_new_tab_without_document(live_server, p
     expect((message_page.page.get_by_text("Nouvelle note"))).to_be_visible()
 
     message_page.message_title.fill("Title of the message")
-    message_page.message_content.fill("My content \n with a line return")
+    message_page.message_content.type("My content \n with a line return")
     message_page.submit_message()
 
     page.wait_for_url(f"**{object.get_absolute_url()}#tabpanel-messages-panel")
@@ -520,7 +524,7 @@ def generic_test_can_add_and_see_demande_intervention_in_new_tab_without_documen
     expect((message_page.page.get_by_text("Nouvelle demande d'intervention"))).to_be_visible()
 
     message_page.message_title.fill("Title of the message")
-    message_page.message_content.fill("My content \n with a line return")
+    message_page.message_content.type("My content \n with a line return")
     message_page.submit_message()
 
     page.wait_for_url(f"**{object.get_absolute_url()}#tabpanel-messages-panel")
@@ -555,7 +559,7 @@ def generic_test_can_add_and_see_point_de_situation_in_new_tab_without_document(
     expect((message_page.page.get_by_text("Nouveau point de situation"))).to_be_visible()
 
     message_page.message_title.fill("Title of the message")
-    message_page.message_content.fill("My content \n with a line return")
+    message_page.message_content.type("My content \n with a line return")
     message_page.submit_message()
 
     page.wait_for_url(f"**{object.get_absolute_url()}#tabpanel-messages-panel")
@@ -665,9 +669,12 @@ def generic_test_can_reply_to_message(live_server, page: Page, choice_js_fill, o
     message_page.page.get_by_text("Répondre", exact=True).click()
 
     assert message_page.message_title.input_value() == f"{settings.REPLY_PREFIX} {message.title}"
-    assert message_page.message_content.input_value() == message.get_reply_intro_text()
+    assert message_page.message_content.inner_text().replace("\n", "") == message.get_reply_intro_text().replace(
+        "\n", ""
+    )
 
-    message_page.message_content.fill("Ma réponse")
+    message_page.erase_message_content()
+    message_page.message_content.type("Ma réponse")
     message_page.pick_recipient_copy(contact.agent, choice_js_fill)
     message_page.submit_message()
 
@@ -675,7 +682,7 @@ def generic_test_can_reply_to_message(live_server, page: Page, choice_js_fill, o
     reply = Message.objects.first()
 
     expected_title = f"{settings.REPLY_PREFIX} {message.title}"
-    expected_content = "Ma réponse"
+    expected_content = "<p>Ma réponse</p>"
     expected_recipients = [contact_sender_structure]
 
     assert reply.title == expected_title, f"{reply.title=!r} != {expected_title=!r}"

--- a/ssa/tests/test_evenement_produit_message.py
+++ b/ssa/tests/test_evenement_produit_message.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from playwright.sync_api import Page, expect
 import pytest
-from waffle.testutils import override_flag
 
 from core.factories import ContactAgentFactory, ContactStructureFactory, MessageFactory
 from core.models import Message
@@ -44,13 +43,11 @@ def test_can_add_and_see_message_without_document(live_server, page: Page, choic
     generic_test_can_add_and_see_message_without_document(live_server, page, choice_js_fill, evenement_produit)
 
 
-@override_flag("rich_text_editor", active=True)
 def test_can_add_and_see_message_with_rich_text_editor(live_server, page: Page, choice_js_fill):
     evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
     generic_test_can_add_and_see_message_with_rich_text_editor(live_server, page, choice_js_fill, evenement_produit)
 
 
-@override_flag("rich_text_editor", active=True)
 def test_can_send_draft_message_with_rich_text_editor(live_server, page: Page, mocked_authentification_user):
     evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
     generic_test_can_send_draft_message_with_rich_text_editor(

--- a/ssa/tests/test_investigation_cas_humain_message.py
+++ b/ssa/tests/test_investigation_cas_humain_message.py
@@ -1,6 +1,5 @@
 from playwright.sync_api import Page
 import pytest
-from waffle.testutils import override_flag
 
 from core.factories import ContactStructureFactory, MessageFactory
 from core.models import Message
@@ -43,13 +42,11 @@ def test_can_add_and_see_message_without_document(live_server, page: Page, choic
     generic_test_can_add_and_see_message_without_document(live_server, page, choice_js_fill, evenement_produit)
 
 
-@override_flag("rich_text_editor", active=True)
 def test_can_add_and_see_message_with_rich_text_editor(live_server, page: Page, choice_js_fill):
     evenement = InvestigationCasHumainFactory(etat=EvenementInvestigationCasHumain.Etat.EN_COURS)
     generic_test_can_add_and_see_message_with_rich_text_editor(live_server, page, choice_js_fill, evenement)
 
 
-@override_flag("rich_text_editor", active=True)
 def test_can_send_draft_message_with_rich_text_editor(live_server, page: Page, mocked_authentification_user):
     evenement = InvestigationCasHumainFactory(etat=EvenementInvestigationCasHumain.Etat.EN_COURS)
     generic_test_can_send_draft_message_with_rich_text_editor(

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -6,7 +6,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from playwright.sync_api import Page, expect
 import pytest
-from waffle.testutils import override_flag
 
 from core.constants import AC_STRUCTURE, MUS_STRUCTURE, Visibilite
 from core.factories import (
@@ -61,13 +60,11 @@ def test_can_add_and_see_message_without_document(live_server, page: Page, choic
     generic_test_can_add_and_see_message_without_document(live_server, page, choice_js_fill, evenement)
 
 
-@override_flag("rich_text_editor", active=True)
 def test_can_add_and_see_message_with_rich_text_editor(live_server, page: Page, choice_js_fill):
     evenement = EvenementFactory()
     generic_test_can_add_and_see_message_with_rich_text_editor(live_server, page, choice_js_fill, evenement)
 
 
-@override_flag("rich_text_editor", active=True)
 def test_can_send_draft_message_with_rich_text_editor(live_server, page: Page, mocked_authentification_user):
     evenement = EvenementFactory()
     generic_test_can_send_draft_message_with_rich_text_editor(
@@ -125,7 +122,7 @@ def test_can_add_and_see_compte_rendu_in_new_tab(live_server, page: Page, choice
     page.get_by_text("MUS", exact=True).click()
     page.get_by_text("BSV", exact=True).click()
     page.locator("#id_title").fill("Title of the message")
-    page.locator("#id_content").fill("My content \n with a line return")
+    page.locator("#rich-text-editor .ql-editor").fill("My content \n with a line return")
     choice_js_fill(
         page,
         'label[for="id_recipients_copy"] ~ div.choices',
@@ -208,7 +205,7 @@ def test_can_add_and_see_message_with_multiple_recipients_and_copies(live_server
     )
 
     page.locator("#id_title").fill("Title of the message")
-    page.locator("#id_content").fill("My content \n with a line return")
+    page.locator("#rich-text-editor .ql-editor").fill("My content \n with a line return")
     page.get_by_test_id("fildesuivi-add-submit").click()
 
     assert page.url == f"{live_server.url}{evenement.get_absolute_url()}#tabpanel-messages-panel"
@@ -233,7 +230,7 @@ def test_can_add_and_see_message_with_multiple_recipients_and_copies(live_server
     new_page = new_page_info.value
 
     expect(new_page.get_by_role("heading", name="Title of the message")).to_be_visible()
-    assert "My content <br> with a line return" in new_page.content()
+    assert "<p>My content </p><p> with a line return</p>" in new_page.content()
 
     # Check that all the recipients / copies were added as contact
     new_page.goto(f"{live_server.url}{evenement.get_absolute_url()}")
@@ -282,7 +279,7 @@ def test_can_click_on_shortcut_when_evenement_has_structure(live_server, page: P
 
     message_page.page.locator(".destinataires-shortcut").locator("visible=true").click()
     message_page.page.locator("#id_title").fill("Title of the message")
-    message_page.page.locator("#id_content").fill("My content \n with a line return")
+    message_page.page.locator("#rich-text-editor .ql-editor").fill("My content \n with a line return")
     message_page.page.get_by_test_id("fildesuivi-add-submit").click()
 
     message_page.page.wait_for_url(f"**{evenement.get_absolute_url()}#tabpanel-messages-panel")
@@ -312,7 +309,7 @@ def test_can_click_on_add_all_contacts_shortcut_when_evenement_has_contact(
 
     message_page.page.locator(".destinataires-contacts-shortcut").locator("visible=true").click()
     message_page.page.locator("#id_title").fill("Title of the message")
-    message_page.page.locator("#id_content").fill("My content \n with a line return")
+    message_page.page.locator("#rich-text-editor .ql-editor").fill("My content \n with a line return")
     message_page.page.get_by_test_id("fildesuivi-add-submit").click()
     message_page.page.wait_for_url(f"**{evenement.get_absolute_url()}#tabpanel-messages-panel")
 
@@ -484,13 +481,13 @@ def test_create_message_adds_agent_and_structure_contacts(
     )
     page.keyboard.press("Escape")
     page.locator("#id_title").fill("Title of the message")
-    page.locator("#id_content").fill("Message de test")
+    page.locator("#rich-text-editor .ql-editor").fill("Message de test")
     page.get_by_test_id("fildesuivi-add-submit").click()
 
     # Vérification que le message a été créé
     assert evenement.messages.count() == 1
     message = evenement.messages.get()
-    assert message.content == "Message de test"
+    assert message.content == "<p>Message de test</p>"
     assert message.message_type == Message.MESSAGE
 
     # Vérification des contacts dans l'interface
@@ -541,7 +538,7 @@ def test_create_multiple_messages_adds_contacts_once(
         use_locator_as_parent_element=True,
     )
     page.locator("#id_title").fill("Message 1")
-    page.locator("#id_content").fill("Message de test 1")
+    page.locator("#rich-text-editor .ql-editor").fill("Message de test 1")
     page.get_by_test_id("fildesuivi-add-submit").click()
 
     # Ajout du second message
@@ -556,7 +553,7 @@ def test_create_multiple_messages_adds_contacts_once(
         use_locator_as_parent_element=True,
     )
     page.locator("#id_title").fill("Message 2")
-    page.locator("#id_content").fill("Message de test 2")
+    page.locator("#rich-text-editor .ql-editor").fill("Message de test 2")
     page.get_by_test_id("fildesuivi-add-submit").click()
 
     # Vérification que les deux messages ont été créés
@@ -609,7 +606,7 @@ def test_create_message_from_locale_changes_to_limitee_and_add_structures_in_all
         use_locator_as_parent_element=True,
     )
     page.locator("#id_title").fill("Title of the message")
-    page.locator("#id_content").fill("Message de test")
+    page.locator("#rich-text-editor .ql-editor").fill("Message de test")
     page.get_by_test_id("fildesuivi-add-submit").click()
 
     evenement.refresh_from_db()
@@ -644,7 +641,7 @@ def test_create_message_from_locale_from_same_structure_does_not_changes_visibil
         use_locator_as_parent_element=True,
     )
     page.locator("#id_title").fill("Title of the message")
-    page.locator("#id_content").fill("Message de test")
+    page.locator("#rich-text-editor .ql-editor").fill("Message de test")
     page.get_by_test_id("fildesuivi-add-submit").click()
 
     evenement.refresh_from_db()
@@ -682,7 +679,7 @@ def test_create_message_from_visibilite_limitee_add_structures_in_allowed_struct
         use_locator_as_parent_element=True,
     )
     page.locator("#id_title").fill("Title of the message")
-    page.locator("#id_content").fill("Message de test")
+    page.locator("#rich-text-editor .ql-editor").fill("Message de test")
     page.get_by_test_id("fildesuivi-add-submit").click()
 
     # Vérification que le message a été créé
@@ -766,7 +763,7 @@ def test_message_with_national_referent_does_not_add_structure(live_server, page
         use_locator_as_parent_element=True,
     )
     page.locator("#id_title").fill("Message pour référent national")
-    page.locator("#id_content").fill("Test avec référent national")
+    page.locator("#rich-text-editor .ql-editor").fill("Test avec référent national")
     page.get_by_test_id("fildesuivi-add-submit").click()
 
     assert evenement.contacts.filter(agent=national_referent.agent).exists()
@@ -808,7 +805,7 @@ def test_message_with_two_national_referents_in_same_structure_does_not_add_stru
         use_locator_as_parent_element=True,
     )
     page.locator("#id_title").fill("Message pour deux référents nationaux")
-    page.locator("#id_content").fill("Test avec deux référents nationaux")
+    page.locator("#rich-text-editor .ql-editor").fill("Test avec deux référents nationaux")
     page.get_by_test_id("fildesuivi-add-submit").click()
 
     assert evenement.contacts.filter(agent=national_referent1.agent).exists()
@@ -846,7 +843,7 @@ def test_message_with_national_referent_and_regular_agent_add_structure(live_ser
         use_locator_as_parent_element=True,
     )
     page.locator("#id_title").fill("Message pour référent national et agent normal")
-    page.locator("#id_content").fill("Test avec deux destinataires")
+    page.locator("#rich-text-editor .ql-editor").fill("Test avec deux destinataires")
     page.get_by_test_id("fildesuivi-add-submit").click()
 
     assert evenement.contacts.filter(agent=national_referent.agent).exists()
@@ -883,7 +880,7 @@ def test_message_with_national_referent_and_regular_agent_in_different_structure
         use_locator_as_parent_element=True,
     )
     page.locator("#id_title").fill("Message pour agents de structures différentes")
-    page.locator("#id_content").fill("Test avec deux destinataires de structures différentes")
+    page.locator("#rich-text-editor .ql-editor").fill("Test avec deux destinataires de structures différentes")
     page.get_by_test_id("fildesuivi-add-submit").click()
 
     assert evenement.contacts.filter(agent=national_referent.agent).exists()
@@ -907,7 +904,7 @@ def test_can_add_draft_message(live_server, page: Page, choice_js_fill, mailoutb
         use_locator_as_parent_element=True,
     )
     page.locator("#id_title").fill("Title of the message")
-    page.locator("#id_content").fill("My content \n with a line return")
+    page.locator("#rich-text-editor .ql-editor").fill("My content \n with a line return")
     page.get_by_role("button", name="Enregistrer comme brouillon").click()
 
     cell_selector = f"#table-sm-row-key-1 td:nth-child({4}) a"
@@ -925,7 +922,7 @@ def test_can_add_draft_note(live_server, page: Page, choice_js_fill, mailoutbox)
     page.get_by_test_id("element-actions").click()
     page.get_by_role("link", name="Note").click()
     page.locator("#id_title").fill("Title of the note")
-    page.locator("#id_content").fill("My content \n with a line return")
+    page.locator("#rich-text-editor .ql-editor").fill("My content \n with a line return")
     page.get_by_role("button", name="Enregistrer comme brouillon").click()
 
     cell_selector = f"#table-sm-row-key-1 td:nth-child({4}) a"
@@ -943,7 +940,7 @@ def test_can_add_draft_point_situtation(live_server, page: Page, choice_js_fill,
     page.get_by_test_id("element-actions").click()
     page.get_by_role("link", name="Point de situation").click()
     page.locator("#id_title").fill("Title of the point de situation")
-    page.locator("#id_content").fill("My content \n with a line return")
+    page.locator("#rich-text-editor .ql-editor").fill("My content \n with a line return")
     page.get_by_role("button", name="Enregistrer comme brouillon").click()
 
     cell_selector = f"#table-sm-row-key-1 td:nth-child({4}) a"
@@ -976,7 +973,7 @@ def test_can_add_draft_demande_intervention(
         use_locator_as_parent_element=True,
     )
     page.locator("#id_title").fill("Title of the demande d'intervention")
-    page.locator("#id_content").fill("My content \n with a line return")
+    page.locator("#rich-text-editor .ql-editor").fill("My content \n with a line return")
     page.get_by_role("button", name="Enregistrer comme brouillon").click()
 
     cell_selector = f"#table-sm-row-key-1 td:nth-child({4}) a"
@@ -1000,7 +997,7 @@ def test_can_add_draft_compte_rendu(live_server, page: Page, mailoutbox):
     page.get_by_text("MUS", exact=True).click()
     page.get_by_text("BSV", exact=True).click()
     page.locator("#id_title").fill("Title of the message")
-    page.locator("#id_content").fill("My content \n with a line return")
+    page.locator("#rich-text-editor .ql-editor").fill("My content \n with a line return")
     page.get_by_role("button", name="Enregistrer comme brouillon").click()
 
     cell_selector = f"#table-sm-row-key-1 td:nth-child({4}) a"

--- a/tiac/tests/test_evenement_simple_message.py
+++ b/tiac/tests/test_evenement_simple_message.py
@@ -1,6 +1,5 @@
 from playwright.sync_api import Page, expect
 import pytest
-from waffle.testutils import override_flag
 
 from core.factories import ContactAgentFactory, ContactStructureFactory
 from core.models import Message
@@ -45,13 +44,11 @@ def test_can_add_and_see_message_without_document(live_server, page: Page, choic
     generic_test_can_add_and_see_message_without_document(live_server, page, choice_js_fill, evenement_produit)
 
 
-@override_flag("rich_text_editor", active=True)
 def test_can_add_and_see_message_with_rich_text_editor(live_server, page: Page, choice_js_fill):
     evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
     generic_test_can_add_and_see_message_with_rich_text_editor(live_server, page, choice_js_fill, evenement)
 
 
-@override_flag("rich_text_editor", active=True)
 def test_can_send_draft_message_with_rich_text_editor(live_server, page: Page, mocked_authentification_user):
     evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
     generic_test_can_send_draft_message_with_rich_text_editor(

--- a/tiac/tests/test_investigation_message.py
+++ b/tiac/tests/test_investigation_message.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from playwright.sync_api import Page, expect
 import pytest
-from waffle.testutils import override_flag
 
 from core.factories import ContactAgentFactory, ContactStructureFactory
 from core.models import Message
@@ -46,13 +45,11 @@ def test_can_add_and_see_message_without_document(live_server, page: Page, choic
     generic_test_can_add_and_see_message_without_document(live_server, page, choice_js_fill, evenement)
 
 
-@override_flag("rich_text_editor", active=True)
 def test_can_add_and_see_message_with_rich_text_editor(live_server, page: Page, choice_js_fill):
     evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
     generic_test_can_add_and_see_message_with_rich_text_editor(live_server, page, choice_js_fill, evenement)
 
 
-@override_flag("rich_text_editor", active=True)
 def test_can_send_draft_message_with_rich_text_editor(live_server, page: Page, mocked_authentification_user):
     evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
     generic_test_can_send_draft_message_with_rich_text_editor(


### PR DESCRIPTION
- Adapt the tests in order to account for the "removal" of the textarea and the introduction of the editor instead.
- Remove extra spaces in get_reply_intro_text (typo and ease the testing)