### PR TITLE
Move conclusion form to modal

### DIFF
--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -38,6 +38,14 @@ class WithTreeSelect:
         self.page.evaluate('document.querySelector("html").dispatchEvent(new Event("blur", {bubbles: true}))')
         expect(self.page.locator(f"#{container_id} .treeselect-list"), "Treeselect wasn't closed").to_have_count(0)
 
+    def _set_treeselect_option_by_search_term(self, container_id, search_term, label):
+        self.page.locator(f"#{container_id} .treeselect-input__edit").locator("visible=true").click(force=True)
+        self.page.locator(f"#{container_id} .treeselect-input__edit").locator("visible=true").fill(search_term)
+        element = self.page.get_by_title(label, exact=True)
+        element.locator(".treeselect-list__item-checkbox-icon").locator("visible=true").click(force=True)
+        self.page.evaluate('document.querySelector("html").dispatchEvent(new Event("blur", {bubbles: true}))')
+        expect(self.page.locator(f"#{container_id} .treeselect-list"), "Treeselect wasn't closed").to_have_count(0)
+
     def get_treeselect_options(self, container_id):
         elements = self.page.locator(f"#{container_id} .treeselect-input__tags-count")
         return [elements.nth(i).inner_text() for i in range(elements.count())]

--- a/tiac/forms.py
+++ b/tiac/forms.py
@@ -239,10 +239,6 @@ class EvenementSimpleTransferForm(DsfrBaseForm, forms.ModelForm):
 
 
 class InvestigationTiacForm(DsfrBaseForm, WithFreeLinksMixin, WithLatestVersionLocking, forms.ModelForm):
