### PR TITLE
Show categorie de danger for ICH on SSA

### DIFF
--- a/ssa/display.py
+++ b/ssa/display.py
@@ -28,11 +28,9 @@ class EvenementDisplay:
 
         if isinstance(evenement, EvenementProduit):
             categorie_produit = evenement.get_categorie_produit_display() or "-"
-            categorie_danger = evenement.get_categorie_danger_display() or "-"
             tooltip_str = f"tooltip-produit-{evenement.pk}"
         else:
             categorie_produit = "-"
-            categorie_danger = "-"
             tooltip_str = f"tooltip-investigation-{evenement.pk}"
 
         etat_data = evenement.get_etat_data_from_fin_de_suivi(evenement.has_fin_de_suivi)
@@ -46,7 +44,7 @@ class EvenementDisplay:
             readable_etat=etat_data["readable_etat"],
             absolute_url=evenement.get_absolute_url(),
             categorie_produit=categorie_produit,
-            categorie_danger=categorie_danger,
+            categorie_danger=evenement.get_categorie_danger_display() or "-",
             type_evenement=evenement.get_type_evenement_display(),
             last_update=evenement.last_updated,
             tooltip_str=tooltip_str,

--- a/ssa/tests/pages.py
+++ b/ssa/tests/pages.py
@@ -386,6 +386,12 @@ class EvenementProduitListPage(WithTreeSelect):
     def description_cell(self, line_index=1):
         return self._cell_content(line_index, 4)
 
+    def produit_cell(self, line_index=1):
+        return self._cell_content(line_index, 5)
+
+    def danger_cell(self, line_index=1):
+        return self._cell_content(line_index, 6)
+
     def type_evenement_cell(self, line_index=1):
         return self._cell_content(line_index, 7)
 

--- a/ssa/tests/test_evenements_list.py
+++ b/ssa/tests/test_evenements_list.py
@@ -57,13 +57,6 @@ def test_list_filtered_by_visibilite(live_server, mocked_authentification_user, 
 
 def test_row_content(live_server, mocked_authentification_user, page: Page):
     evenement = EvenementProduitFactory()
-    other_structure = StructureFactory()
-    LienLibre.objects.create(
-        related_object_1=evenement, related_object_2=EvenementProduitFactory(createur=other_structure)
-    )
-    LienLibre.objects.create(
-        related_object_1=evenement, related_object_2=EvenementProduitFactory(createur=other_structure)
-    )
     search_page = EvenementProduitListPage(page, live_server.url)
     search_page.navigate()
 
@@ -71,6 +64,24 @@ def test_row_content(live_server, mocked_authentification_user, page: Page):
     assert search_page.date_publication_cell().text_content() == evenement.date_publication.strftime("%d/%m/%Y")
     assert search_page.date_maj_cell().text_content() == datetime.date.today().strftime("%d/%m/%Y")
     assert search_page.description_cell().inner_text() == evenement.description
+    assert search_page.produit_cell().inner_text() == evenement.get_categorie_produit_display()
+    assert search_page.danger_cell().inner_text() == evenement.get_categorie_danger_display()
+    assert search_page.type_evenement_cell().text_content() == evenement.get_type_evenement_display()
+    assert search_page.createur_cell().text_content() == mocked_authentification_user.agent.structure.libelle
+    assert search_page.etat_cell().text_content() == "Brouillon"
+
+
+def test_row_content_for_investigation_cas_humain(live_server, mocked_authentification_user, page: Page):
+    evenement = InvestigationCasHumainFactory()
+    search_page = EvenementProduitListPage(page, live_server.url)
+    search_page.navigate()
+
+    assert search_page.numero_cell().text_content() == evenement.numero
+    assert search_page.date_publication_cell().text_content() == evenement.date_publication.strftime("%d/%m/%Y")
+    assert search_page.date_maj_cell().text_content() == datetime.date.today().strftime("%d/%m/%Y")
+    assert search_page.description_cell().inner_text() == evenement.description
+    assert search_page.produit_cell().inner_text() == "-"
+    assert search_page.danger_cell().inner_text() == evenement.get_categorie_danger_display()
     assert search_page.type_evenement_cell().text_content() == evenement.get_type_evenement_display()
     assert search_page.createur_cell().text_content() == mocked_authentification_user.agent.structure.libelle
     assert search_page.etat_cell().text_content() == "Brouillon"


### PR DESCRIPTION
Make sure we show the "categorie de danger" field for ICH objects on SSA list view.
Rework a bit the test to make them more complete, remove links in tests are they are no longer shown on the table.