### PR TITLE
Improve testing for documents

### DIFF
--- a/core/pages.py
+++ b/core/pages.py
@@ -105,21 +105,24 @@ class BaseDocumentPage(ABC):
         if close:
             self.validate_document_modal()
 
+    def get_accordion(self, document_name):
+        return (
+            self.page.get_by_test_id("document-upload-title")
+            .get_by_text(document_name, exact=True)
+            .locator('xpath=./ancestor::*[@data-testid="document-upload"]')
+        )
+
     def remove_document_by_name_from_modal(self, document_name):
         self.open_document_modal()
         accordions = self.page.get_by_test_id("document-upload").filter(visible=True)
         count = accordions.count()
-        accordions.filter(has_text=document_name).get_by_role(role="button", name="Supprimer").click()
+        self.get_accordion(document_name).get_by_role(role="button", name="Supprimer").click()
         expect(accordions).to_have_count(count - 1)
         self.validate_document_modal()
 
     @contextmanager
     def modify_document_by_name(self, document_name, *, validate_modal=True) -> Generator[Locator, None, None]:
-        accordion = (
-            self.page.get_by_test_id("document-upload-title")
-            .get_by_text(document_name, exact=True)
-            .locator('xpath=./ancestor::*[@data-testid="document-upload"]')
-        )
+        accordion = self.get_accordion(document_name)
         # Setting a temporary data-testid to resist `nom` field changes
         # language=javascript
         accordion.evaluate('el => el.setAttribute("data-testid", "document-upload-tmp")')


### PR DESCRIPTION
Fix test_can_see_and_delete_documents_from_draft_message_in_new_tab when document names are similar.

FAILED tiac/tests/test_investigation_message.py::test_can_see_and_delete_documents_from_draft_message_in_new_tab[chromium] - playwright._impl._errors.Error: Locator.click: Error: strict mode violation: get_by_test_id("document-upload").filter(visible=True).filter(has_text="In.").get_by_role("button", name="Supprimer") resolved to 2 elements:
    1) <button type="button" data-document-form-target="deleteBtn" data-action="document-form#onDelete:stop:prevent" class="fr-btn fr-btn--sm fr-icon-delete-bin-line fr-btn--tertiary delete-btn">↵                            Supprimer↵          …</button> aka get_by_role("button", name="Supprimer").nth(4)
    2) <button type="button" data-document-form-target="deleteBtn" data-action="document-form#onDelete:stop:prevent" class="fr-btn fr-btn--sm fr-icon-delete-bin-line fr-btn--tertiary delete-btn">↵                            Supprimer↵          …</button> aka get_by_role("button", name="Supprimer").nth(5)

For example when the documents names are "In." and "Clearly Remain."