### PR TITLE
Allow to see sub-objects added in same revision

### DIFF
--- a/core/diffs.py
+++ b/core/diffs.py
@@ -430,6 +430,25 @@ class CompareMixin(CompareMethodsMixin, OriginalCompareMixin):
                     else:
                         new = f"Objet ajouté : {item}"
                     diff.append(Diff(self._get_pretty_field(field), "", new, version2.revision))
+                    for item in change["added_items"]:
+                        obj_instance = item._object_version.object
+                        model_name = obj_instance._meta.verbose_name.title()
+                        prefix = f"{model_name} ({str(obj_instance)})"
+
+                        for field in obj_instance._meta.get_fields():
+                            if field.one_to_many:
+                                related_model = field.related_model
+                                remote_field_name = field.remote_field.name
+
+                                filter_kwargs = {remote_field_name: obj_instance}
+                                children = related_model.objects.filter(**filter_kwargs)
+
+                                for child in children:
+                                    child_model_name = related_model._meta.verbose_name.title()
+                                    new_line = f"Objet ajouté : {child_model_name} {str(child)}"
+                                    field_label = self._get_pretty_field(field, prefix=prefix)
+                                    diff.append(Diff(field_label, "", new_line, version2.revision))
+
                 for item_1, _item_2 in change["changed_items"]:
                     model_name = item_1._object_version.object._meta.verbose_name.title()
                     prefix = f"{model_name} ({str(item_1._object_version.object)})"

--- a/ssa/tests/test_evenement_produit_history.py
+++ b/ssa/tests/test_evenement_produit_history.py
@@ -129,13 +129,13 @@ def test_can_evenement_produit_history_performances_with_messages(client, django
     with reversion.create_revision():
         MessageFactory.create(content_object=evenement)
         evenement.save()
-    with django_assert_max_num_queries(base_queries + 7):
+    with django_assert_max_num_queries(base_queries + 8):
         response = client.get(url)
         assert len(response.context["patches"]) == 2
 
     with reversion.create_revision():
         MessageFactory.create(content_object=evenement)
         evenement.save()
-    with django_assert_max_num_queries(base_queries + 16):
+    with django_assert_max_num_queries(base_queries + 18):
         response = client.get(url)
         assert len(response.context["patches"]) == 3

--- a/sv/tests/test_evenement_history.py
+++ b/sv/tests/test_evenement_history.py
@@ -338,3 +338,48 @@ def test_evenement_history_content_add_and_edit_zone_infestee_with_detection(
     update_text = f"Fiche Détection ({detection}) - Zone Infestee"
     expect(page.get_by_text(creation_text, exact=True)).to_be_visible()
     expect(page.get_by_text(update_text, exact=True)).to_be_visible()
+
+
+def test_evenement_history_content_prelevement_shows_even_when_added_with_lieu(
+    live_server, page, form_elements: FicheDetectionFormDomElements, lieu_form_elements, choice_js_fill
+):
+    statut, _ = StatutReglementaire.objects.get_or_create(libelle="organisme quarantaine prioritaire")
+    StructurePreleveuseFactory()
+    organisme_nuisible = OrganismeNuisibleFactory()
+    page.goto(f"{live_server.url}{reverse('sv:fiche-detection-creation')}")
+    choice_js_fill(
+        page,
+        "#organisme-nuisible .choices__list--single",
+        organisme_nuisible.libelle_court,
+        organisme_nuisible.libelle_court,
+    )
+    page.get_by_label("Statut réglementaire").select_option(value=str(statut.id))
+    page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").click()
+
+    evenement = Evenement.objects.get()
+    detection = evenement.detections.get()
+
+    page.goto(f"{live_server.url}{detection.get_update_url()}")
+
+    form_elements.add_lieu_btn.click()
+    lieu_form_elements.nom_input.fill("Mon lieu")
+    lieu_form_elements.lieu_site_inspection_input.select_option("INCONNU")
+    lieu_form_elements.save_btn.click()
+
+    form_elements.add_prelevement_btn.click()
+    prelevement_form_elements = PrelevementFormDomElements(page)
+    prelevement_form_elements.date_prelevement_input.click()
+    prelevement_form_elements.structure_input.select_option(value=str(StructurePreleveuse.objects.first().id))
+    prelevement_form_elements.date_prelevement_input.fill("2021-01-01")
+    prelevement_form_elements.resultat_input(Prelevement.Resultat.DETECTE).click()
+    prelevement_form_elements.type_analyse_input("première intention").click()
+    prelevement_form_elements.save_btn.click()
+    page.get_by_test_id("bottom-action-btns").get_by_role("button", name="Enregistrer").click()
+
+    prelevement = Prelevement.objects.get()
+    content_type = ContentType.objects.get_for_model(Evenement)
+    url = reverse("revision-list", kwargs={"content_type": content_type.pk, "pk": evenement.pk})
+    page.goto(f"{live_server.url}{url}")
+
+    creation_text = f"Objet ajouté : Prélèvement {str(prelevement)}"
+    expect(page.get_by_text(creation_text)).to_be_visible()


### PR DESCRIPTION
Make sure that when using the history view we can see the subobjects that were added in the same operation (example : add a prelevement and a lieu in the same edit).