### PR TITLE
Fix issue with values when repas modal is closed

### DIFF
--- a/tiac/static/tiac/repas.mjs
+++ b/tiac/static/tiac/repas.mjs
@@ -20,6 +20,11 @@ class RepasFormController extends BaseFormInModal {
     }
 
     onCloseForm() {
+        if (!this.keepChangesValue) {
+            this.restoreForm()
+        }
+        this.keepChangesValue = false
+
         // this.shouldImmediatelyShowValue indicates that the card has not be rendered yet.
         // In this case, the form is not considered valid and it should be deleted on close
         if (this.shouldImmediatelyShowValue) this.forceDelete()

--- a/tiac/templates/tiac/forms/repas_suspect_base_set.html
+++ b/tiac/templates/tiac/forms/repas_suspect_base_set.html
@@ -6,7 +6,6 @@
         data-controller="repas-form"
         data-repas-form-form-prefix-value="{{ form.prefix }}"
         data-repas-form-should-immediately-show-value="{{ should_immediately_show|default:False }}"
-        data-action="dsfr.conceal->repas-form#onCloseForm"
     >
         <button class="fr-btn fr-hidden" type="button" data-fr-opened="false" aria-controls="fr-modal-{{ form.prefix }}"></button>
         <dialog

--- a/tiac/tests/test_investigation_tiac_edition.py
+++ b/tiac/tests/test_investigation_tiac_edition.py
@@ -414,3 +414,33 @@ def test_update_investigation_tiac_updates_last_updated_field(live_server, page)
     update_page.page.wait_for_url(f"**{evenement.numero_evenement}**")
     evenement.refresh_from_db()
     assert evenement.last_updated > initial_last_update
+
+
+def test_cancel_edit_on_repas_reset_values(live_server, page: Page, ensure_departements, assert_models_are_equal):
+    departement, *_ = ensure_departements("Paris")
+
+    investigation: InvestigationTiac = InvestigationTiacFactory(
+        with_repas=1,
+        with_repas__departement=departement,
+    )
+    initial_repas = investigation.repas.get()
+
+    edit_page = InvestigationTiacEditPage(page, live_server.url, investigation)
+    edit_page.navigate()
+
+    card = edit_page.get_repas_card(0)
+    card.locator(".modify-button").click()
+    edit_page.current_modal.locator("visible=true").locator('[id$="denomination"]').fill("New value")
+    edit_page.current_modal.get_by_role("button", name="Annuler").click()
+    edit_page.get_repas_card(0).locator(".modify-button").click()
+
+    modal = edit_page.current_modal
+    expect(modal.locator('[id$="denomination"]')).to_have_value(initial_repas.denomination)
+
+    edit_page.current_modal.get_by_role("button", name="Annuler").click()
+    edit_page.submit()
+
+    investigation.refresh_from_db()
+
+    assert investigation.repas.count() == 1
+    assert initial_repas == investigation.repas.get()


### PR DESCRIPTION
Make sure that when the modal is closed (except when using the save button) the values are not kept.
I had to remove a ligne from the HTML as this line is duplicated in the same file, leading to a function being called twice and messing with the process.