### PR TITLE
Improve test for card etablissement in TIAC and SSA

### DIFF
--- a/ssa/tests/conftest.py
+++ b/ssa/tests/conftest.py
@@ -10,7 +10,7 @@ def assert_etablissement_card_is_correct():
         expect(locator.get_by_text(expected_values.pays.name, exact=True)).to_be_visible()
         expect(locator.get_by_text(f"Type exploitant : {expected_values.type_exploitant}", exact=True)).to_be_visible()
         expect(locator.get_by_text(f"{expected_values.commune}")).to_be_visible()
-        expect(locator.get_by_text(f"{expected_values.departement.nom}")).to_be_visible()
+        expect(locator.locator(".fr-card__desc").get_by_text(f"{expected_values.departement.nom}")).to_be_visible()
         expect(locator.get_by_text(expected_values.get_position_dossier_display(), exact=True)).to_be_visible()
 
     return _assert_etablissement_card_is_correct

--- a/tiac/tests/conftest.py
+++ b/tiac/tests/conftest.py
@@ -9,7 +9,7 @@ def assert_etablissement_card_is_correct():
         expect(locator.get_by_text(expected_values.enseigne_usuelle, exact=True)).to_be_visible()
         expect(locator.get_by_text(f"Siret : {expected_values.siret}")).to_be_visible()
         expect(locator.get_by_text(expected_values.type_etablissement, exact=True)).to_be_visible()
-        expect(locator.get_by_text(f"{expected_values.departement.nom}")).to_be_visible()
+        expect(locator.locator(".fr-card__desc").get_by_text(f"{expected_values.departement.nom}")).to_be_visible()
         expect(locator.get_by_text(expected_values.commune)).to_be_visible()
 
     return _assert_etablissement_card_is_correct


### PR DESCRIPTION
Make sure we take the correct tag for the departement. In Django Countries, Martinique is described as a country (this should be fixed but needs approval and more work) leading to places where Martinique is both the country and the departement:

    1) <p class="pays fr-tag fr-mb-4v">Martinique</p> aka get_by_role("paragraph").filter(has_text=re.compile(r"^Martinique$"))
    2) <p class="fr-card__detail fr-icon-map-pin-2-line fr-my-2v">Davidborough | 972 - Martinique</p> aka get_by_text("Davidborough | 972 -")