### PR TITLE
Correction de l'erreur 500 à la sauvegarde d'un évènement produit SSA

### DIFF
--- a/ssa/forms.py
+++ b/ssa/forms.py
@@ -232,7 +232,9 @@ class EvenementProduitForm(DSFRForm, WithEvenementCommonMixin, WithLatestVersion
 
 
 class EvenementProduitTreeselectForm(EvenementProduitForm):
-    categorie_produit = ChoiceField(required=False, choices=CategorieProduit.treeselect_groups, widget=TreeselectRadio)
+    categorie_produit = ChoiceField(
+        required=False, choices=CategorieProduit, widget=TreeselectRadio(choices=CategorieProduit.treeselect_groups)
+    )
     categorie_danger = ChoiceField(
         required=False, choices=CategorieDanger, widget=TreeselectRadio(choices=CategorieDanger.treeselect_choices)
     )


### PR DESCRIPTION
Suite à la revue de #2069.

Régression introduite [par le remplacement des choix du champ `EvenementProduitTreeselectForm.categorie_produit` par les groupes Treeselect](https://github.com/betagouv/seves/pull/2064/changes#diff-d30aa2376d505f18cb9896a1ffc9fa5578bc90e2709c79e26ff28795059534aaR235). 

Le problème se produisait lors de la validation du champ, car `ChoiceField` attend un itérable de paires `(valeur, libellé)` alors que les groupes Treeselect sont composés d’objets `TreeselectItem` qui ne peuvent pas être unpack.

