### PR TITLE
Exclude document from MUS structure when sending notifications

### DIFF
--- a/core/managers.py
+++ b/core/managers.py
@@ -198,6 +198,9 @@ class StructureQueryset(QuerySet):
     def only_DD(self):
         return self.filter(libelle__startswith="DD").can_be_contacted()
 
+    def get_mus(self):
+        return self.get(niveau2=MUS_STRUCTURE)
+
 
 class EvenementManagerMixin:
     def _with_nb_liens_libres(self, model_class):

--- a/ssa/management/commands/send_document_emails_batch.py
+++ b/ssa/management/commands/send_document_emails_batch.py
@@ -3,7 +3,7 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.db.models import Count
 
-from core.models import Document
+from core.models import Document, Structure
 from core.notifications import notify_document_upload
 from ssa.models import EvenementInvestigationCasHumain, EvenementProduit
 
@@ -14,6 +14,7 @@ class Command(BaseCommand):
         content_type_2 = ContentType.objects.get_for_model(EvenementInvestigationCasHumain)
 
         base_queryset = Document.objects.filter(notification_sent=False, document_type__in=Document.NEED_NOTIFICATION)
+        base_queryset = base_queryset.exclude(created_by_structure=Structure.objects.get_mus())
         base_queryset = base_queryset.filter(content_type_id__in=[content_type_1.id, content_type_2.id])
         groups = base_queryset.values("content_type", "object_id").annotate(count=Count("id"))
         for group in groups:

--- a/ssa/tests/test_management_command.py
+++ b/ssa/tests/test_management_command.py
@@ -52,3 +52,27 @@ def test_send_email_document_uploaded(mailoutbox, mus_contact):
     # Make sure the emails are sent only once
     call_command("send_document_emails_batch")
     assert len(mailoutbox) == 2
+
+
+@pytest.mark.django_db
+def test_send_email_document_uploaded_when_sender_is_not_mus(mailoutbox, mus_contact):
+    contact_agent = ContactAgentFactory(
+        with_active_agent__with_groups=(settings.SSA_GROUP,), agent__structure=mus_contact.structure
+    )
+    evenement_produit = EvenementProduitFactory()
+    evenement_produit.contacts.add(contact_agent)
+    doc_1 = DocumentFactory(content_object=evenement_produit, document_type=Document.TypeDocument.RAPPORT_ANALYSE)
+    doc_2 = DocumentFactory(
+        content_object=evenement_produit,
+        created_by_structure=mus_contact.structure,
+        document_type=Document.TypeDocument.ANALYSE_RISQUE,
+    )
+    evenement_produit.documents.add(doc_1, doc_2)
+
+    call_command("send_document_emails_batch")
+    assert len(mailoutbox) == 1
+
+    mail = mailoutbox[0]
+    assert "Ajout de document" in mail.subject
+    assert doc_1.nom in mail.body
+    assert doc_2.nom not in mail.body


### PR DESCRIPTION
They already have the information a few documents have been added, no need to spam them in this situation.