### PR TITLE
Do not display placeholder for note message

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -135,6 +135,8 @@ class DocumentEditForm(DSFRForm, forms.ModelForm):
 
 
 class CommonMessageForm(forms.ModelForm):
+    show_placeholder = True
+
     def __init__(
         self,
         sender,
@@ -339,6 +341,8 @@ class NoteForm(CommonMessageForm, DsfrBaseForm):
             },
         ),
     )
+
+    show_placeholder = False
 
     def __init__(self, *args, sender, obj, **kwargs):
         super().__init__(*args, sender=sender, obj=obj, **kwargs)

--- a/core/static/core/rich_text_editor.mjs
+++ b/core/static/core/rich_text_editor.mjs
@@ -4,6 +4,7 @@ import {Controller} from "Stimulus"
 
 class RichTextEditorController extends Controller {
     static targets = ["textarea", "container"]
+    static values = {showPlaceholder: Boolean}
 
     TEXT_PREFIX = "text-color"
     BACKGROUND_PREFIX = "background-color"
@@ -63,10 +64,12 @@ class RichTextEditorController extends Controller {
     }
 
     connect() {
+        const placeholder = this.showPlaceholderValue
+            ? "Seront automatiquement ajoutés à votre message : vos nom et prénom, structure, informations principales de l'évènement et le lien vers la fiche Sèves."
+            : ""
         const quill = new Quill(this.containerTarget, {
             theme: "snow",
-            placeholder:
-                "Seront automatiquement ajoutés à votre message : vos nom et prénom, structure, informations principales de l'évènement et le lien vers la fiche Sèves.",
+            placeholder: placeholder,
             modules: {
                 toolbar: "#toolbar",
             },

--- a/core/templates/core/message_form.html
+++ b/core/templates/core/message_form.html
@@ -54,7 +54,7 @@
                 {% csrf_token %}
                 <input type="hidden" name="id" value="{{ form.instance.pk }}">
                 <div class="white-container">
-                    <div data-controller="rich-text-editor">
+                    <div data-controller="rich-text-editor" data-rich-text-editor-show-placeholder-value="{{ form.show_placeholder|yesno:'true,false' }}">
                         {% for field in form %}
                             {% if field.name == "content" %}
                                 <div class="fr-fieldset__element fr-hidden">

--- a/core/tests/generic_tests/messages.py
+++ b/core/tests/generic_tests/messages.py
@@ -486,6 +486,11 @@ def generic_test_can_add_and_see_note_in_new_tab_without_document(live_server, p
     message_page.new_note()
     expect((message_page.page.get_by_text("Nouvelle note"))).to_be_visible()
 
+    expect(
+        message_page.page.locator(
+            '[data-placeholder="Seront automatiquement ajoutés à votre message : vos nom et prénom, structure, informations principales de l\'évènement et le lien vers la fiche Sèves."]'
+        )
+    ).to_have_count(0)
     message_page.message_title.fill("Title of the message")
     message_page.message_content.type("My content \n with a line return")
     message_page.submit_message()


### PR DESCRIPTION
This is not true for note message so we don't add the placeholder to avoid any confusion.