### PR TITLE
Correction d'une erreur bénine dans AlertController

### DIFF
--- a/core/static/core/stimulus_app.mjs
+++ b/core/static/core/stimulus_app.mjs
@@ -97,11 +97,8 @@ class AlertController extends Controller {
 
     /**@param {HTMLElement} target */
     closeTargetConnected(target) {
-        const action = `click->${this.identifier}#onClose`
-        const previous = target.dataset.action
-        if (previous === undefined || !previous.includes(action)) {
-            target.dataset.action = `${previous} ${action}`.trim()
-        }
+        const actions = [...(target.dataset.action ?? "").split(/s+/g), `click->${this.identifier}#onClose`]
+        target.dataset.action = actions.join(" ").trim()
     }
 
     /** @param {Event} evt */


### PR DESCRIPTION
AlertController définit automatiquement un événement auclic sur `closeTarget`, en tenant compte une éventuelle valeur existante pour `data-action`. Cependant, si `data-action` n'est pas défini, le code concaténait par erreur `undefined` à la nouvelle valeur.