-    SuspicionConclusion = SuspicionConclusion
-    CategorieDanger = CategorieDanger
-    DangersSyndromiques = DangersSyndromiques
-
     date_reception = forms.DateField(
         required=True,
         label="Date de réception",
@@ -324,10 +320,6 @@ class InvestigationTiacForm(DsfrBaseForm, WithFreeLinksMixin, WithLatestVersionL
     precisions = forms.CharField(
         widget=forms.TextInput(attrs={"disabled": True}), required=False, label="Précisions", help_text="Type d'analyse"
     )
-    suspicion_conclusion = SEVESChoiceField(
-        label="Conclusion de la suspicion de TIAC", choices=SuspicionConclusion, required=False
-    )
-    selected_hazard = SimpleArrayField(forms.CharField(), delimiter="||", label="Dangers retenus", required=False)
 
     class Meta:
         model = InvestigationTiac
@@ -377,14 +369,6 @@ class InvestigationTiacForm(DsfrBaseForm, WithFreeLinksMixin, WithLatestVersionL
     def common_danger(self):
         return DANGERS_COURANTS
 
-    @cached_property
-    def selected_hazard_confirmed_choices(self):
-        return json.dumps(self.CategorieDanger.build_options())
-
-    @cached_property
-    def selected_hazard_suspected_choices(self):
-        return json.dumps([{"name": label, "value": value} for value, label in DangersSyndromiques.choices_short_names])
-
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user")
         super().__init__(*args, **kwargs)
@@ -401,29 +385,6 @@ class InvestigationTiacForm(DsfrBaseForm, WithFreeLinksMixin, WithLatestVersionL
         today = timezone.localtime(timezone.now()).date().isoformat()
         self.fields["date_reception"].initial = today
         self.fields["date_reception"].widget.attrs["max"] = today
-
-    def clean_suspicion_conclusion_and_selected_hazard(self):
-        suspicion_conclusion = self.cleaned_data.get("suspicion_conclusion")
-        selected_hazard = self.cleaned_data.get("selected_hazard")
-
-        if suspicion_conclusion not in (SuspicionConclusion.CONFIRMED, SuspicionConclusion.SUSPECTED):
-            self.cleaned_data["selected_hazard"] = []
-        elif suspicion_conclusion == SuspicionConclusion.CONFIRMED and any(
-            item not in CategorieDanger.values for item in selected_hazard
-        ):
-            self.add_error(
-                "selected_hazard", f"La valeur doit être comprise parmis [{', '.join(CategorieDanger.labels)}]"
-            )
-        elif suspicion_conclusion == SuspicionConclusion.SUSPECTED and any(
-            item not in DangersSyndromiques.values for item in selected_hazard
-        ):
-            self.add_error(
-                "selected_hazard", f"La valeur doit être comprise parmis [{', '.join(DangersSyndromiques.labels)}]"
-            )
-
-    def clean(self):
-        self.clean_suspicion_conclusion_and_selected_hazard()
-        return super().clean()
 
     def save(self, commit=True):
         if self.data.get("action") == "publish":
@@ -596,3 +557,84 @@ class AnalyseAlimentaireForm(DsfrBaseForm, forms.ModelForm):
         widgets = {
             "sent_to_lnr_cnr": forms.RadioSelect(choices=((True, "Oui"), (False, "Non"))),
         }
+
+
+class ConclusionForm(DsfrBaseForm, forms.ModelForm):
+    SuspicionConclusion = SuspicionConclusion
+
+    suspicion_conclusion = SEVESChoiceField(
+        label="Conclusion de la suspicion de TIAC", choices=SuspicionConclusion, required=True
+    )
+    selected_hazard = SimpleArrayField(
+        forms.CharField(), delimiter="||", label="Dangers retenus", required=False, widget=forms.HiddenInput
+    )
+
+    class Meta:
+        model = InvestigationTiac
+        fields = (
+            "suspicion_conclusion",
+            "selected_hazard",
+            "conclusion_comment",
+            "conclusion_repas",
+            "conclusion_aliment",
+        )
+
+    @property
+    def media(self):
+        return super().media + Media(
+            js=(
+                js_module("tiac/tiac_conclusion.mjs"),
+                js_module("ssa/treeselectjs.umd.js"),
+                js_module("ssa/form/widgets/legacy_treeselect.mjs"),
+            ),
+            css={
+                "all": (
+                    "https://cdn.jsdelivr.net/npm/treeselectjs@0.13.1/dist/treeselectjs.css",
+                    "ssa/form/widgets/_custom_tree_select.css",
+                )
+            },
+        )
+
+    def clean_suspicion_conclusion_and_selected_hazard(self):
+        suspicion_conclusion = self.cleaned_data.get("suspicion_conclusion")
+        selected_hazard = self.cleaned_data.get("selected_hazard")
+
+        if suspicion_conclusion not in (SuspicionConclusion.CONFIRMED, SuspicionConclusion.SUSPECTED):
+            self.cleaned_data["selected_hazard"] = []
+        elif suspicion_conclusion == SuspicionConclusion.CONFIRMED and any(
+            item not in CategorieDanger.values for item in selected_hazard
+        ):
+            self.add_error(
+                "selected_hazard", f"La valeur doit être comprise parmis [{', '.join(CategorieDanger.labels)}]"
+            )
+        elif suspicion_conclusion == SuspicionConclusion.SUSPECTED and any(
+            item not in DangersSyndromiques.values for item in selected_hazard
+        ):
+            self.add_error(
+                "selected_hazard", f"La valeur doit être comprise parmis [{', '.join(DangersSyndromiques.labels)}]"
+            )
+
+    def clean(self):
+        self.clean_suspicion_conclusion_and_selected_hazard()
+        return super().clean()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        for field in ("conclusion_repas", "conclusion_aliment"):
+            self[field].field.empty_label = settings.SELECT_EMPTY_CHOICE
+            queryset = self[field].field.queryset
+            self[field].field.queryset = (
+                queryset.filter(investigation=self.instance) if self.instance.pk else queryset.none()
+            )
+
+    @cached_property
+    def selected_hazard_confirmed_choices(self):
+        return json.dumps(CategorieDanger.build_options())
+
+    @cached_property
+    def selected_hazard_suspected_choices(self):
+        return json.dumps([{"name": label, "value": value} for value, label in DangersSyndromiques.choices_short_names])
+
+    @cached_property
+    def common_danger(self):
+        return DANGERS_COURANTS

--- a/tiac/templates/tiac/_investigation_tiac_informations_conclusion.html
+++ b/tiac/templates/tiac/_investigation_tiac_informations_conclusion.html
@@ -1,6 +1,6 @@
 {% load and_more_ellipsis_tooltip or_empty_value_tag %}
 
-<div class="blue-container">
+<div class="blue-container" data-testid="conclusion-block">
     <h2 class="fr-h6">Conclusion</h2>
     <div class="fr-grid-row fr-grid-row--gutters fr-my-0">
         <div class="fr-col-6">

--- a/tiac/templates/tiac/forms/conclusion.html
+++ b/tiac/templates/tiac/forms/conclusion.html
@@ -1,0 +1,84 @@
+{% load dsfr_tags widget_tweaks %}
+<dialog id="modal-conclusion" class="fr-modal" aria-labelledby="modal-conclusion-title" aria-modal="true">
+    <form method="post" action="{% url 'tiac:investigation-tiac-edition-conclusion' object.pk %}">
+        {% csrf_token %}
+        <div class="fr-container fr-container--fluid fr-container-md">
+            <div class="fr-grid-row fr-grid-row--center">
+                <div class="fr-col-12 fr-col-md-10 fr-col-lg-8">
+                    <div class="fr-modal__body">
+                        <div class="fr-modal__header">
+                            <button aria-controls="modal-conclusion" title="Fermer" type="button"
+                                    class="fr-btn--close fr-btn">Fermer
+                            </button>
+                        </div>
+                        <div class="fr-modal__content">
+                            <h2 id="modal-conclusion-title" class="fr-modal__title">
+                                <span class="fr-icon-arrow-right-line fr-icon--lg" aria-hidden="true"></span>
+                                Enregistrer la conclusion
+                            </h2>
+
+                            <fieldset
+                                class="fr-fieldset fr-flex fr-flex--align-normal form-fieldset fr-mt-2w"
+                                data-controller="conclusion-form"
+                                data-conclusion-form-suspicion-conclusion-choices-value="{{ form.SuspicionConclusion.as_json }}"
+                                data-conclusion-form-selected-hazard-confirmed-choices-value="{{ form.selected_hazard_confirmed_choices }}"
+                                data-conclusion-form-selected-hazard-suspected-choices-value="{{ form.selected_hazard_suspected_choices }}"
+                            >
+                                {% dsfr_form_field form.suspicion_conclusion|set_data:"action:conclusion-form#onSuspicionConclusionChanged:prevent:default"|set_data:"conclusion-form-target:suspicionConclusion" %}
+                                <div id="selected_hazard-treeselect" class="fr-input-group">
+                                    {{ form.selected_hazard.label_tag }}
+                                    <div
+                                        data-conclusion-form-target="selectedHazardTreeselect"
+                                        data-action="input->conclusion-form#onTreeselectInput update-dom->conclusion-form#onUpdateDom"
+                                    ></div>
+                                    {{ form.selected_hazard|set_data:"conclusion-form-target:selectedHazardTreeselectInput" }}
+                                    <template data-conclusion-form-target="selectedHazardTreeselectHeader">
+                                        <div class="categorie-danger-header">
+                                            <div class="fr-ml-1v">Dangers les plus courants</div>
+                                            {% for danger in form.common_danger %}
+                                                <div
+                                                    class="treeselect-list__item"
+                                                    level="0"
+                                                    group="false"
+                                                    data-action="mousedown->conclusion-form#onShortcut:prevent:stop"
+                                                >
+                                                    <input
+                                                        type="checkbox"
+                                                        id="shortcut_{{ forloop.counter0 }}"
+                                                        class="treeselect-list__item-checkbox-container"
+                                                    >
+                                                    <label
+                                                        class="treeselect-list__item-label shortcut"
+                                                        for="shortcut_{{ forloop.counter0 }}"
+                                                    >{{ danger }}</label>
+                                                </div>
+                                            {% endfor %}
+                                            <div class="fr-ml-1v">Liste complète des dangers</div>
+                                        </div>
+                                    </template>
+                                </div>
+                                {% dsfr_form_field form.conclusion_comment|remove_attr:"cols"|remove_attr:"rows" %}
+
+                                {% dsfr_form_field form.conclusion_repas|set_data:"conclusion-form-target:conclusionRepas" %}
+                                {% dsfr_form_field form.conclusion_aliment|set_data:"conclusion-form-target:conclusionAliment" %}
+                            </fieldset>
+
+                        </div>
+
+                        <div class="fr-modal__footer">
+                            <div
+                                class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                <button class="fr-btn fr-btn--secondary" aria-controls="modal-conclusion">
+                                    Annuler
+                                </button>
+
+                                <button type="submit" class="fr-btn">Enregistrer</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </form>
+
+</dialog>

--- a/tiac/templates/tiac/investigation.html
+++ b/tiac/templates/tiac/investigation.html
@@ -14,7 +14,7 @@
         {% csrf_token %}
         {{ form.latest_version }}
         <main class="main-container">
-            <div class="evenement-produit-form-header fr-grid-row">
+            <div class="evenement-produit-form-header fr-grid-row" data-testid="top-action-btns">
                 <h1 class="fr-col-6">
                     {% if form.instance.pk %}
                         Modification de l'événement {{ object.numero }}
@@ -204,77 +204,7 @@
                 </div>
 
             </fieldset>
-            <fieldset
-                class="fr-fieldset fr-flex fr-flex--align-normal form-fieldset fr-mt-2w"
-                data-controller="conclusion-form"
-                data-conclusion-form-suspicion-conclusion-choices-value="{{ form.SuspicionConclusion.as_json }}"
-                data-conclusion-form-selected-hazard-confirmed-choices-value="{{ form.selected_hazard_confirmed_choices }}"
-                data-conclusion-form-selected-hazard-suspected-choices-value="{{ form.selected_hazard_suspected_choices }}"
-            >
-                <legend class="fr-h3 fr-fieldset__legend">Conclusion</legend>
 
-                <div class="fr-notice fr-notice--info">
-                    <div class="fr-container">
-                        <div class="fr-notice__body">
-                            <p>
-                                <span class="fr-notice__title">
-                                    Afin de préciser le scénario (repas/aliment), il est
-                                    nécessaire d’avoir préalablement publié ou enregistré vos ajouts/modifications pour
-                                    pouvoir les sélectionner dans les menus déroulants ci-dessous
-                                </span>
-                            </p>
-                        </div>
-                    </div>
-                </div>
-                <div class="fr-grid-row fr-grid-row--gutters fr-my-0">
-                    <div class="fr-col-6 needs-required">
-                        {% dsfr_form_field form.suspicion_conclusion|set_data:"action:conclusion-form#onSuspicionConclusionChanged:prevent:default"|set_data:"conclusion-form-target:suspicionConclusion" %}
-                        <div id="selected_hazard-treeselect" class="fr-input-group">
-                            {{ form.selected_hazard.label_tag }}
-                            <div
-                                data-conclusion-form-target="selectedHazardTreeselect"
-                                data-action="input->conclusion-form#onTreeselectInput update-dom->conclusion-form#onUpdateDom"
-                            ></div>
-                            {{ form.selected_hazard|set_data:"conclusion-form-target:selectedHazardTreeselectInput" }}
-                            <template data-conclusion-form-target="selectedHazardTreeselectHeader">
-                                <div class="categorie-danger-header">
-                                    <div class="fr-ml-1v">Dangers les plus courants</div>
-                                    {% for danger in form.common_danger %}
-                                        <div
-                                            class="treeselect-list__item"
-                                            level="0"
-                                            group="false"
-                                            data-action="mousedown->conclusion-form#onShortcut:prevent:stop"
-                                        >
-                                            <input
-                                                type="checkbox"
-                                                id="shortcut_{{ forloop.counter0 }}"
-                                                class="treeselect-list__item-checkbox-container"
-                                            >
-                                            <label
-                                                class="treeselect-list__item-label shortcut"
-                                                for="shortcut_{{ forloop.counter0 }}"
-                                            >{{ danger }}</label>
-                                        </div>
-                                    {% endfor %}
-                                    <div class="fr-ml-1v">Liste complète des dangers</div>
-                                </div>
-                            </template>
-                        </div>
-                    </div>
-                    <div class="fr-col-6 conclusion-comment">
-                        {% dsfr_form_field form.conclusion_comment|remove_attr:"cols"|remove_attr:"rows" %}
-                    </div>
-                </div>
-                <div class="fr-grid-row fr-grid-row--gutters fr-my-0">
-                    <div class="fr-col-3">
-                        {% dsfr_form_field form.conclusion_repas|set_data:"conclusion-form-target:conclusionRepas" %}
-                    </div>
-                    <div class="fr-col-3">
-                        {% dsfr_form_field form.conclusion_aliment|set_data:"conclusion-form-target:conclusionAliment"  %}
-                    </div>
-                </div>
-            </fieldset>
             <fieldset id="liens-libre" class="fr-fieldset form-fieldset fr-mt-2w">
                 <div class="fieldset-header">
                     <legend class="fr-fieldset__legend fr-h3">Événements liés</legend>

--- a/tiac/templates/tiac/investigation_tiac_detail.html
+++ b/tiac/templates/tiac/investigation_tiac_detail.html
@@ -32,6 +32,9 @@
         {% if display_warning_modification %}
           {% include "core/modal_warning_update.html" with url=object.get_update_url %}
         {% endif %}
+        {% if can_be_modified and object.is_published %}
+          {% include "tiac/forms/conclusion.html" with form=conclusion_form %}
+        {% endif %}
 
         <div class="details-top-row--actions">
           <ul class="fr-btns-group fr-btns-group--inline-md">
@@ -44,6 +47,17 @@
                   <input type="hidden" value="{{ object.pk }}" name="content_id">
                   <input type="submit" class="fr-btn fr-btn--secondary" value="Publier"/>
                 </form>
+              </li>
+            {% endif %}
+            {% if can_be_modified and object.is_published %}
+              <li>
+                <button class="fr-btn fr-btn--secondary" data-fr-opened="false" aria-controls="modal-conclusion">
+                  {% if object.suspicion_conclusion %}
+                    Modifier la conclusion
+                  {% else %}
+                    Enregistrer la conclusion
+                  {% endif %}
+                </button>
               </li>
             {% endif %}
             <li>

--- a/tiac/tests/pages.py
+++ b/tiac/tests/pages.py
@@ -494,9 +494,6 @@ class InvestigationTiacFormPage(WithAnalyseAlimentaireMixin, WithEtablissementMi
         "datetime_last_symptoms",
         "analyses_sur_les_malades",
         "precisions",
-        "suspicion_conclusion",
-        "selected_hazard",
-        "conclusion_comment",
     ]
 
     def __init__(self, page: Page, base_url):
@@ -670,8 +667,18 @@ class InvestigationTiacFormPage(WithAnalyseAlimentaireMixin, WithEtablissementMi
     def nb_aliments(self):
         return self.page.locator(".aliment-card").locator("visible=true").count()
 
+    def submit_from_top(self):
+        self.page.get_by_test_id("top-action-btns").get_by_test_id("submit-publish").click()
+        self.page.wait_for_url(f"**{reverse('tiac:investigation-tiac-details', kwargs={'numero': '*'})}")
+
     def submit(self, btn_label="Enregistrer"):
         self.page.get_by_test_id("bottom-action-btns").get_by_test_id("submit-publish").click()
+        self.page.wait_for_url(f"**{reverse('tiac:investigation-tiac-details', kwargs={'numero': '*'})}")
+
+    def submit_from_top_as_draft(self):
+        self.page.get_by_test_id("top-action-btns").get_by_role(
+            "button", name="Enregistrer le brouillon", exact=True
+        ).click()
         self.page.wait_for_url(f"**{reverse('tiac:investigation-tiac-details', kwargs={'numero': '*'})}")
 
     def submit_as_draft(self):
@@ -686,17 +693,6 @@ class InvestigationTiacFormPage(WithAnalyseAlimentaireMixin, WithEtablissementMi
     def remove_free_link(self, index):
         self.page.locator("#liens-libre").get_by_role("button", name="Remove item").nth(index).click()
 
-    def fill_conlusion(self, input_data):
-        self.suspicion_conclusion.select_option(input_data.suspicion_conclusion)
-        if input_data.suspicion_conclusion == SuspicionConclusion.CONFIRMED:
-            for item in input_data.selected_hazard:
-                self._set_treeselect_option("selected_hazard-treeselect", CategorieDanger(item).label)
-        elif input_data.suspicion_conclusion == SuspicionConclusion.SUSPECTED:
-            for item in input_data.selected_hazard:
-                self._set_treeselect_option("selected_hazard-treeselect", DangersSyndromiques(item).short_name)
-
-        self.conclusion_comment.fill(input_data.conclusion_comment)
-
 
 class InvestigationTiacEditPage(InvestigationTiacFormPage):
     def __init__(self, page: Page, base_url, investigation: InvestigationTiac):
@@ -709,7 +705,7 @@ class InvestigationTiacEditPage(InvestigationTiacFormPage):
         )
 
 
-class InvestigationTiacDetailsPage(WithEtablissementMixin, WithActionsPage, WithSyntheseBlockMixin):
+class InvestigationTiacDetailsPage(WithEtablissementMixin, WithActionsPage, WithSyntheseBlockMixin, WithTreeSelect):
     def __init__(self, page: Page, base_url):
         self.page = page
         self.base_url = base_url
@@ -777,3 +773,32 @@ class InvestigationTiacDetailsPage(WithEtablissementMixin, WithActionsPage, With
     @property
     def current_modal(self):
         return self.page.locator(".fr-modal__body").locator("visible=true")
+
+    @property
+    def add_conclusion_button(self):
+        return self.page.get_by_role("button", name="Enregistrer la conclusion")
+
+    @property
+    def edit_conclusion_button(self):
+        return self.page.get_by_role("button", name="Modifier la conclusion")
+
+    def fill_conclusion(self, input_data):
+        self.add_conclusion_button.click()
+        self.page.locator("#id_suspicion_conclusion").select_option(input_data["suspicion_conclusion"])
+        if input_data["suspicion_conclusion"] == SuspicionConclusion.CONFIRMED:
+            for item in input_data["selected_hazard"]:
+                final_label = CategorieDanger(item).label.split(">")[-1].strip()
+                self._set_treeselect_option_by_search_term("selected_hazard-treeselect", final_label, final_label)
+        elif input_data["suspicion_conclusion"] == SuspicionConclusion.SUSPECTED:
+            for item in input_data["selected_hazard"]:
+                self._set_treeselect_option("selected_hazard-treeselect", DangersSyndromiques(item).short_name)
+
+        self.page.locator("#id_conclusion_comment").fill(input_data["conclusion_comment"])
+
+        if input_data["suspicion_conclusion"] not in (SuspicionConclusion.DISCARDED, SuspicionConclusion.UNKNOWN):
+            if input_data.get("conclusion_repas"):
+                self.page.locator("#id_conclusion_repas").select_option(str(input_data["conclusion_repas"]))
+            if input_data.get("conclusion_aliment"):
+                self.page.locator("#id_conclusion_aliment").select_option(str(input_data["conclusion_aliment"]))
+
+        self.page.locator(".fr-modal__body").locator("visible=true").get_by_role("button", name="Enregistrer").click()

--- a/tiac/tests/test_investigation_details_actions.py
+++ b/tiac/tests/test_investigation_details_actions.py
@@ -1,14 +1,20 @@
-from playwright.sync_api import expect
+import random
 
+from playwright.sync_api import Page, expect
+import pytest
+
+from core.factories import ContactAgentFactory
 from core.tests.generic_tests.actions import (
     generic_test_ac_can_update_fiche_even_when_state_is_cloture,
     generic_test_can_cloturer_evenement,
     generic_test_can_update_fiche_even_when_free_links_exists_to_a_deleted_object,
     generic_test_soft_delete_object_also_removes_existing_lien_libre,
 )
+from ssa.constants import CategorieDanger
 from tiac.factories import InvestigationTiacFactory
 from tiac.models import InvestigationTiac
 
+from ..constants import DANGERS_COURANTS, DangersSyndromiques, SuspicionConclusion
 from .pages import InvestigationTiacDetailsPage
 
 
@@ -78,3 +84,147 @@ def test_can_download_document_investigation_cas_humain_when_no_publication_date
     details_page.navigate(evenement)
     download = details_page.download().value
     assert download.suggested_filename == f"investigation_tiac_{evenement.numero}.docx"
+
+
+test_data = [
+    pytest.param(
+        SuspicionConclusion.CONFIRMED.value,
+        random.sample(CategorieDanger.values, k=1),
+        id=f"{SuspicionConclusion.CONFIRMED}-single",
+    ),
+    pytest.param(
+        SuspicionConclusion.CONFIRMED.value,
+        random.sample(CategorieDanger.values, k=2),
+        id=f"{SuspicionConclusion.CONFIRMED}-multiple",
+    ),
+    pytest.param(
+        SuspicionConclusion.CONFIRMED.value,
+        random.sample(DANGERS_COURANTS, k=1),
+        id=f"{SuspicionConclusion.CONFIRMED}-common-choices",
+    ),
+    pytest.param(
+        SuspicionConclusion.SUSPECTED.value,
+        random.sample(DangersSyndromiques.values, k=1),
+        id=f"{SuspicionConclusion.SUSPECTED}-single",
+    ),
+    pytest.param(
+        SuspicionConclusion.SUSPECTED.value,
+        random.sample(DangersSyndromiques.values, k=2),
+        id=f"{SuspicionConclusion.SUSPECTED}-multiple",
+    ),
+    *[(item.value, []) for item in SuspicionConclusion.no_clue],
+]
+
+
+@pytest.mark.parametrize("suspicion_conclusion,selected_hazard", test_data)
+def test_can_add_conclusion_to_investigation_tiac(
+    live_server,
+    mocked_authentification_user,
+    page: Page,
+    assert_models_are_equal,
+    suspicion_conclusion,
+    selected_hazard,
+):
+    evenement = InvestigationTiacFactory(
+        etat=InvestigationTiac.Etat.EN_COURS,
+        suspicion_conclusion="",
+        selected_hazard=[],
+        conclusion_comment="",
+        conclusion_repas=None,
+        conclusion_aliment=None,
+        with_repas=1,
+        with_aliment_suspect=1,
+    )
+    detail_page = InvestigationTiacDetailsPage(page, live_server.url)
+    detail_page.navigate(evenement)
+    contact = mocked_authentification_user.agent.contact_set.get()
+    assert contact not in evenement.contacts.all()
+
+    input_data = {
+        "conclusion_comment": "Mon commentaire",
+        "suspicion_conclusion": suspicion_conclusion,
+        "selected_hazard": selected_hazard,
+        "conclusion_repas": evenement.repas.get().pk,
+        "conclusion_aliment": evenement.aliments.get().pk,
+    }
+
+    with page.expect_event("framenavigated"):
+        detail_page.fill_conclusion(input_data)
+
+    investigation = InvestigationTiac.objects.get()
+    assert investigation.conclusion_comment == "Mon commentaire"
+    assert investigation.suspicion_conclusion == suspicion_conclusion
+    assert sorted(investigation.selected_hazard) == sorted(selected_hazard)
+    if suspicion_conclusion not in (SuspicionConclusion.DISCARDED, SuspicionConclusion.UNKNOWN):
+        assert investigation.conclusion_repas == evenement.repas.get()
+        assert investigation.conclusion_aliment == evenement.aliments.get()
+    assert contact in evenement.contacts.all()
+
+
+def test_can_add_conclusion_button_is_hidden_for_other_states(live_server, page: Page):
+    evenement = InvestigationTiacFactory(
+        etat=InvestigationTiac.Etat.BROUILLON,
+        suspicion_conclusion="",
+        selected_hazard=[],
+        conclusion_comment="",
+        conclusion_repas=None,
+        conclusion_aliment=None,
+        with_repas=1,
+        with_aliment_suspect=1,
+    )
+    detail_page = InvestigationTiacDetailsPage(page, live_server.url)
+    detail_page.navigate(evenement)
+    expect(detail_page.add_conclusion_button).not_to_be_visible()
+
+    evenement = InvestigationTiacFactory(
+        etat=InvestigationTiac.Etat.CLOTURE,
+        suspicion_conclusion="",
+        selected_hazard=[],
+        conclusion_comment="",
+        conclusion_repas=None,
+        conclusion_aliment=None,
+        with_repas=1,
+        with_aliment_suspect=1,
+    )
+    detail_page = InvestigationTiacDetailsPage(page, live_server.url)
+    detail_page.navigate(evenement)
+    expect(detail_page.add_conclusion_button).not_to_be_visible()
+
+
+def test_can_edit_existing_conclusion(live_server, page: Page):
+    evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
+    detail_page = InvestigationTiacDetailsPage(page, live_server.url)
+    detail_page.navigate(evenement)
+    detail_page.edit_conclusion_button.click()
+
+    detail_page.page.locator("#id_conclusion_comment").fill("New comment")
+    detail_page.page.locator(".fr-modal__body").locator("visible=true").get_by_role(
+        "button", name="Enregistrer"
+    ).click()
+    investigation = InvestigationTiac.objects.get()
+    assert investigation.conclusion_comment == "New comment"
+
+
+def test_edit_investigation_tiac_with_conclusion_notification(live_server, page: Page, mailoutbox):
+    investigation = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS, suspicion_conclusion=None)
+    contact_1, contact_2, contact_3 = ContactAgentFactory.create_batch(3)
+    investigation.contacts.add(contact_1, contact_2, contact_3)
+    creation_page = InvestigationTiacDetailsPage(page, live_server.url)
+    creation_page.navigate(investigation)
+
+    input_data = {
+        "conclusion_comment": "Commentaire",
+        "suspicion_conclusion": SuspicionConclusion.CONFIRMED,
+        "selected_hazard": [CategorieDanger.ALLERGENE_LAIT],
+    }
+    with page.expect_event("framenavigated"):
+        creation_page.fill_conclusion(input_data)
+
+    investigation = InvestigationTiac.objects.get()
+    assert investigation.suspicion_conclusion == SuspicionConclusion.CONFIRMED
+
+    assert len(mailoutbox) == 1
+    mail = mailoutbox[0]
+    assert set(mail.to) == {contact_1.email, contact_2.email, contact_3.email}
+    assert "Conclusion suspicion TIAC" in mail.subject
+    assert "TIAC à agent confirmé" in mail.body

--- a/tiac/tests/test_investigation_tiac_creation.py
+++ b/tiac/tests/test_investigation_tiac_creation.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import random
 from unittest import mock
 
 from django.http import JsonResponse
@@ -24,11 +23,9 @@ from tiac.factories import (
 )
 
 from ..constants import (
-    DANGERS_COURANTS,
     DangersSyndromiques,
     ModaliteDeclarationEvenement,
     MotifAliment,
-    SuspicionConclusion,
     TypeCollectivite,
     TypeRepas,
 )
@@ -126,8 +123,6 @@ def test_can_create_investigation_tiac_with_all_fields(
     for danger in input_data.agents_confirmes_ars:
         creation_page.add_agent_pathogene_confirme(CategorieDanger(danger).label)
 
-    creation_page.fill_conlusion(input_data)
-
     creation_page.submit_as_draft()
 
     investigation = InvestigationTiac.objects.last()
@@ -145,70 +140,9 @@ def test_can_create_investigation_tiac_with_all_fields(
             "date_publication",
             "analyses_sur_les_malades",
             "last_updated",
-        ],
-        ignore_array_order=True,
-    )
-
-
-test_data = [
-    pytest.param(
-        SuspicionConclusion.CONFIRMED.value,
-        random.sample(CategorieDanger.values, k=1),
-        id=f"{SuspicionConclusion.CONFIRMED}-single",
-    ),
-    pytest.param(
-        SuspicionConclusion.CONFIRMED.value,
-        random.sample(CategorieDanger.values, k=2),
-        id=f"{SuspicionConclusion.CONFIRMED}-multiple",
-    ),
-    pytest.param(
-        SuspicionConclusion.CONFIRMED.value,
-        random.sample(DANGERS_COURANTS, k=1),
-        id=f"{SuspicionConclusion.CONFIRMED}-common-choices",
-    ),
-    pytest.param(
-        SuspicionConclusion.SUSPECTED.value,
-        random.sample(DangersSyndromiques.values, k=1),
-        id=f"{SuspicionConclusion.SUSPECTED}-single",
-    ),
-    pytest.param(
-        SuspicionConclusion.SUSPECTED.value,
-        random.sample(DangersSyndromiques.values, k=2),
-        id=f"{SuspicionConclusion.SUSPECTED}-multiple",
-    ),
-    *[(item.value, []) for item in SuspicionConclusion.no_clue],
-]
-
-
-@pytest.mark.parametrize("suspicion_conclusion,selected_hazard", test_data)
-def test_can_create_investigation_tiac_conlusion(
-    live_server,
-    mocked_authentification_user,
-    page: Page,
-    assert_models_are_equal,
-    suspicion_conclusion,
-    selected_hazard,
-):
-    input_data: InvestigationTiac = InvestigationTiacFactory.build(
-        danger_syndromiques_suspectes=[], suspicion_conclusion=suspicion_conclusion, selected_hazard=selected_hazard
-    )
-
-    creation_page = InvestigationTiacFormPage(page, live_server.url)
-    creation_page.navigate()
-    creation_page.fill_required_fields(input_data)
-
-    creation_page.fill_conlusion(input_data)
-
-    creation_page.submit_as_draft()
-
-    investigation = InvestigationTiac.objects.last()
-    assert_models_are_equal(
-        input_data,
-        investigation,
-        fields=[
+            "conclusion_comment",
             "suspicion_conclusion",
             "selected_hazard",
-            "conclusion_comment",
             "conclusion_repas",
             "conclusion_aliment",
         ],
@@ -240,7 +174,7 @@ def test_can_create_investigation_tiac_ars(live_server, mocked_authentification_
     creation_page.set_analyses("Oui")
     creation_page.precisions.fill("Mes précisions")
     creation_page.add_agent_pathogene_confirme_via_shortcut("Shigella")
-    creation_page.submit_as_draft()
+    creation_page.submit_from_top_as_draft()
 
     investigation = InvestigationTiac.objects.last()
     assert investigation.agents_confirmes_ars == ["Shigella"]

--- a/tiac/tests/test_investigation_tiac_edition.py
+++ b/tiac/tests/test_investigation_tiac_edition.py
@@ -3,7 +3,6 @@ from playwright.sync_api import Page, expect
 import pytest
 
 from core.constants import MUS_STRUCTURE
-from core.factories import ContactAgentFactory
 from core.models import Contact, LienLibre
 from ssa.factories import EvenementProduitFactory
 from ssa.models import EvenementProduit
@@ -111,7 +110,7 @@ def test_can_edit_ars_block(live_server, page: Page, assert_models_are_equal, ch
     edit_page.set_analyses(new_analyses_sur_les_malades.value)
     edit_page.precisions.fill(new_precision)
     edit_page.add_agent_pathogene_confirme_via_shortcut("Shigella")
-    edit_page.submit()
+    edit_page.submit_from_top()
 
     investigation.refresh_from_db()
     assert_models_are_equal(
@@ -268,20 +267,13 @@ def test_cancel_edit_on_etablissement_reset_all_value(
     assert initial_etablissement == investigation.etablissements.get()
 
 
-def test_can_edit_etiologie_conclusion_and_freelinks(
+def test_can_edit_freelinks(
     live_server, page: Page, ensure_departements, assert_models_are_equal, choose_different_values, choice_js_fill
 ):
     investigation: InvestigationTiac = InvestigationTiacFactory(with_liens_libres=2)
     other_event_1 = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
     other_event_2 = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
     other_event_3 = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
-
-    new_investigation: InvestigationTiac = InvestigationTiacFactory(
-        agents_confirmes_ars=choose_different_values(SuspicionConclusion.values, investigation.agents_confirmes_ars),
-        suspicion_conclusion=choose_different_values(
-            SuspicionConclusion.values, [investigation.suspicion_conclusion], singleton=True
-        ),
-    )
 
     edit_page = InvestigationTiacEditPage(page, live_server.url, investigation)
     edit_page.navigate()
@@ -290,8 +282,6 @@ def test_can_edit_etiologie_conclusion_and_freelinks(
     edit_page.add_free_link(other_event_1.numero, choice_js_fill)
     edit_page.add_free_link(other_event_2.numero, choice_js_fill, link_label="Enregistrement simple : ")
     edit_page.add_free_link(other_event_3.numero, choice_js_fill, link_label="Événement produit : ")
-    edit_page.fill_conlusion(new_investigation)
-
     edit_page.submit()
 
     investigation.refresh_from_db()
@@ -300,18 +290,6 @@ def test_can_edit_etiologie_conclusion_and_freelinks(
         other_event_2,
         other_event_3,
     }
-    assert_models_are_equal(
-        investigation,
-        new_investigation,
-        fields=[
-            "suspicion_conclusion",
-            "selected_hazard",
-            "conclusion_comment",
-            "conclusion_repas",
-            "conclusion_aliment",
-        ],
-        ignore_array_order=True,
-    )
 
 
 def test_edit_investigation_tiac_with_investigation_coordonnee_notification(live_server, page: Page, mailoutbox):
@@ -330,28 +308,6 @@ def test_edit_investigation_tiac_with_investigation_coordonnee_notification(live
     assert set(mail.to) == {"text@example.com", contact_structure_mus.email}
     assert "Investigation coordonnée" in mail.subject
     assert contact_structure_mus in investigation.contacts.all()
-
-
-def test_edit_investigation_tiac_with_conclusion_notification(live_server, page: Page, mailoutbox):
-    investigation = InvestigationTiacFactory(suspicion_conclusion=None)
-    contact_1, contact_2, contact_3 = ContactAgentFactory.create_batch(3)
-    investigation.contacts.add(contact_1, contact_2, contact_3)
-    creation_page = InvestigationTiacEditPage(page, live_server.url, investigation=investigation)
-    creation_page.navigate()
-    creation_page.suspicion_conclusion.select_option(SuspicionConclusion.CONFIRMED)
-    creation_page._set_treeselect_option(
-        "selected_hazard-treeselect", "Allergène - composition ou étiquetage > Allergène - Arachide"
-    )
-    creation_page.submit_as_draft()
-
-    investigation = InvestigationTiac.objects.get()
-    assert investigation.suspicion_conclusion == SuspicionConclusion.CONFIRMED
-
-    assert len(mailoutbox) == 1
-    mail = mailoutbox[0]
-    assert set(mail.to) == {contact_1.email, contact_2.email, contact_3.email}
-    assert "Conclusion suspicion TIAC" in mail.subject
-    assert "TIAC à agent confirmé" in mail.body
 
 
 def test_can_update_ars_block_only_when_analysis_is_true(live_server, mocked_authentification_user, page: Page):

--- a/tiac/urls.py
+++ b/tiac/urls.py
@@ -26,6 +26,11 @@ urlpatterns = [
         name="investigation-tiac-edition",
     ),
     path(
+        "investigation-tiac/edition/<int:pk>/conclusion/",
+        views.ConclusionUpdateView.as_view(),
+        name="investigation-tiac-edition-conclusion",
+    ),
+    path(
         "evenement-simple/<str:numero>/",
         views.EvenementSimpleDetailView.as_view(),
         name="evenement-simple-details",

--- a/tiac/views.py
+++ b/tiac/views.py
@@ -10,7 +10,9 @@ from django.contrib.contenttypes.models import ContentType
 from django.forms import Media
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.urls import reverse
+from django.utils.decorators import method_decorator
 from django.views import View
+from django.views.decorators.http import require_POST
 from django.views.generic import CreateView, DetailView, ListView, UpdateView
 from django.views.generic.edit import ModelFormMixin, ProcessFormView
 from docxtpl import DocxTemplate
@@ -46,7 +48,7 @@ from tiac.tasks import export_tiac_task
 from .constants import DangersSyndromiques, EvenementFollowUp
 from .display import DisplayItem
 from .filters import TiacFilter
-from .forms import EvenementSimpleTransferForm
+from .forms import ConclusionForm, EvenementSimpleTransferForm
 from .formsets import (
     AlimentFormSet,
     AnalysesAlimentairesFormSet,
@@ -472,8 +474,6 @@ class InvestigationTiacBaseView(
             if "follow_up" in dirty_fields and self.object.follow_up == InvestigationFollowUp.INVESTIGATION_COORDONNEE:
                 notify_investigation_coordonnee(self.object, self.request.user)
                 self.object.contacts.add(Contact.objects.get_mus())
-            if "suspicion_conclusion" in dirty_fields:
-                notify_conclusion(self.object, self.request.user)
 
     def form_valid(self, form):
         dirty_fields = None
@@ -580,10 +580,14 @@ class InvestigationTiacDetailView(
         ]
         context["etablissements"] = list(self.get_object().etablissements.all())
         context["dates_repas"] = [r.datetime_repas for r in self.get_object().repas.all() if r.datetime_repas]
+        context["conclusion_form"] = ConclusionForm(instance=self.get_object())
         return context
 
     def get_publish_success_message(self):
         return "L’évènement a été publié avec succès."
+
+    def get_media(self, **context_data) -> Media:
+        return super().get_media(**context_data) + context_data["conclusion_form"].media
 
 
 class EvenementSimpleDocumentExportView(WithDocumentExportContextMixin, UserPassesTestMixin, View):
@@ -668,3 +672,27 @@ class TiacExportView(WithFilteredListMixin, WithExportHeterogeneousQuerysetMixin
 
     def get_success_url(self):
         return reverse("tiac:evenement-liste")
+
+
+@method_decorator(require_POST, name="dispatch")
+class ConclusionUpdateView(MediaDefiningMixin, WithFormErrorsAsMessagesMixin, WithAddUserContactsMixin, UpdateView):
+    form_class = ConclusionForm
+
+    def get_queryset(self):
+        return InvestigationTiac.objects.all().get_user_can_view(user=self.request.user)
+
+    def test_func(self):
+        return self.get_object().can_be_modified(self.request.user)
+
+    def form_valid(self, form):
+        dirty_fields = self.object.get_dirty_fields()
+        self.object = form.save()
+        self.add_user_contacts(self.object)
+        if "suspicion_conclusion" in dirty_fields:
+            notify_conclusion(self.object, self.request.user)
+        messages.success(self.request, "L’évènement a été mis à jour avec succès.")
+        return HttpResponseRedirect(self.object.get_absolute_url())
+
+    def form_invalid(self, form):
+        super().form_invalid(form)
+        return HttpResponseRedirect(form.instance.get_absolute_url())


### PR DESCRIPTION
We want the conclusion to be a dedicated action instead of being the part of the classic form itself:

- Split form into two parts and glue everything together
- It had to rewrite a part of _set_treeselect_option in order to take into account the fact that the field can now be in a modal. We have less vertical space and we need to scroll to a specific position in the list in order to see the option.