### PR TITLE
Correction de la logique sur `TreeselectPage.open_group`

### DIFF
--- a/core/tests/pages.py
+++ b/core/tests/pages.py
@@ -158,11 +158,11 @@ class TreeselectPage:
 
         @playwright_repeatable
         def do_open():
-            button.click()
-            expect(collapse).to_be_visible()
+            if not collapse.is_visible():
+                button.click()
+                expect(collapse).to_be_visible()
 
-        if not collapse.is_visible():
-            do_open()
+        do_open()
 
         return group
 
@@ -180,11 +180,11 @@ class TreeselectPage:
 
         @playwright_repeatable
         def do_close():
-            button.click()
-            expect(collapse).not_to_be_visible()
+            if collapse.is_visible():
+                button.click()
+                expect(collapse).not_to_be_visible()
 
-        if collapse.is_visible():
-            do_close()
+        do_close()
 
         return group or self.container
 


### PR DESCRIPTION
Il semble que sur Chrome, dans certaines circonstances, lors de tests sur Treeselect, au lieu d'ouvrir un accordéon, la méthode `TreeselectPage.open_group` le referme car il est déjà ouvert. `@playwright_repeatable` devait permettre d'éviter cette situation en réessayant d'ouvrir le groupe une deuxième fois si le menu déroule de l'accordéon n'est pas visible. Mais par la suite, Playwright semble incapable de cliquer sur le bouton pour rouvrir le groupe. Cette PR modifie la logique d'ouverture des groupes afin d'éviter de fermer le groupe au lieu de l'ouvrir.