### PR TITLE
Add placeholder in rich text editor

### DIFF
--- a/core/static/core/rich_text_editor.mjs
+++ b/core/static/core/rich_text_editor.mjs
@@ -65,6 +65,8 @@ class RichTextEditorController extends Controller {
     connect() {
         const quill = new Quill(this.containerTarget, {
             theme: "snow",
+            placeholder:
+                "Seront automatiquement ajoutés à votre message : vos nom et prénom, structure, informations principales de l'évènement et le lien vers la fiche Sèves.",
             modules: {
                 toolbar: "#toolbar",
             },

--- a/core/tests/generic_tests/messages.py
+++ b/core/tests/generic_tests/messages.py
@@ -50,6 +50,11 @@ def generic_test_can_add_and_see_message_with_rich_text_editor(live_server, page
     message_page.pick_recipient(active_contact, choice_js_fill)
     expect(message_page.page.get_by_text(f"Ouvrir la fiche {object.numero}", exact=True)).to_be_visible()
     expect(message_page.message_form_title).to_have_text("Nouveau message")
+    expect(
+        message_page.page.locator(
+            '[data-placeholder="Seront automatiquement ajoutés à votre message : vos nom et prénom, structure, informations principales de l\'évènement et le lien vers la fiche Sèves."]'
+        )
+    ).to_have_count(1)
 
     message_page.message_title.fill("Title of the message")
     message_page.page.locator(".ql-bold").click()


### PR DESCRIPTION
Was "removed" by error when the editor was changed to a rich text editor.