### PR TITLE
Correction de design de la recette du nouveau treeselect sur les filtres 

### DIFF
--- a/core/static/core/form/widgets/treeselect.mjs
+++ b/core/static/core/form/widgets/treeselect.mjs
@@ -5,11 +5,54 @@ import {search} from "Utils"
 const WIDGET_IDENTIFIER = "treeselect"
 const GROUP_IDENTIFIER = "treeselect-group"
 const UNSELECT_EVENT = "unselected"
+const SELECT_EVENT = "selected"
+
+const VALUE_ALL_PLACEHOLDER = "__all__"
 
 let counter = 0
 
+/**
+ * *** Targets ***
+ * @property {HTMLInputElement[]} inputTargets
+ * *** Targets ***
+ * @property {HTMLInputElement} inputTarget
+ */
 class TreeselectGroupConnectable extends Controller {
+    static targets = ["input"]
+
+    get checked() {
+        return this.inputTargets.findIndex(it => !it.checked) === -1
+    }
+
+    #selectAllOfSameValue = async ({detail: {value}}) => {
+        if (value === VALUE_ALL_PLACEHOLDER) return
+        this.inputTargets.forEach(it => {
+            if (it.value.trim() === value.trim() && it.checked === false) {
+                it.setAttribute("data-implicit-check", "")
+            }
+        })
+    }
+
+    #unselectAllOfSameValue = async ({detail: {value}}) => {
+        if (value === VALUE_ALL_PLACEHOLDER) return
+        this.inputTargets.forEach(it => {
+            if (it.value.trim() === value.trim() && it.checked === true) {
+                it.checked = false
+                it.removeAttribute("data-implicit-check")
+            }
+        })
+    }
+
     connect() {
+        /**@type {Controller}*/
+        this.treeselect = this.application.getControllerForElementAndIdentifier(
+            this.element.closest(`[data-controller~="${WIDGET_IDENTIFIER}"]`),
+            WIDGET_IDENTIFIER,
+        )
+
+        this.treeselect.element.addEventListener(`${WIDGET_IDENTIFIER}:${SELECT_EVENT}`, this.#selectAllOfSameValue)
+        this.treeselect.element.addEventListener(`${WIDGET_IDENTIFIER}:${UNSELECT_EVENT}`, this.#unselectAllOfSameValue)
+
         const enclosingGroup = this.element.parentElement.closest(
             `[data-controller~="${WIDGET_IDENTIFIER}"], [data-controller~="${GROUP_IDENTIFIER}"]`,
         )
@@ -25,18 +68,20 @@ class TreeselectGroupConnectable extends Controller {
 
     disconnect() {
         this._parentGroup?.unregisterChild(this._childId, this)
+        this.treeselect.element.removeEventListener(`${WIDGET_IDENTIFIER}:${SELECT_EVENT}`, this.#selectAllOfSameValue)
+        this.treeselect.element.removeEventListener(
+            `${WIDGET_IDENTIFIER}:${UNSELECT_EVENT}`,
+            this.#unselectAllOfSameValue,
+        )
     }
 }
 
 /**
- * *** Targets ***
- * @property {HTMLInputElement} inputTarget
  * *** Values ***
  * @property {Boolean} hiddenValue
  */
 class TreeselectElement extends TreeselectGroupConnectable {
     static values = {hidden: {type: Boolean, default: false}}
-    static targets = ["input"]
 
     get labels() {
         return [
@@ -82,7 +127,6 @@ class TreeselectElement extends TreeselectGroupConnectable {
 /**
  * *** Targets ***
  * @property {HTMLElement[]} collapseTargets
- * @property {HTMLInputElement[]} inputTargets
  * @property {HTMLInputElement[]} accordionBtnTargets
  * *** Values ***
  * @property {Boolean} hiddenValue
@@ -95,7 +139,7 @@ class TreeselectGroup extends TreeselectGroupConnectable {
         selfMatchesSearch: {type: Boolean, default: true},
         hasChildrenMatching: {type: Boolean, default: true},
     }
-    static targets = ["input", "accordionBtn", "collapse"]
+    static targets = ["accordionBtn", "collapse"]
 
     get labels() {
         const result = []
@@ -107,13 +151,8 @@ class TreeselectGroup extends TreeselectGroupConnectable {
     }
 
     initialize() {
+        /** @type {Map<string, TreeselectGroupConnectable>} */
         this.children = new Map()
-
-        for (const it of this.element.querySelectorAll("& > .fr-treeselect__group-header input")) {
-            it.setAttribute(`data-${this.identifier}-target`, "input")
-            const actions = (it.dataset.action || "").split(/\s+/)
-            it.dataset.action = [`${this.identifier}#onSelect`, ...actions].join(" ")
-        }
     }
 
     registerChild(id, child) {
@@ -162,13 +201,51 @@ class TreeselectGroup extends TreeselectGroupConnectable {
         }
     }
 
-    onSelect({target: {checked}}) {
-        if (checked) {
+    /**
+     * @param param0
+     * @param {HTMLInputElement} param0.target
+     * @param param0.detail
+     * @param {boolean} [param0.detail.implicit] Parameter that indecate that this event
+     *      was emitted by clicking another input. Since this method may itself emit an
+     *      change event, this parameter is necessary to prevent infinite recusrsion
+     */
+    onSelect({target, detail}) {
+        if (detail?.implicit === true) return
+
+        if (target.checked) {
             this.collapseTargets.forEach(async it => {
                 await dsfrDisclosePromise(dsfr(it).collapse)
                 it.scrollIntoView({block: "center"})
             })
         }
+        if (target.type === "checkbox") {
+            this.children.values().forEach(child => {
+                child.inputTargets.forEach(it => {
+                    it.checked = target.checked
+                    it.dispatchEvent(new CustomEvent("change", {detail: {implicit: true}}))
+                })
+            })
+        }
+    }
+
+    /**
+     * @param param0
+     * @param {HTMLInputElement} param0.target
+     * @param param0.detail
+     * @param {boolean} [param0.detail.implicit] Parameter that indecate that this event
+     *      was emitted by clicking another input. Since this method may itself emit an
+     *      change event, this parameter is necessary to prevent infinite recusrsion
+     */
+    onChildCheckboxChange({target, detail}) {
+        if (detail?.implicit === true || target.type !== "checkbox") return
+
+        const newCheck = !(!target.checked || this.children.values().find(it => !it.checked) !== undefined)
+        this.inputTargets.forEach(it => {
+            if (it.checked !== newCheck) {
+                it.checked = newCheck
+                it.dispatchEvent(new CustomEvent("change", {detail: {implicit: true}}))
+            }
+        })
     }
 }
 
@@ -192,7 +269,7 @@ class TreeselectSelectedBadge extends Controller {
     }
 
     onUnselected({detail: {value}}) {
-        if (value === this.formvalValue || value === "__all__") {
+        if (value === this.formvalValue || value === VALUE_ALL_PLACEHOLDER) {
             this.element.remove()
         }
     }
@@ -252,7 +329,7 @@ class Treeselect extends Controller {
         await Promise.all(this.children.values().map(it => it.search(search, this.minSearchLengthValue)))
     }
 
-    onChange({target}) {
+    onChange({target, detail}) {
         const label = target.labels[0].textContent.trim() || target.ariaLabel
         const categorisedLabel = target.dataset.categorisedLabel || label
         // If inputs are radio buttons, we allow only one value
@@ -261,7 +338,7 @@ class Treeselect extends Controller {
         }
 
         if (target.checked) {
-            this.selectChoice(target.value, label, categorisedLabel)
+            this.selectChoice(target.value, label, categorisedLabel, detail?.implicit)
         } else {
             this.unselectChoice(target.value)
         }
@@ -271,8 +348,7 @@ class Treeselect extends Controller {
         } else if (size === 1) {
             this.buttonTarget.textContent = `${this.choices.values().next().value}`
         } else {
-            const additionnal = this.choices.size - 1
-            this.buttonTarget.textContent = `${this.choices.values().next().value} +${additionnal} élément${additionnal > 1 ? "s" : ""}`
+            this.buttonTarget.textContent = `${this.choices.size} éléments`
         }
     }
 
@@ -283,10 +359,11 @@ class Treeselect extends Controller {
 
     clearChoices() {
         this.choices.clear()
-        this.dispatch(UNSELECT_EVENT, {detail: {value: "__all__"}})
+        this.dispatch(UNSELECT_EVENT, {detail: {value: VALUE_ALL_PLACEHOLDER}})
     }
 
     selectChoice(value, label, categorisedLabel) {
+        this.dispatch(SELECT_EVENT, {detail: {value}})
         this.choices.set(value, categorisedLabel)
         this.selectedGroupTarget.insertAdjacentHTML(
             "beforeend",
@@ -295,8 +372,10 @@ class Treeselect extends Controller {
     }
 
     unselectChoice(value) {
-        this.choices.delete(value)
-        this.dispatch(UNSELECT_EVENT, {detail: {value}})
+        if (this.choices.has(value)) {
+            this.choices.delete(value)
+            this.dispatch(UNSELECT_EVENT, {detail: {value}})
+        }
     }
 }
 

--- a/core/static/core/form/widgets/treeselect.mjs
+++ b/core/static/core/form/widgets/treeselect.mjs
@@ -4,54 +4,28 @@ import {search} from "Utils"
 
 const WIDGET_IDENTIFIER = "treeselect"
 const GROUP_IDENTIFIER = "treeselect-group"
-const UNSELECT_EVENT = "unselected"
-const SELECT_EVENT = "selected"
-
-const VALUE_ALL_PLACEHOLDER = "__all__"
+const CHOICES_CHANGED_EVENT = "choices"
 
 let counter = 0
 
 /**
  * *** Targets ***
  * @property {HTMLInputElement[]} inputTargets
- * *** Targets ***
  * @property {HTMLInputElement} inputTarget
+ * @property {boolean} hasInputTarget
  */
 class TreeselectGroupConnectable extends Controller {
     static targets = ["input"]
 
-    get checked() {
-        return this.inputTargets.findIndex(it => !it.checked) === -1
-    }
-
-    #selectAllOfSameValue = async ({detail: {value}}) => {
-        if (value === VALUE_ALL_PLACEHOLDER) return
-        this.inputTargets.forEach(it => {
-            if (it.value.trim() === value.trim() && it.checked === false) {
-                it.setAttribute("data-implicit-check", "")
-            }
-        })
-    }
-
-    #unselectAllOfSameValue = async ({detail: {value}}) => {
-        if (value === VALUE_ALL_PLACEHOLDER) return
-        this.inputTargets.forEach(it => {
-            if (it.value.trim() === value.trim() && it.checked === true) {
-                it.checked = false
-                it.removeAttribute("data-implicit-check")
-            }
-        })
-    }
-
     connect() {
-        /**@type {Controller}*/
+        /** @type {Treeselect} */
         this.treeselect = this.application.getControllerForElementAndIdentifier(
             this.element.closest(`[data-controller~="${WIDGET_IDENTIFIER}"]`),
             WIDGET_IDENTIFIER,
         )
 
-        this.treeselect.element.addEventListener(`${WIDGET_IDENTIFIER}:${SELECT_EVENT}`, this.#selectAllOfSameValue)
-        this.treeselect.element.addEventListener(`${WIDGET_IDENTIFIER}:${UNSELECT_EVENT}`, this.#unselectAllOfSameValue)
+        this.onChoicesChanged = this.onChoicesChanged.bind(this)
+        this.treeselect.element.addEventListener(`${WIDGET_IDENTIFIER}:${CHOICES_CHANGED_EVENT}`, this.onChoicesChanged)
 
         const enclosingGroup = this.element.parentElement.closest(
             `[data-controller~="${WIDGET_IDENTIFIER}"], [data-controller~="${GROUP_IDENTIFIER}"]`,
@@ -68,11 +42,28 @@ class TreeselectGroupConnectable extends Controller {
 
     disconnect() {
         this._parentGroup?.unregisterChild(this._childId, this)
-        this.treeselect.element.removeEventListener(`${WIDGET_IDENTIFIER}:${SELECT_EVENT}`, this.#selectAllOfSameValue)
         this.treeselect.element.removeEventListener(
-            `${WIDGET_IDENTIFIER}:${UNSELECT_EVENT}`,
-            this.#unselectAllOfSameValue,
+            `${WIDGET_IDENTIFIER}:${CHOICES_CHANGED_EVENT}`,
+            this.onChoicesChanged,
         )
+    }
+
+    /**
+     * @param {CustomEvent} param0
+     * @param {Object} param0.detail
+     * @param {Map<string, string>} param0.detail.choices
+     */
+    async onChoicesChanged({target, detail: {choices}}) {
+        for (const it of this.inputTargets) {
+            if (target === it) continue
+            if (choices.has(it.value.trim()) && !it.checked) {
+                it.checked = true
+            } else if (!choices.has(it.value.trim()) && it.checked && it.type === "radio") {
+                // Here, we don't want to uncheck if input is of type checkbox since this would interfere with
+                // the feature to automatically select group input when all children are selected
+                it.checked = false
+            }
+        }
     }
 }
 
@@ -141,6 +132,8 @@ class TreeselectGroup extends TreeselectGroupConnectable {
     }
     static targets = ["accordionBtn", "collapse"]
 
+    #locked = false
+
     get labels() {
         const result = []
         for (const it of this.inputTargets) {
@@ -148,6 +141,10 @@ class TreeselectGroup extends TreeselectGroupConnectable {
             result.push(it.ariaLabel?.trim() ?? "")
         }
         return result
+    }
+
+    get childTargets() {
+        return Array.from(this.children.values()).flatMap(child => child.inputTargets)
     }
 
     initialize() {
@@ -201,51 +198,49 @@ class TreeselectGroup extends TreeselectGroupConnectable {
         }
     }
 
-    /**
-     * @param param0
-     * @param {HTMLInputElement} param0.target
-     * @param param0.detail
-     * @param {boolean} [param0.detail.implicit] Parameter that indecate that this event
-     *      was emitted by clicking another input. Since this method may itself emit an
-     *      change event, this parameter is necessary to prevent infinite recusrsion
-     */
-    onSelect({target, detail}) {
-        if (detail?.implicit === true) return
+    async onChoicesChanged(evt) {
+        if (this.#locked) return
 
-        if (target.checked) {
+        await super.onChoicesChanged(evt)
+        if (!this.hasInputTarget || this.inputTarget.type !== "checkbox") return
+
+        try {
+            this.#locked = true
+            const hasAll = this.childTargets.every(it => it.checked)
+            if (hasAll && !this.inputTarget.checked) {
+                this.inputTarget.checked = true
+                this.inputTarget.dispatchEvent(new Event("change"))
+            } else if (!hasAll && this.inputTarget.checked) {
+                this.inputTarget.checked = false
+                this.inputTarget.dispatchEvent(new Event("change"))
+            }
+        } finally {
+            this.#locked = false
+        }
+    }
+
+    /** @param {Event} evt */
+    onSelect(evt) {
+        if (this.#locked) return
+
+        if (!this.hasInputTarget || this.inputTarget.type !== "checkbox") return
+
+        const checked = evt.target.checked
+        try {
+            this.#locked = true
+            for (const it of this.childTargets) {
+                it.checked = checked
+                it.dispatchEvent(new Event("change"))
+            }
+        } finally {
+            this.#locked = false
+        }
+        if (checked) {
             this.collapseTargets.forEach(async it => {
                 await dsfrDisclosePromise(dsfr(it).collapse)
                 it.scrollIntoView({block: "center"})
             })
         }
-        if (target.type === "checkbox") {
-            this.children.values().forEach(child => {
-                child.inputTargets.forEach(it => {
-                    it.checked = target.checked
-                    it.dispatchEvent(new CustomEvent("change", {detail: {implicit: true}}))
-                })
-            })
-        }
-    }
-
-    /**
-     * @param param0
-     * @param {HTMLInputElement} param0.target
-     * @param param0.detail
-     * @param {boolean} [param0.detail.implicit] Parameter that indecate that this event
-     *      was emitted by clicking another input. Since this method may itself emit an
-     *      change event, this parameter is necessary to prevent infinite recusrsion
-     */
-    onChildCheckboxChange({target, detail}) {
-        if (detail?.implicit === true || target.type !== "checkbox") return
-
-        const newCheck = !(!target.checked || this.children.values().find(it => !it.checked) !== undefined)
-        this.inputTargets.forEach(it => {
-            if (it.checked !== newCheck) {
-                it.checked = newCheck
-                it.dispatchEvent(new CustomEvent("change", {detail: {implicit: true}}))
-            }
-        })
     }
 }
 
@@ -255,21 +250,30 @@ class TreeselectGroup extends TreeselectGroupConnectable {
  */
 class TreeselectSelectedBadge extends Controller {
     static values = {formval: String}
+
     connect() {
         this.treeselect = this.application.getControllerForElementAndIdentifier(
             this.element.closest(`[data-controller~="${WIDGET_IDENTIFIER}"]`),
             WIDGET_IDENTIFIER,
         )
-        this.onUnselected = this.onUnselected.bind(this)
-        this.treeselect.element.addEventListener(`${WIDGET_IDENTIFIER}:${UNSELECT_EVENT}`, this.onUnselected)
+        this.onChoicesChanged = this.onChoicesChanged.bind(this)
+        this.treeselect.element.addEventListener(`${WIDGET_IDENTIFIER}:${CHOICES_CHANGED_EVENT}`, this.onChoicesChanged)
     }
 
     disconnect() {
-        this.treeselect.element.removeEventListener(`${WIDGET_IDENTIFIER}:${UNSELECT_EVENT}`, this.onUnselected)
+        this.treeselect.element.removeEventListener(
+            `${WIDGET_IDENTIFIER}:${CHOICES_CHANGED_EVENT}`,
+            this.onChoicesChanged,
+        )
     }
 
-    onUnselected({detail: {value}}) {
-        if (value === this.formvalValue || value === VALUE_ALL_PLACEHOLDER) {
+    /**
+     * @param {CustomEvent} param0
+     * @param {Object} param0.detail
+     * @param {Map<string, string>} param0.detail.choices
+     */
+    onChoicesChanged({detail: {choices}}) {
+        if (!choices.has(this.formvalValue)) {
             this.element.remove()
         }
     }
@@ -329,18 +333,31 @@ class Treeselect extends Controller {
         await Promise.all(this.children.values().map(it => it.search(search, this.minSearchLengthValue)))
     }
 
-    onChange({target, detail}) {
+    /**
+     * @param {Event} param0
+     * @param {HTMLInputElement} param0.target
+     */
+    onChange({target}) {
         const label = target.labels[0].textContent.trim() || target.ariaLabel
+        const value = target.value.trim()
         const categorisedLabel = target.dataset.categorisedLabel || label
+
+        // Don't process event if already in corect state
+        if (this.choices.has(value) === target.checked) return
+
         // If inputs are radio buttons, we allow only one value
         if (target.type === "radio") {
-            this.clearChoices()
+            this.choices.clear()
         }
 
         if (target.checked) {
-            this.selectChoice(target.value, label, categorisedLabel, detail?.implicit)
+            this.choices.set(value, categorisedLabel)
+            this.selectedGroupTarget.insertAdjacentHTML(
+                "beforeend",
+                this.selectedTagTplTarget.innerHTML.replaceAll("__label__", label).replaceAll("__value__", value),
+            )
         } else {
-            this.unselectChoice(target.value)
+            this.choices.delete(value)
         }
         const size = this.choices.size
         if (size === 0) {
@@ -350,32 +367,12 @@ class Treeselect extends Controller {
         } else {
             this.buttonTarget.textContent = `${this.choices.size} éléments`
         }
+        this.dispatch(CHOICES_CHANGED_EVENT, {target, detail: {choices: this.choices}})
     }
 
     onEraseSearch() {
         this.searchbarTarget.value = ""
         this.searchbarTarget.dispatchEvent(new Event("input"))
-    }
-
-    clearChoices() {
-        this.choices.clear()
-        this.dispatch(UNSELECT_EVENT, {detail: {value: VALUE_ALL_PLACEHOLDER}})
-    }
-
-    selectChoice(value, label, categorisedLabel) {
-        this.dispatch(SELECT_EVENT, {detail: {value}})
-        this.choices.set(value, categorisedLabel)
-        this.selectedGroupTarget.insertAdjacentHTML(
-            "beforeend",
-            this.selectedTagTplTarget.innerHTML.replaceAll("__label__", label).replaceAll("__value__", value),
-        )
-    }
-
-    unselectChoice(value) {
-        if (this.choices.has(value)) {
-            this.choices.delete(value)
-            this.dispatch(UNSELECT_EVENT, {detail: {value}})
-        }
     }
 }
 

--- a/core/static/core/form/widgets/treeselect_dsfr.css
+++ b/core/static/core/form/widgets/treeselect_dsfr.css
@@ -155,13 +155,6 @@
     background-position: left center;
 }
 
-/* CSS to allow to implicitely check several radio inputs with the same value */
-.fr-radio-group input[type="radio"][data-implicit-check] + label {
-    background-image:
-        radial-gradient(transparent 10px, var(--border-active-blue-france) 11px, transparent 12px),
-        radial-gradient(var(--background-active-blue-france) 5px, transparent 6px) !important;
-}
-
 .fr-treeselect__selected .fr-tag .fr-btn {
     max-width: none;
     padding: 0.25rem;

--- a/core/static/core/form/widgets/treeselect_dsfr.css
+++ b/core/static/core/form/widgets/treeselect_dsfr.css
@@ -155,6 +155,13 @@
     background-position: left center;
 }
 
+/* CSS to allow to implicitely check several radio inputs with the same value */
+.fr-radio-group input[type="radio"][data-implicit-check] + label {
+    background-image:
+        radial-gradient(transparent 10px, var(--border-active-blue-france) 11px, transparent 12px),
+        radial-gradient(var(--background-active-blue-france) 5px, transparent 6px) !important;
+}
+
 .fr-treeselect__selected .fr-tag .fr-btn {
     max-width: none;
     padding: 0.25rem;

--- a/core/templates/core/form/widgets/treeselect.html
+++ b/core/templates/core/form/widgets/treeselect.html
@@ -75,7 +75,6 @@
             {% endif %}
         >
             {% for optgroup in widget.optgroups %}
-                {% merge_data_action optgroup.attrs "change->treeselect-group#onChildCheckboxChange" %}
                 {% include optgroup.template_name with widget=optgroup %}
             {% endfor %}
         </div>

--- a/core/templates/core/form/widgets/treeselect.html
+++ b/core/templates/core/form/widgets/treeselect.html
@@ -2,9 +2,8 @@
 
 {% partialdef input %}
     <div class="fr-{{ widget.type }}-group{% if parent_index %} fr-treeselect__group-selectable{% endif %}">
-        {% with data_action=widget.attrs|get_item:"data-action"|default:"" %}
-            {% set_context_var widget.attrs "data-action" data_action|strfmt:"{} change->treeselect#onChange" %}
-        {% endwith %}
+        {% merge_data_action widget.attrs "change->treeselect#onChange" %}
+        {% if parent_index %}{% set_context_var widget.attrs "data-treeselect-group-target" "input" %}{% endif %}
         {% include "django/forms/widgets/input.html" %}
         <label class="fr-label" for="{{ widget.attrs.id }}">
             {% if parent_index %}
@@ -51,6 +50,7 @@
                 >{{ widget.group }}</p>
             {% elif widget.group_option %}
                 {% with widget=widget.group_option parent_index=widget.group_index %}
+                    {% merge_data_action widget.attrs "change->treeselect-group#onSelect" %}
                     {% partial input %}
                 {% endwith %}
             {% else %}
@@ -75,6 +75,7 @@
             {% endif %}
         >
             {% for optgroup in widget.optgroups %}
+                {% merge_data_action optgroup.attrs "change->treeselect-group#onChildCheckboxChange" %}
                 {% include optgroup.template_name with widget=optgroup %}
             {% endfor %}
         </div>
@@ -130,7 +131,7 @@
                     >
                         <template data-treeselect-target="selectedTagTpl">
                             <div
-                                class="fr-tag fr-tag--dismiss"
+                                class="fr-tag fr-background-action-high--blue-france fr-text-inverted--blue-france"
                                 type="button"
                                 data-controller="treeselect-selected-badge"
                                 data-treeselect-selected-badge-formval-value="__value__"

--- a/core/templatetags/set_context_var.py
+++ b/core/templatetags/set_context_var.py
@@ -1,4 +1,5 @@
-from typing import MutableMapping
+import re
+from typing import Mapping, MutableMapping
 
 from django import template
 
@@ -11,4 +12,16 @@ def set_context_var(target, key, value):
         target[key] = value
     else:
         setattr(target, key, value)
+    return ""
+
+
+@register.simple_tag
+def merge_data_action(target, value):
+    if isinstance(target, Mapping):
+        result = target.get("data-action", "")
+    else:
+        result = getattr(target, "data-action", "")
+
+    result = re.split(r"\s+", result) + [value]
+    set_context_var(target, "data-action", " ".join(result).strip())
     return ""

--- a/core/widgets.py
+++ b/core/widgets.py
@@ -26,6 +26,7 @@ class TreeselectItem:
     value: Any
     label: str
     categorised_label: str | None
+    html_name_prefix: str | None = None
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -35,10 +36,6 @@ class TreeselectGroup(BaseChoiceIterator):
     choices: _Choices
     categorised_label: str | None
     can_expand: bool = True
-
-    @property
-    def has_option(self):
-        return self.value is not _UNSET
 
     def __post_init__(self):
         self.choices = normalize_choices(self.choices)
@@ -81,6 +78,11 @@ class TreeselectGroupWidget(widgets.ChoiceWidget):
         else:
             super().__init__(self.parent.attrs, ((item.label, item.value),))
 
+    def get_selected(self, option_value, value):
+        selected = (not self.parent.has_selected or self.parent.allow_multiple_selected) and str(option_value) in value
+        self.parent.has_selected |= selected
+        return selected
+
     def get_context(self, name, value, attrs):
         attrs = attrs or {}
         context = super().get_context(name, value, attrs)
@@ -93,12 +95,12 @@ class TreeselectGroupWidget(widgets.ChoiceWidget):
             context["can_expand"] = self.item.can_expand
             if self.item.categorised_label:
                 attrs["data-categorised-label"] = self.item.categorised_label
-            if self.item.has_option:
+            if self.item.value:
                 context["group_option"] = self.create_option(
                     name,
                     self.item.value,
                     self.group_label,
-                    str(self.group_label) in value,
+                    self.get_selected(self.item.value, value),
                     self.parent.get_next_id(),
                     None,
                     attrs,
@@ -108,7 +110,6 @@ class TreeselectGroupWidget(widgets.ChoiceWidget):
 
     def optgroups(self, name, value, attrs=None):
         attrs = attrs or {}
-        has_selected = False
         for choice in self.choices:
             if isinstance(choice, TreeselectGroup):
                 yield TreeselectGroupWidget(self.parent, choice).get_context(name, value, attrs)
@@ -117,10 +118,20 @@ class TreeselectGroupWidget(widgets.ChoiceWidget):
                     choice = TreeselectItem(value=choice[0], label=choice[1], categorised_label=None)
                 if choice.categorised_label:
                     attrs["data-categorised-label"] = choice.categorised_label
-                selected = (not has_selected or self.parent.allow_multiple_selected) and str(choice.value) in value
-                has_selected |= selected
+                if choice.html_name_prefix:
+                    name = f"{choice.html_name_prefix}-{name}"
+                    selected = str(choice.value) in value
+                else:
+                    selected = self.get_selected(choice.value, value)
+
                 yield self.create_option(
-                    name, choice.value, choice.label, selected, self.parent.get_next_id(), subindex=None, attrs=attrs
+                    name,
+                    choice.value,
+                    choice.label,
+                    selected,
+                    self.parent.get_next_id(),
+                    subindex=None,
+                    attrs=attrs,
                 )
 
     def create_option(self, name, value, label, selected, index, subindex=None, attrs=None, *, group_option=False):
@@ -185,6 +196,7 @@ class TreeselectCheckbox(widgets.ChoiceWidget):
         return context
 
     def optgroups(self, name, values, attrs=None):
+        self.has_selected = False
         for choice in self.choices:
             match choice:
                 case TreeselectGroup() | TreeselectItem():

--- a/ssa/constants.py
+++ b/ssa/constants.py
@@ -19,9 +19,9 @@ class GroupedChoicesMixin:
             self._splitted_label_ = re.split(r"\s*>\s*", self.label)
         return self._splitted_label_
 
-    @enum_property
-    def treeselect_item(self):
-        return TreeselectItem(value=self.value, label=self.uncategorized_label, categorised_label=self.label)
+    def get_treeselect_item(self, **kwargs):
+        kwargs = {"value": self.value, "label": self.uncategorized_label, "categorised_label": self.label, **kwargs}
+        return TreeselectItem(**kwargs)
 
     @classproperty
     def treeselect_groups(cls):
@@ -39,6 +39,7 @@ class GroupedChoicesMixin:
             treeselect_kwargs = {"categorised_label": None}
             if group_item := item.pop("__self__", None):
                 treeselect_kwargs["value"] = group_item.value
+                treeselect_kwargs["categorised_label"] = group_item.categorised_label
             treeselect_kwargs["label"] = label
             treeselect_kwargs["choices"] = []
             for label, item in item.items():
@@ -689,7 +690,7 @@ class CategorieDanger(WithChoicesToJS, GroupedChoicesMixin, models.TextChoices):
         return (
             TreeselectGroup(
                 label="Dangers les plus courants",
-                choices=tuple(it.treeselect_item for it in cls.danger_courants),
+                choices=tuple(it.get_treeselect_item(html_name_prefix="shortcut") for it in cls.danger_courants),
                 can_expand=False,
                 categorised_label=None,
             ),


### PR DESCRIPTION
Modifications :

- sélectionne tous les boutons radio avec la même valeur lorsqu'un raccourci est sélectionné,
- cocher une checkbox de niveau 2 sélectionne les enfants,
- correction du texte du label principal (affichait avant le label du premier élément + `+ *x* élements` lorsque multiple, maintenant n'affiche que `+ *x* éléments`,
- correction du label complet des groupes de niveau 2