### PR TITLE
Nouveau treeselect sur investigation cas humain (SSA)

### DIFF
--- a/core/static/core/form/widgets/treeselect_dsfr.css
+++ b/core/static/core/form/widgets/treeselect_dsfr.css
@@ -13,7 +13,7 @@
     position: relative;
 }
 
-.fr-label + .fr-treeselect {
+.fr-label + .fr-nav:has(> .fr-treeselect) {
     margin-top: 0.5rem;
 }
 

--- a/ssa/forms.py
+++ b/ssa/forms.py
@@ -351,3 +351,20 @@ class InvestigationCasHumainForm(DsfrBaseForm, WithEvenementCommonMixin, WithLat
                 },
             )
         }
+
+
+class InvestigationCasHumainTreeselectForm(InvestigationCasHumainForm):
+    categorie_danger = ChoiceField(
+        required=False,
+        choices=CategorieDanger,
+        widget=TreeselectRadio(
+            choices=(
+                TreeselectGroup(
+                    value=None,
+                    label="Dangers les plus courants",
+                    choices=[(it.value, it.uncategorized_label) for it in DANGERS_COURANTS],
+                ),
+                TreeselectGroup(value=None, label="Liste complète des dangers", choices=CategorieDanger),
+            )
+        ),
+    )

--- a/ssa/views/investigation_cas_humain.py
+++ b/ssa/views/investigation_cas_humain.py
@@ -12,6 +12,7 @@ from django.views.generic import CreateView, DetailView, UpdateView
 from django.views.generic.detail import BaseDetailView
 from docxtpl import DocxTemplate
 from reversion.models import Version
+import waffle
 
 from core.audit import audit_log
 from core.mixins import (
@@ -31,7 +32,7 @@ from core.mixins import (
     WithMessageMixin,
 )
 
-from ..forms import InvestigationCasHumainForm
+from ..forms import InvestigationCasHumainForm, InvestigationCasHumainTreeselectForm
 from ..formsets import InvestigationCasHumainsEtablissementFormSet
 from ..models import EvenementInvestigationCasHumain
 from ..notifications import notify_souches_clusters
@@ -50,6 +51,10 @@ class InvestigationCasHumainCreateView(
     form_class = InvestigationCasHumainForm
     success_message = "L’évènement Investigation de cas humain a été créé avec succès."
 
+    @cached_property
+    def new_treeselect(self):
+        return waffle.flag_is_active(self.request, "new_treeselect")
+
     @property
     def etablissement_formset(self):
         if not hasattr(self, "_etablissement_formset"):
@@ -60,6 +65,9 @@ class InvestigationCasHumainCreateView(
         kwargs = super().get_form_kwargs()
         kwargs["user"] = self.request.user
         return kwargs
+
+    def get_form_class(self):
+        return InvestigationCasHumainTreeselectForm if self.new_treeselect else super().get_form_class()
 
     def get_context_data(self, **kwargs):
         return super().get_context_data(**kwargs, etablissement_formset=self.etablissement_formset)


### PR DESCRIPTION
Je cherche une façon d'isoler le code spécifique à l'ancien treeselect (CSS/JS/HTML) dans un widget à part afin de regrouper tout le code à supprimer lorsque le nouveau treeselect sera officiellement ouvert au public. Sauf si tu me dit que c'est pas la peine de perdre du temps là-dessus et que vois à peu près le code à nettoyer ?