### PR TITLE
Correction des alignements du filtre `with_free_links` sur SSA & TIAC

### DIFF
--- a/ssa/static/ssa/evenement_produit_list.css
+++ b/ssa/static/ssa/evenement_produit_list.css
@@ -22,7 +22,7 @@
 }
 
 .with_free_links .fr-checkbox-group {
-    margin-bottom: 0 !important;
+    margin-bottom: 0.5rem !important;
 }
 
 .choices {

--- a/ssa/templates/ssa/evenements_list.html
+++ b/ssa/templates/ssa/evenements_list.html
@@ -25,10 +25,10 @@
             </div>
             <div class="filter-grid">
 
-                <div>
+                <div class="filter-grid-2">
                     {% dsfr_form_field filter.form.annee %}
                 </div>
-                <div>
+                <div class="filter-grid-2">
                     {% dsfr_form_field filter.form.numero %}
                 </div>
                 <div class="filter-grid-2 fr-flex--align-end with_free_links">

--- a/tiac/static/tiac/list.css
+++ b/tiac/static/tiac/list.css
@@ -1,6 +1,6 @@
 .evenements_liste__search-form .fr-checkbox-group {
     margin-top: auto;
-    margin-bottom: auto !important;
+    margin-bottom: 0.5rem !important;
 }
 
 .fr-input-group {

--- a/tiac/templates/tiac/tiac_list.html
+++ b/tiac/templates/tiac/tiac_list.html
@@ -24,8 +24,12 @@
                 </button>
             </div>
             <div class="evenements_liste__search-form">
-                {% dsfr_form_field filter.form.annee|set_data:"action:search-form#disableCheckboxIfNeeded"|set_data:"search-form-target:annee"  %}
-                {% dsfr_form_field filter.form.numero|set_data:"action:search-form#disableCheckboxIfNeeded"|set_data:"search-form-target:numero"  %}
+                <div class="fr-fieldset__element">
+                    {% dsfr_form_field filter.form.annee|set_data:"action:search-form#disableCheckboxIfNeeded"|set_data:"search-form-target:annee"  %}
+                </div>
+                <div class="fr-fieldset__element">
+                    {% dsfr_form_field filter.form.numero|set_data:"action:search-form#disableCheckboxIfNeeded"|set_data:"search-form-target:numero"  %}
+                </div>
                 {% for field in filter.form %}
                     {% if field.name in filter.form.main_filters %}
                         <div class="fr-fieldset__element">


### PR DESCRIPTION
Cette PR modifie aussi la marge du bas de la checkbox `with_free_links` pour quelle apparaisse verticalement alignée avec le centre d'un input plutôt qu'avec le bas. Ça semble visuellement plus satisfaisant.

## Avant

### SSA

<img src="https://github.com/user-attachments/assets/c09d0366-64cf-447a-a695-55b2867babe5" />

### TIAC

<img src="https://github.com/user-attachments/assets/c977836e-fa62-4593-9cf7-b8166f5df293" />


## Après

### SSA

<img src="https://github.com/user-attachments/assets/b69e9824-45a3-4bac-8d12-e13a78b07609" />

### TIAC

<img src="https://github.com/user-attachments/assets/faaf48af-7b98-4506-ad6d-62eeca92fe7e" />
