### PR TITLE
Fix conclusion edit, keep danger selected

### DIFF
--- a/tiac/static/tiac/tiac_conclusion.mjs
+++ b/tiac/static/tiac/tiac_conclusion.mjs
@@ -50,9 +50,6 @@ class ConclusionFormController extends Controller {
             },
         })
         patchItems(this.treeselect.srcElement)
-        if (this.suspicionConclusionValue !== "") {
-            this.suspicionConclusionValueChanged(this.suspicionConclusionChoicesValue)
-        }
     }
 
     selectedHazardTreeselectTargetDiconnected() {
@@ -156,7 +153,7 @@ class ConclusionFormController extends Controller {
 
         if (this.selectedHazardTreeselectInitializedValue) {
             this.treeselect.updateValue("")
-        } else {
+        } else if (value) {
             this.treeselect.updateValue(this.selectedHazardTreeselectInputTarget.value.split("||"))
             this.selectedHazardTreeselectInitializedValue = true
         }

--- a/tiac/tests/test_investigation_details_actions.py
+++ b/tiac/tests/test_investigation_details_actions.py
@@ -228,3 +228,31 @@ def test_edit_investigation_tiac_with_conclusion_notification(live_server, page:
     assert set(mail.to) == {contact_1.email, contact_2.email, contact_3.email}
     assert "Conclusion suspicion TIAC" in mail.subject
     assert "TIAC à agent confirmé" in mail.body
+
+
+def test_edit_investigation_show_previous_danger_value(live_server, page: Page):
+    evenement = InvestigationTiacFactory(
+        etat=InvestigationTiac.Etat.EN_COURS,
+        suspicion_conclusion=SuspicionConclusion.CONFIRMED,
+        selected_hazard=[CategorieDanger.ALLERGENE_LAIT],
+    )
+    detail_page = InvestigationTiacDetailsPage(page, live_server.url)
+    detail_page.navigate(evenement)
+    detail_page.edit_conclusion_button.click()
+    expect(detail_page.current_modal.get_by_text("Allergène - Lait")).to_be_visible()
+
+
+def test_edit_investigation_show_previous_danger_values(live_server, page: Page):
+    evenement = InvestigationTiacFactory(
+        etat=InvestigationTiac.Etat.EN_COURS,
+        suspicion_conclusion=SuspicionConclusion.CONFIRMED,
+        selected_hazard=[
+            CategorieDanger.ALLERGENE_LAIT,
+            CategorieDanger.ALLERGENE_SESAME,
+            CategorieDanger.ALLERGENE_SOJA,
+        ],
+    )
+    detail_page = InvestigationTiacDetailsPage(page, live_server.url)
+    detail_page.navigate(evenement)
+    detail_page.edit_conclusion_button.click()
+    expect(detail_page.current_modal.get_by_text("3 éléments sélectionnés")).to_be_visible()


### PR DESCRIPTION
Make sure we kept the previous values selected in the treeselect when we edit a conclusion.

The code was a bit weird:
- We went three times into the suspicionConclusionValueChanged (no need for the extra call that was made)
- The extra call that was made was made with incorect parameter (this.suspicionConclusionChoicesValue instead of suspicionConclusionValue I believe)
- The logic of "doing the updateValue from the field only once" because the go into this method a first time with an empty value (the field was set), then a second time with a correct value (the field value was unset).