### PR TITLE
Avoid spawing to many worker in CI

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -109,6 +109,7 @@ jobs:
       - name: Run tests
         run: >-
           pytest
+          --numprocesses 3
           --disable-warnings
           --tracing=retain-on-failure
           --splits ${{ strategy.job-total }}


### PR DESCRIPTION
This is a test to try to limit the number of timeout errors (10s) we had, looks like we are asking to much.