### PR TITLE
Improve performances of block commun

### DIFF
--- a/core/templates/core/_documents.html
+++ b/core/templates/core/_documents.html
@@ -168,8 +168,12 @@
                                                         </li>
                                                     {% endif %}
                                                 </ul>
-                                                {% include "core/_modale_edition_document.html" %}
-                                                {% include "core/_modale_suppression_document.html" %}
+                                                {% if can_update_document %}
+                                                    {% include "core/_modale_edition_document.html" %}
+                                                {% endif %}
+                                                {% if can_delete_document %}
+                                                    {% include "core/_modale_suppression_document.html" %}
+                                                {% endif %}
                                             {% endif %}
 
                                         </td>


### PR DESCRIPTION
When we have a large number of documents this part of the code can be slow both on the backend and the frontend:

- On the backend avoid generating useless HTML when the user dont have the right to perform a specific action
- On the frontend avoid more HTML to read/parse. It looks like this will also helps with the CPU load coming from the JS. From my understanding it is because the DSFR does a querySelectorAll on everything that controls a modal element, including the "Close" (Fermer) link in the modal itself.