### PR TITLE
Relax the constraint on cluster filter for SSA

### DIFF
--- a/ssa/filters.py
+++ b/ssa/filters.py
@@ -120,6 +120,7 @@ class EvenementFilter(
         widget=CategorieDangerLegacyTreeselect,
         label="Catégorie de danger",
     )
+    reference_clusters = django_filters.CharFilter(lookup_expr="icontains")
 
     class Meta:
         model = EvenementProduit

--- a/ssa/tests/test_evenements_list.py
+++ b/ssa/tests/test_evenements_list.py
@@ -471,7 +471,8 @@ def test_can_filter_by_reference_souches(live_server, mocked_authentification_us
 
 
 def test_can_filter_by_reference_clusters(live_server, mocked_authentification_user, page: Page):
-    to_be_found = EvenementProduitFactory(reference_clusters="FOO")
+    to_be_found_1 = EvenementProduitFactory(reference_clusters="FOO")
+    to_be_found_2 = EvenementProduitFactory(reference_clusters="fool")
     not_to_be_found_1 = EvenementProduitFactory(reference_clusters="BAR")
     not_to_be_found_2 = EvenementProduitFactory(reference_clusters="BUZZ")
     not_to_be_found_3 = InvestigationCasHumainFactory()
@@ -483,7 +484,8 @@ def test_can_filter_by_reference_clusters(live_server, mocked_authentification_u
     search_page.add_filters()
     search_page.submit_search()
 
-    expect(page.get_by_text(to_be_found.numero, exact=True)).to_be_visible()
+    expect(page.get_by_text(to_be_found_1.numero, exact=True)).to_be_visible()
+    expect(page.get_by_text(to_be_found_2.numero, exact=True)).to_be_visible()
     expect(page.get_by_text(not_to_be_found_1.numero, exact=True)).not_to_be_visible()
     expect(page.get_by_text(not_to_be_found_2.numero, exact=True)).not_to_be_visible()
     expect(page.get_by_text(not_to_be_found_3.numero, exact=True)).not_to_be_visible()


### PR DESCRIPTION
Change an exact match to an icontains match to make it easier to find a specific cluster (for example the content of the field can be : 123 or cluster 123).