### PR TITLE
Send DI notifications to agents

### DIFF
--- a/core/notifications.py
+++ b/core/notifications.py
@@ -135,7 +135,7 @@ def notify_message(message_obj: Message):
             recipients = message_obj.recipients.all()
         case Message.DEMANDE_INTERVENTION:
             recipients = message_obj.recipients.structures_only()
-            copy = message_obj.recipients_copy.structures_only()
+            copy = message_obj.recipients_copy.all()
         case Message.NOTIFICATION_AC:
             content = f"Bonjour,\nLa fiche {message_obj.content_object.numero} vient d'être déclarée à l'administration centrale."
             recipients = [Contact.objects.get_mus(), Contact.objects.get_bsv()]

--- a/core/tests/generic_tests/messages.py
+++ b/core/tests/generic_tests/messages.py
@@ -540,7 +540,7 @@ def generic_test_can_add_and_see_note_in_new_tab_with_specific_date(live_server,
 
 
 def generic_test_can_add_and_see_demande_intervention_in_new_tab_without_document(
-    live_server, page: Page, choice_js_fill, object, mocked_authentification_user
+    live_server, page: Page, choice_js_fill, object, mocked_authentification_user, mailoutbox
 ):
     structure, _ = Structure.objects.get_or_create(niveau1=AC_STRUCTURE, niveau2=MUS_STRUCTURE, libelle=MUS_STRUCTURE)
     ContactStructureFactory(structure=structure)
@@ -589,6 +589,12 @@ def generic_test_can_add_and_see_demande_intervention_in_new_tab_without_documen
             f"CC : {contact_cc.display_with_agent_unit}, {contact_cc_agent.display_with_agent_unit}", exact=True
         )
     ).to_be_visible()
+
+    assert len(mailoutbox) == 1
+    mail = mailoutbox[0]
+    assert "Title of the message" in mail.body
+    assert set(mail.to) == {contact.email}
+    assert set(mail.cc) == {contact_cc.email, contact_cc_agent.email}
 
 
 def generic_test_can_add_and_see_point_de_situation_in_new_tab_without_document(live_server, page: Page, object):

--- a/ssa/tests/test_evenement_produit_message.py
+++ b/ssa/tests/test_evenement_produit_message.py
@@ -88,11 +88,11 @@ def test_can_add_and_see_point_de_situation_in_new_tab_without_document(live_ser
 
 
 def test_can_add_and_see_demande_intervention_in_new_tab_without_document(
-    live_server, page: Page, choice_js_fill, mocked_authentification_user
+    live_server, page: Page, choice_js_fill, mocked_authentification_user, mailoutbox
 ):
     evenement_produit = EvenementProduitFactory(etat=EvenementProduit.Etat.EN_COURS)
     generic_test_can_add_and_see_demande_intervention_in_new_tab_without_document(
-        live_server, page, choice_js_fill, evenement_produit, mocked_authentification_user
+        live_server, page, choice_js_fill, evenement_produit, mocked_authentification_user, mailoutbox
     )
 
 

--- a/ssa/tests/test_investigation_cas_humain_message.py
+++ b/ssa/tests/test_investigation_cas_humain_message.py
@@ -85,11 +85,11 @@ def test_can_add_and_see_point_de_situation_in_new_tab_without_document(live_ser
 
 
 def test_can_add_and_see_demande_intervention_in_new_tab_without_document(
-    live_server, page: Page, choice_js_fill, mocked_authentification_user
+    live_server, page: Page, choice_js_fill, mocked_authentification_user, mailoutbox
 ):
     evenement = InvestigationCasHumainFactory(etat=EvenementInvestigationCasHumain.Etat.EN_COURS)
     generic_test_can_add_and_see_demande_intervention_in_new_tab_without_document(
-        live_server, page, choice_js_fill, evenement, mocked_authentification_user
+        live_server, page, choice_js_fill, evenement, mocked_authentification_user, mailoutbox
     )
 
 

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -103,11 +103,11 @@ def test_can_add_and_see_point_de_situation_in_new_tab_without_document(live_ser
 
 
 def test_can_add_and_see_demande_intervention_in_new_tab_without_document(
-    live_server, page: Page, choice_js_fill, mocked_authentification_user
+    live_server, page: Page, choice_js_fill, mocked_authentification_user, mailoutbox
 ):
     evenement = EvenementFactory()
     generic_test_can_add_and_see_demande_intervention_in_new_tab_without_document(
-        live_server, page, choice_js_fill, evenement, mocked_authentification_user
+        live_server, page, choice_js_fill, evenement, mocked_authentification_user, mailoutbox
     )
 
 

--- a/sv/tests/test_notifications.py
+++ b/sv/tests/test_notifications.py
@@ -110,7 +110,7 @@ def test_notification_demande_intervention(mailoutbox):
     )
     assert message.content in mail.body
     assert set(mail.to) == {structure_1.email}
-    assert set(mail.cc) == {structure_2.email}
+    assert set(mail.cc) == {structure_2.email, agent_2.email}
 
 
 @pytest.mark.django_db

--- a/tiac/tests/test_evenement_simple_message.py
+++ b/tiac/tests/test_evenement_simple_message.py
@@ -87,11 +87,11 @@ def test_can_add_and_see_point_de_situation_in_new_tab_without_document(live_ser
 
 
 def test_can_add_and_see_demande_intervention_in_new_tab_without_document(
-    live_server, page: Page, choice_js_fill, mocked_authentification_user
+    live_server, page: Page, choice_js_fill, mocked_authentification_user, mailoutbox
 ):
     evenement = EvenementSimpleFactory(etat=EvenementSimple.Etat.EN_COURS)
     generic_test_can_add_and_see_demande_intervention_in_new_tab_without_document(
-        live_server, page, choice_js_fill, evenement, mocked_authentification_user
+        live_server, page, choice_js_fill, evenement, mocked_authentification_user, mailoutbox
     )
 
 

--- a/tiac/tests/test_investigation_message.py
+++ b/tiac/tests/test_investigation_message.py
@@ -94,11 +94,11 @@ def test_can_add_and_see_point_de_situation_in_new_tab_without_document(
 
 
 def test_can_add_and_see_demande_intervention_in_new_tab_without_document(
-    live_server, page: Page, choice_js_fill, mocked_authentification_user
+    live_server, page: Page, choice_js_fill, mocked_authentification_user, mailoutbox
 ):
     evenement = InvestigationTiacFactory(etat=InvestigationTiac.Etat.EN_COURS)
     generic_test_can_add_and_see_demande_intervention_in_new_tab_without_document(
-        live_server, page, choice_js_fill, evenement, mocked_authentification_user
+        live_server, page, choice_js_fill, evenement, mocked_authentification_user, mailoutbox
     )
 
 


### PR DESCRIPTION
It was send only to structures due to the previous behavior where only structures could be picked in the UI. The UI was changed but not the part responsible for the actual sending.

Fix and test it.