### PR TITLE
Correction de design sur le nouveau treeselect: affiche le label entier avec la categorie lorsqu'un résultat est sélectionné

### DIFF
--- a/core/static/core/form/widgets/treeselect.mjs
+++ b/core/static/core/form/widgets/treeselect.mjs
@@ -254,13 +254,14 @@ class Treeselect extends Controller {
 
     onChange({target}) {
         const label = target.labels[0].textContent.trim() || target.ariaLabel
+        const categorisedLabel = target.dataset.categorisedLabel || label
         // If inputs are radio buttons, we allow only one value
         if (target.type === "radio") {
             this.clearChoices()
         }
 
         if (target.checked) {
-            this.selectChoice(target.value, label)
+            this.selectChoice(target.value, label, categorisedLabel)
         } else {
             this.unselectChoice(target.value)
         }
@@ -285,8 +286,8 @@ class Treeselect extends Controller {
         this.dispatch(UNSELECT_EVENT, {detail: {value: "__all__"}})
     }
 
-    selectChoice(value, label) {
-        this.choices.set(value, label)
+    selectChoice(value, label, categorisedLabel) {
+        this.choices.set(value, categorisedLabel)
         this.selectedGroupTarget.insertAdjacentHTML(
             "beforeend",
             this.selectedTagTplTarget.innerHTML.replaceAll("__label__", label).replaceAll("__value__", value),

--- a/core/widgets.py
+++ b/core/widgets.py
@@ -1,4 +1,4 @@
-from copy import deepcopy
+from copy import copy, deepcopy
 import dataclasses
 import itertools
 import re
@@ -74,6 +74,7 @@ class TreeselectGroupWidget(widgets.ChoiceWidget):
         return context
 
     def optgroups(self, name, value, attrs=None):
+        attr = attrs or {}
         has_selected = False
         for option_label, option_value in self.choices.items():
             if self._is_dunder(option_label):
@@ -81,6 +82,8 @@ class TreeselectGroupWidget(widgets.ChoiceWidget):
             if isinstance(option_value, Mapping):
                 yield TreeselectGroupWidget(self.parent, option_label, option_value).get_context(name, value, attrs)
             else:
+                if categorised_label := self.parent.field_choices.get(option_value):
+                    attr["data-categorised-label"] = categorised_label
                 selected = (not has_selected or self.parent.allow_multiple_selected) and str(option_value) in value
                 has_selected |= selected
                 yield self.create_option(
@@ -121,6 +124,11 @@ class TreeselectCheckbox(widgets.ChoiceWidget):
     def choices(self, value):
         if not self._choices:
             self._choices = self._choices_as_dict(value)
+        self._field_choices = dict(value)
+
+    @property
+    def field_choices(self) -> dict[Any, str]:
+        return self._field_choices
 
     @property
     def media(self):
@@ -138,19 +146,29 @@ class TreeselectCheckbox(widgets.ChoiceWidget):
         choices: Iterable[tuple[Any, Any] | tuple[str, Iterable[tuple[Any, Any]]]] | Iterable[TreeselectGroup] = (),
         *,
         input_type: Literal["checkbox", "radio"] = None,
-        has_search_bar=_UNSET,
-        category_separator=_UNSET,
+        has_search_bar: bool = _UNSET,
+        category_separator: str = _UNSET,
     ):
-        self._choices = {}
-        self._widget_choices = None
-
         if input_type is not None:
             self.input_type = input_type
         if has_search_bar is not _UNSET:
             self.has_search_bar = has_search_bar
         if category_separator is not _UNSET:
             self.category_separator = category_separator
-        super().__init__(attrs, choices)
+
+        # Here, we want to avoid triggering the self.choices setter. The rationale is that if constructor is called
+        # with a value for the 'choices' parameter, it's most likely to specify categories and subcategories that are
+        # different from the 'choices' that is passed to the field. So we want to detect that case and recover
+        # the field's choices in self._field_choices instead.
+        self._choices = self._choices_as_dict(choices)
+        self._field_choices = {}
+        super().__init__(attrs, choices=())
+
+    def __deepcopy__(self, memo):
+        field_choices = copy(self._field_choices)
+        result = super().__deepcopy__(memo)
+        result._field_choices = field_choices
+        return result
 
     def get_next_id(self):
         if not hasattr(self, "_id_stream"):


### PR DESCRIPTION
## Avant

<img src="https://github.com/user-attachments/assets/a5365000-3b2e-4e97-a80c-9377d30fec92" />

## Après

<img src="https://github.com/user-attachments/assets/6311fa48-750d-47d4-95af-f799bd43ed87" />