### PR TITLE
Correction d'une regression sur `EvenementProduitForm.produit_pret_a_manger` avec le nouveau treeselect

### DIFF
--- a/core/templates/core/form/widgets/treeselect.html
+++ b/core/templates/core/form/widgets/treeselect.html
@@ -1,8 +1,10 @@
-{% load set_context_var %}
+{% load dsfr_tags get_item set_context_var %}
 
 {% partialdef input %}
     <div class="fr-{{ widget.type }}-group{% if parent_index %} fr-treeselect__group-selectable{% endif %}">
-        {% set_context_var widget.attrs "data-action" "change->treeselect#onChange" %}
+        {% with data_action=widget.attrs|get_item:"data-action"|default:"" %}
+            {% set_context_var widget.attrs "data-action" data_action|strfmt:"{} change->treeselect#onChange" %}
+        {% endwith %}
         {% include "django/forms/widgets/input.html" %}
         <label class="fr-label" for="{{ widget.attrs.id }}">
             {% if parent_index %}

--- a/core/templatetags/render_field.py
+++ b/core/templatetags/render_field.py
@@ -10,3 +10,9 @@ def render_field(field):
         {field.label_tag()}
         {field}
     """)
+
+
+# Avoid clash with widget_tweaks's render_field
+@register.simple_tag
+def seves_render_field(field):
+    return render_field(field)

--- a/ssa/forms.py
+++ b/ssa/forms.py
@@ -104,6 +104,8 @@ class WithEvenementCommonMixin(WithEvenementProduitFreeLinksMixin, forms.Form):
 
 
 class EvenementProduitForm(DSFRForm, WithEvenementCommonMixin, WithLatestVersionLocking, forms.ModelForm):
+    CategorieDanger = CategorieDanger
+
     type_evenement = SEVESChoiceField(choices=TypeEvenement.choices, label="Type d'événement")
     source = SEVESChoiceField(choices=Source.choices, required=True)
 

--- a/ssa/static/ssa/categorie_djanger.mjs
+++ b/ssa/static/ssa/categorie_djanger.mjs
@@ -1,4 +1,6 @@
+import {applicationReady} from "Application"
 import {findPath, isLevel2WithChildren, patchItems, tsDefaultOptions} from "CustomTreeSelect"
+import {Controller} from "Stimulus"
 
 const NOTICE_TEXT = "Il existe des sous catégories pour « __value__ » : pensez à préciser dès que possible."
 
@@ -7,15 +9,10 @@ function handleValueChangeCategorieDanger(value, options) {
         .map(n => n.name)
         .join(" > ")
 
-    document.getElementById("id_categorie_danger").value = value
+    const input = document.getElementById("id_categorie_danger")
+    input.value = value
+    input.dispatchEvent(new Event("input"))
     document.querySelector("#categorie-danger .treeselect-input__tags-count").innerText = fullPath
-    if (document.getElementById("pam-container")) {
-        if (fullPath.includes("Bactérie >") && document.getElementById("pam-container")) {
-            document.getElementById("pam-container").classList.remove("fr-hidden")
-        } else {
-            document.getElementById("pam-container").classList.add("fr-hidden")
-        }
-    }
 }
 
 function handleNoticeDangerDisplay(options, value) {
@@ -95,10 +92,6 @@ function setupCategorieDanger() {
     treeselect.srcElement.addEventListener("input", e => {
         if (e.detail) {
             handleValueChangeCategorieDanger(e.detail, options)
-        } else {
-            if (document.getElementById("pam-container")) {
-                document.getElementById("pam-container").classList.add("fr-hidden")
-            }
         }
     })
 
@@ -106,6 +99,47 @@ function setupCategorieDanger() {
         handleNoticeDangerDisplay(options, e.detail)
     })
     handleNoticeDangerDisplay(options, selectedValue)
+    document.querySelector("#id_categorie_danger").dispatchEvent(new Event("input"))
 }
 
-setupCategorieDanger()
+/**
+ * @property {HTMLInputElement} categorieDangerInputTarget
+ * @property {HTMLElement} pamContainerTarget
+ */
+class RisqueController extends Controller {
+    static targets = ["categorieDangerInput", "pamContainer"]
+
+    #dangersBacteriens = new Set()
+
+    initialize() {
+        this.#dangersBacteriens = new Set(JSON.parse(this.element.querySelector("#dangers-bacteriens").innerText))
+    }
+
+    /** @param {HTMLInputElement} el */
+    async categorieDangerInputTargetConnected(el) {
+        if (el.type === "radio" && el.checked) {
+            el.dispatchEvent(new Event("change"))
+        }
+    }
+
+    onCategorieDangerSelected({target}) {
+        let show = false
+        if (target.type === "radio") {
+            // new treeselect
+            show = target.checked && this.#dangersBacteriens.has(target.value)
+        } else {
+            show = this.#dangersBacteriens.has(target.value)
+        }
+
+        if (show) {
+            this.pamContainerTarget.classList.remove("fr-hidden")
+        } else {
+            this.pamContainerTarget.classList.add("fr-hidden")
+        }
+    }
+}
+
+applicationReady.then(app => {
+    app.register("risque-fieldset", RisqueController)
+    setupCategorieDanger()
+})

--- a/ssa/templates/ssa/evenement_produit_form.html
+++ b/ssa/templates/ssa/evenement_produit_form.html
@@ -1,7 +1,6 @@
 {% extends "ssa/base.html" %}
-{% load waffle_tags %}
-{% load static %}
-{% load render_field dsfr_tags %}
+{% load dsfr_tags render_field static widget_tweaks %}
+
 {% block extrahead %}
     <link rel="stylesheet" href="{% static 'ssa/evenement_produit_form.css' %}">
 {% endblock %}
@@ -68,10 +67,10 @@
                                 <input type="text" id="date-publication-input" class="fr-input fr-mt-0" value="{% if form.instance.date_publication %}{{ form.instance.date_publication|date:"d/m/Y" }}{% else %}{% now 'd/m/Y' %}{% endif %}" disabled>
                             </div>
                             <div>
-                                {% render_field form.date_reception %}
+                                {% seves_render_field form.date_reception %}
                             </div>
                             {% if form.numero_rasff %}
-                                <div class="rasff">{% render_field form.numero_rasff %}</div>
+                                <div class="rasff">{% seves_render_field form.numero_rasff %}</div>
                             {% endif %}
                             {{ form.aliments_animaux.label_tag }}
                             <div class="radio-inline-container radio-inline-container--wrap">
@@ -79,11 +78,11 @@
                             </div>
                         </div>
                         <div class="fr-col-12 fr-col-lg-4 flex-column">
-                            <div>{% render_field form.type_evenement %}</div>
-                            <div class="source">{% render_field form.source %}</div>
+                            <div>{% seves_render_field form.type_evenement %}</div>
+                            <div class="source">{% seves_render_field form.source %}</div>
                         </div>
                         <div class="fr-col-12 fr-col-lg-4">
-                            {% render_field form.description %}
+                            {% seves_render_field form.description %}
                         </div>
                     </div>
                 </div>
@@ -98,25 +97,25 @@
                                 <label>Catégorie de produit</label>
                                 <div id="categorie-produit"></div>
                                 <div>
-                                    {% flag "new_treeselect" %}
+                                    {% if flag_new_treeselect %}
                                         <div class="fr-mb-2w">
-                                            {{ form.categorie_produit  }}
+                                            {{ form.categorie_produit }}
                                         </div>
                                     {% else %}
                                         <div class="fr-mt-2w">
-                                            {{ form.categorie_produit  }}
+                                            {{ form.categorie_produit }}
                                         </div>
-                                    {% endflag %}
+                                    {% endif %}
 
                                     <div class="fr-mt-2v fr-hidden" id="notice-container-produit">
                                         {% dsfr_notice title="__content__" %}
                                     </div>
                                     <div class="fr-mt-4v">
-                                        {% render_field form.denomination %}
+                                        {% seves_render_field form.denomination %}
                                     </div>
-                                    {% render_field form.marque %}
-                                    {% render_field form.lots %}
-                                    {% render_field form.description_complementaire %}
+                                    {% seves_render_field form.marque %}
+                                    {% seves_render_field form.lots %}
+                                    {% seves_render_field form.description_complementaire %}
                                     {{ form.temperature_conservation.label_tag }}
                                     <div class="radio-inline-container radio-inline-container--wrap">
                                         {{ form.temperature_conservation }}
@@ -126,17 +125,27 @@
                         </div>
                     </div>
                     <div class="fr-col-12 fr-col-lg-6">
-                        <div class="white-container--lite tall-column risk-column">
+                        <div
+                            class="white-container--lite tall-column risk-column"
+                            data-controller="risque-fieldset"
+                        >
                             <h3>Risque</h3>
                             <div>
                                 <label>Catégorie de danger</label>
-                                <div id="categorie-danger"></div>
-                                {{ form.categorie_danger }}
+                                {% if flag_new_treeselect %}
+                                    {{ form.categorie_danger|set_data:"action:change->risque-fieldset#onCategorieDangerSelected"|set_data:"risque-fieldset-target:categorieDangerInput" }}
+                                {% else %}
+                                    <div id="categorie-danger"></div>
+                                    {{ form.categorie_danger|set_data:"action:risque-fieldset#onCategorieDangerSelected" }}
+                                {% endif %}
+
+                                {{ form.CategorieDanger.dangers_bacteriens|json_script:"dangers-bacteriens" }}
+
                                 <div class="fr-mt-2v fr-hidden" id="notice-container-risque">
                                     {% dsfr_notice title="__content__" %}
                                 </div>
                                 <div class="fr-mt-4v">
-                                    {% render_field form.precision_danger %}
+                                    {% seves_render_field form.precision_danger %}
                                 </div>
                                 <div class="fr-mt-2w">
                                     <div class="fr-grid-row fr-grid-row--gutters">
@@ -146,19 +155,19 @@
                                             {{ form.quantification }}
                                         </div>
                                         <div class="fr-col-lg-4 fr-my-auto">
-                                            {% render_field form.quantification_unite %}
+                                            {% seves_render_field form.quantification_unite %}
                                         </div>
                                     </div>
                                 </div>
-                                {% render_field form.evaluation %}
-                                <div class="radio-inline-container fr-hidden" id="pam-container">
+                                {% seves_render_field form.evaluation %}
+                                <div class="radio-inline-container fr-hidden" data-risque-fieldset-target="pamContainer">
                                     {{ form.produit_pret_a_manger.label_tag }}
                                     <div class="radio-inline-container fr-ml-4w">
                                         {{ form.produit_pret_a_manger }}
                                     </div>
                                 </div>
-                                {% render_field form.reference_souches %}
-                                {% render_field form.reference_clusters %}
+                                {% seves_render_field form.reference_souches %}
+                                {% seves_render_field form.reference_clusters %}
                                 <div class="fr-notice fr-notice--info">
                                     <div class="fr-container">
                                         <div class="fr-notice__body">

--- a/ssa/views/mixins.py
+++ b/ssa/views/mixins.py
@@ -1,6 +1,7 @@
 import json
 
 from queryset_sequence import QuerySetSequence
+import waffle
 
 from core.mixins import WithOrderingMixin
 from ssa.constants import CategorieDanger, CategorieProduit
@@ -55,4 +56,5 @@ class EvenementProduitValuesMixin:
         context["categorie_produit_data"] = json.dumps(CategorieProduit.build_options())
         context["categorie_danger"] = json.dumps(CategorieDanger.build_options(sorted_results=True))
         context["danger_plus_courant"] = EvenementProduit.danger_plus_courants()
+        context["flag_new_treeselect"] = waffle.flag_is_active(self.request, "new_treeselect")
         return context


### PR DESCRIPTION
`EvenementProduitForm.produit_pret_a_manger` n'est jamais affiché avec le nouveau Treeselect parce que la logique n'est pas implémentée dans ce cas. Cette PR corrige le problème.