### PR TITLE
Design treeselect niveau 2

### DIFF
--- a/core/static/core/form/widgets/treeselect.mjs
+++ b/core/static/core/form/widgets/treeselect.mjs
@@ -111,6 +111,8 @@ class TreeselectGroup extends TreeselectGroupConnectable {
 
         for (const it of this.element.querySelectorAll("& > .fr-treeselect__group-header input")) {
             it.setAttribute(`data-${this.identifier}-target`, "input")
+            const actions = (it.dataset.action || "").split(/\s+/)
+            it.dataset.action = [`${this.identifier}#onSelect`, ...actions].join(" ")
         }
     }
 
@@ -157,6 +159,15 @@ class TreeselectGroup extends TreeselectGroupConnectable {
             this.element.setAttribute("hidden", "hidden")
         } else {
             this.element.removeAttribute("hidden")
+        }
+    }
+
+    onSelect({target: {checked}}) {
+        if (checked) {
+            this.collapseTargets.forEach(async it => {
+                await dsfrDisclosePromise(dsfr(it).collapse)
+                it.scrollIntoView({block: "center"})
+            })
         }
     }
 }

--- a/core/static/core/form/widgets/treeselect_dsfr.css
+++ b/core/static/core/form/widgets/treeselect_dsfr.css
@@ -122,11 +122,20 @@
     padding-left: 0.5rem;
 }
 
-.fr-treeselect__element {
-    flex: 1 1 100%;
-    max-width: 100%;
-    padding: 0;
-    margin: 0;
+.fr-treeselect__group-header > .fr-treeselect__group-selectable > .fr-accordion__btn {
+    background-color: transparent !important;
+}
+
+.fr-treeselect__group-header > .fr-treeselect__group-selectable:has(.fr-accordion__btn[aria-expanded="true"]) {
+    background-color: var(--background-contrast-grey);
+}
+
+.fr-treeselect__group-header > .fr-treeselect__group-selectable:has(.fr-accordion__btn):hover {
+    background-color: var(--background-contrast-grey-hover);
+}
+
+.fr-treeselect__group-header > .fr-treeselect__group-selectable:has(.fr-accordion__btn):active {
+    background-color: var(--background-contrast-grey-active);
 }
 
 .fr-treeselect__element > .fr-checkbox-group,
@@ -166,8 +175,9 @@
     position: absolute;
     top: 0;
     right: 0;
-    max-width: 1.5rem;
-    max-height: 1.5rem;
+    max-width: 1.5rem !important;
+    min-height: unset !important;
+    max-height: 1.5rem !important;
 
     padding: 0.25rem;
     margin: 0.5rem 1rem;


### PR DESCRIPTION
Change la couleur de fond et de survol pour les groupes de niveau 2.

Ouvert :

<img width="735" height="512" alt="image" src="https://github.com/user-attachments/assets/5e14cf93-9188-4383-9415-0a403a0eb6cc" />

Au survol :

<img width="735" height="507" alt="image" src="https://github.com/user-attachments/assets/4fe0744c-6feb-45bc-9351-19624e5673b3" />

Implémente aussi une fonctionnalité pour ouvrir et scroller automatiquement un groupe de niveau 2 lorsqu'il a un bouton radio ou une checkbox associée qui est cliquée.