### PR TITLE
Fix message ordering for note with picked date

### DIFF
--- a/core/factories.py
+++ b/core/factories.py
@@ -168,13 +168,17 @@ class MessageFactory(DjangoModelFactory):
     message_type = FuzzyChoice([choice[0] for choice in Message.MESSAGE_TYPE_CHOICES])
     title = factory.Faker("sentence", nb_words=4)
     content = factory.Faker("paragraph")
+    status = Message.Status.FINALISE
 
     sender = factory.SubFactory(ContactAgentFactory)
-    date_publication = factory.LazyFunction(timezone.now)
 
     @factory.lazy_attribute
     def sender_structure(self):
         return self.sender.agent.structure
+
+    @factory.lazy_attribute
+    def date_publication(self):
+        return timezone.now() if self.status == Message.Status.FINALISE else None
 
     @factory.post_generation
     def recipients(self, create, extracted, **kwargs):

--- a/core/managers.py
+++ b/core/managers.py
@@ -260,6 +260,7 @@ class MessageQueryset(QuerySet):
 
         return self.annotate(
             displayed_date_orm=Case(
+                When(date_picked__isnull=False, then=F("date_picked")),
                 When(status=Message.Status.FINALISE, then=F("date_publication")),
                 default=Case(
                     When(last_updated__isnull=False, then=F("last_updated")),

--- a/core/tests/generic_tests/messages.py
+++ b/core/tests/generic_tests/messages.py
@@ -862,20 +862,26 @@ def generic_test_message_ordering(live_server, page: Page, mocked_authentificati
     finalise_oldest = MessageFactory(
         title="finalisé le plus ancien",
         status=Message.Status.FINALISE,
-        date_creation=timezone.make_aware(datetime(2025, 1, 1, 10, 0, 0)),
         **common_kwargs,
+    )
+    Message.objects.filter(pk=finalise_oldest.pk).update(
+        date_publication=timezone.make_aware(datetime(2025, 1, 1, 10, 0, 0))
     )
     brouillon_older = MessageFactory(
         title="Brouillon ancien",
         status=Message.Status.BROUILLON,
-        date_creation=timezone.make_aware(datetime(2025, 2, 1, 10, 0, 0)),
         **common_kwargs,
+    )
+    Message.objects.filter(pk=brouillon_older.pk).update(
+        date_creation=timezone.make_aware(datetime(2025, 2, 1, 10, 0, 0))
     )
     finalise_recent = MessageFactory(
         title="finalisé récent",
         status=Message.Status.FINALISE,
-        date_creation=timezone.make_aware(datetime(2025, 3, 1, 10, 0, 0)),
         **common_kwargs,
+    )
+    Message.objects.filter(pk=finalise_recent.pk).update(
+        date_publication=timezone.make_aware(datetime(2025, 3, 1, 10, 0, 0))
     )
     brouillon_newest = MessageFactory(
         title="Brouillon le plus récent",
@@ -883,24 +889,40 @@ def generic_test_message_ordering(live_server, page: Page, mocked_authentificati
         date_creation=timezone.make_aware(datetime(2025, 4, 1, 10, 0, 0)),
         **common_kwargs,
     )
+    Message.objects.filter(pk=brouillon_newest.pk).update(
+        date_creation=timezone.make_aware(datetime(2025, 4, 1, 10, 0, 0))
+    )
     finalise_newest = MessageFactory(
         title="finalisé le plus récent",
         status=Message.Status.FINALISE,
-        date_creation=timezone.make_aware(datetime(2025, 5, 1, 10, 0, 0)),
         **common_kwargs,
+    )
+    Message.objects.filter(pk=finalise_newest.pk).update(
+        date_publication=timezone.make_aware(datetime(2025, 5, 1, 10, 0, 0))
     )
     old_draft_updated_recently = MessageFactory(
         title="Brouillon ancien mis à jour",
         status=Message.Status.BROUILLON,
-        date_creation=timezone.make_aware(datetime(2024, 2, 1, 10, 0, 0)),
         last_updated=timezone.now(),
         **common_kwargs,
+    )
+    Message.objects.filter(pk=finalise_newest.pk).update(
+        date_creation=timezone.make_aware(datetime(2024, 2, 1, 10, 0, 0))
     )
     old_draft_recently_published = MessageFactory(
         title="Brouillon ancien mais envoyé récemment",
         status=Message.Status.FINALISE,
-        date_creation=timezone.make_aware(datetime(2024, 2, 1, 10, 0, 0)),
         date_publication=timezone.now(),
+        **common_kwargs,
+    )
+    Message.objects.filter(pk=old_draft_recently_published.pk).update(
+        date_creation=timezone.make_aware(datetime(2024, 2, 1, 10, 0, 0))
+    )
+    note_with_specific_picked_date = MessageFactory(
+        title="Note avec une date choisie à la main dans l'interface",
+        message_type=Message.NOTE,
+        date_picked=timezone.make_aware(datetime(2025, 1, 1, 15, 0, 0)),
+        status=Message.Status.FINALISE,
         **common_kwargs,
     )
 
@@ -913,7 +935,8 @@ def generic_test_message_ordering(live_server, page: Page, mocked_authentificati
     assert message_page.message_title_in_table(4) == old_draft_recently_published.title
     assert message_page.message_title_in_table(5) == finalise_newest.title
     assert message_page.message_title_in_table(6) == finalise_recent.title
-    assert message_page.message_title_in_table(7) == finalise_oldest.title
+    assert message_page.message_title_in_table(7) == note_with_specific_picked_date.title
+    assert message_page.message_title_in_table(8) == finalise_oldest.title
 
 
 def generic_test_can_preview_image_from_message_details(live_server, page: Page, target_object):


### PR DESCRIPTION
Fix the ordering when the date is picked for a Note message. Improve the test to make sure we are testing properly (date_creation was used with now per default because of the model).