### PR TITLE
Treeselect : améliorations pour les filtres

### DIFF
--- a/core/static/core/form/widgets/treeselect.mjs
+++ b/core/static/core/form/widgets/treeselect.mjs
@@ -281,18 +281,23 @@ class TreeselectSelectedBadge extends TreeselectChoicesListener {
  * @property {HTMLElement} bodyTarget
  * @property {HTMLButtonElement} buttonTarget
  * @property {HTMLInputElement} searchbarTarget
+ * @property {HTMLButtonElement[]} unselectAllBtnTargets
  * @property {HTMLElement} selectedGroupTarget
  * @property {HTMLButtonElement} selectedTagTarget
  * @property {HTMLButtonElement[]} selectedTagTargets
  * @property {HTMLTemplateElement} selectedTagTplTarget
  */
 class Treeselect extends Controller {
-    static targets = ["body", "button", "searchbar", "selectedGroup", "selectedTag", "selectedTagTpl"]
+    static targets = ["body", "button", "searchbar", "unselectAllBtn", "selectedGroup", "selectedTag", "selectedTagTpl"]
     static values = {minSearchLength: {type: Number, default: 3}}
 
     initialize() {
         this.choices = new Map()
         this.children = new Map()
+        this.element.dataset.action = [
+            `${this.identifier}:${CHOICES_CHANGED_EVENT}->${this.identifier}#onChoicesChange`,
+            ...(this.element.dataset.action ?? "").split(/\s+/g),
+        ].join(" ")
     }
 
     connect() {
@@ -346,6 +351,18 @@ class Treeselect extends Controller {
         } else {
             this.choices.delete(value)
         }
+        this.dispatch(CHOICES_CHANGED_EVENT, {target, detail: {choices: this.choices}})
+    }
+
+    onUnselectAll() {
+        for (const it of this.element.querySelectorAll("input:checked")) {
+            it.checked = false
+        }
+        this.choices.clear()
+        this.dispatch(CHOICES_CHANGED_EVENT, {detail: {choices: this.choices}})
+    }
+
+    onChoicesChange() {
         const size = this.choices.size
         if (size === 0) {
             this.buttonTarget.textContent = this.originalButtonLabel
@@ -354,7 +371,7 @@ class Treeselect extends Controller {
         } else {
             this.buttonTarget.textContent = `${this.choices.size} éléments`
         }
-        this.dispatch(CHOICES_CHANGED_EVENT, {target, detail: {choices: this.choices}})
+        this.unselectAllBtnTargets.forEach(it => it.classList.toggle("fr-hidden", size === 0))
     }
 
     onEraseSearch() {

--- a/core/static/core/form/widgets/treeselect_dsfr.css
+++ b/core/static/core/form/widgets/treeselect_dsfr.css
@@ -152,6 +152,14 @@
     background-position: left center;
 }
 
+.fr-treeselect__selected .fr-tag--text {
+    /* Limit tag to one line only */
+    flex-shrink: 10;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .fr-treeselect__selected .fr-tag .fr-btn {
     max-width: none;
     padding: 0.25rem;
@@ -186,4 +194,17 @@
     --icon-size: 1rem;
     -webkit-mask-image: url("/static/dsfr/dist/icons/system/close-line.svg") !important;
     mask-image: url("/static/dsfr/dist/icons/system/close-line.svg") !important;
+}
+
+.fr-treeselect .fr-treeselect-unselect-all {
+    /* Overrides .fr-nav's --underline-img which is defined to none */
+    --underline-img: linear-gradient(0deg, currentColor, currentColor);
+    background-image: var(--underline-img), var(--underline-img);
+    background-repeat: no-repeat, no-repeat;
+    background-position:
+        var(--underline-x) 100%,
+        var(--underline-x) calc(100% - var(--underline-thickness));
+    background-size:
+        var(--underline-hover-width) calc(var(--underline-thickness) * 2),
+        var(--underline-idle-width) var(--underline-thickness);
 }

--- a/core/templates/core/form/widgets/treeselect.html
+++ b/core/templates/core/form/widgets/treeselect.html
@@ -124,6 +124,20 @@
                     </div>
                 {% endif %}
                 <div class="fr-treeselect__body" data-treeselect-target="body">
+                    {% if widget.allow_multiple_selected %}
+                        <section class="fr-btns-group fr-btns-group--right">
+                            <button
+                                type="button"
+                                class="fr-treeselect-unselect-all fr-link fr-hidden"
+                                data-action="treeselect#onUnselectAll"
+                                data-treeselect-target="unselectAllBtn"
+                                data-fr-prevent-conceal
+                                data-testid="treeselect-unselect-all"
+                            >
+                                Tout désélectionner
+                            </button>
+                        </section>
+                    {% endif %}
                     <section
                         class="fr-tags-group fr-treeselect__selected"
                         data-treeselect-target="selectedGroup"
@@ -132,11 +146,13 @@
                             <div
                                 class="fr-tag fr-background-action-high--blue-france fr-text-inverted--blue-france"
                                 type="button"
+                                title="__label__"
                                 data-controller="treeselect-selected-badge"
                                 data-treeselect-selected-badge-formval-value="__value__"
                                 data-testid="selected-tag"
+                                aria-label="__label__"
                             >
-                                __label__
+                                <span class="fr-tag--text">__label__</span>
                                 <button
                                     type="button"
                                     class="fr-btn fr-icon-close-circle-line"
@@ -147,9 +163,11 @@
                             </div>
                         </template>
                     </section>
-                    {% for optgroup in widget.optgroups %}
-                        {% include optgroup.template_name with widget=optgroup %}
-                    {% endfor %}
+                    <section data-testid="treeselect-options">
+                        {% for optgroup in widget.optgroups %}
+                            {% include optgroup.template_name with widget=optgroup %}
+                        {% endfor %}
+                    </section>
                 </div>
             </div>
         </div>

--- a/core/tests/pages.py
+++ b/core/tests/pages.py
@@ -106,7 +106,7 @@ class TreeselectPage:
 
     @property
     def options_container(self):
-        return self.treeselect.locator(".fr-treeselect__body").first
+        return self.treeselect.get_by_test_id("treeselect-options")
 
     @property
     def search_bar(self):
@@ -142,7 +142,7 @@ class TreeselectPage:
             self.close_treeselect()
 
     def _locate_group(self, name: str, container: Locator | None = None):
-        container = container or self.container
+        container = container or self.options_container
         group_header = container.locator(
             f'.fr-treeselect__group .fr-treeselect__group-header:has(.fr-treeselect__group-button:text-is("{name}"))'
         ).first
@@ -171,7 +171,7 @@ class TreeselectPage:
         for name in names:
             group = self.open_group(name, group)
         # If `names` is an empty liste because check box is top-level, just return the main dropdown
-        return group or self.main_dropdown
+        return group or self.options_container
 
     def close_group(self, name: str, container: Locator | None = None):
         self.open_treeselect()
@@ -218,7 +218,7 @@ class TreeselectPage:
 
     def uncheck_by_tag(self, text):
         with self.opened_treeselect():
-            locator = self.container.get_by_test_id("selected-tag").get_by_text(text, exact=True)
+            locator = self.selected_tags.locator(f':scope:has(:text-is("{text}"))')
             expect(locator).to_be_visible()
             locator.get_by_role("button").click()
             expect(locator).not_to_be_visible()
@@ -232,7 +232,11 @@ class TreeselectPage:
                 assert selected_tags_locator.count() == before - 1
 
     def get_option(self, option: GroupedChoicesMixin, exact=True):
-        return self.container.get_by_label(option.uncategorized_label, exact=exact)
+        return self.options_container.get_by_label(option.uncategorized_label, exact=exact)
+
+    def uncheck_all_by_unselect_button(self):
+        self.treeselect.get_by_test_id("treeselect-unselect-all").click()
+        expect(self.selected_tags).to_have_count(0)
 
     def search(self, term):
         self.search_bar.fill(term)

--- a/core/tests/test_treeselect.py
+++ b/core/tests/test_treeselect.py
@@ -100,14 +100,14 @@ def test_treeselect_all_radio_with_same_value_are_selected(navigate_to_form, pag
 
     # First case: select result inside accordion
     treeselect_animal_radio.check_option(*TestChoices.MUNICH.splitted_label)
-    options = treeselect_animal_radio.container.get_by_label(TestChoices.MUNICH.uncategorized_label, exact=True)
+    options = treeselect_animal_radio.options_container.get_by_label(TestChoices.MUNICH.uncategorized_label, exact=True)
     assert options.count() == 2
     for option in options.all():
         expect(option).to_be_checked()
 
     # Unselect result
     treeselect_animal_radio.uncheck_by_tag(TestChoices.MUNICH.uncategorized_label)
-    options = treeselect_animal_radio.container.get_by_label(TestChoices.MUNICH.uncategorized_label, exact=True)
+    options = treeselect_animal_radio.options_container.get_by_label(TestChoices.MUNICH.uncategorized_label, exact=True)
     assert options.count() == 2
     for option in options.all():
         expect(option).not_to_be_checked()
@@ -117,7 +117,7 @@ def test_treeselect_all_radio_with_same_value_are_selected(navigate_to_form, pag
         treeselect_animal_radio.container.locator(
             f"[name^='shortcut'][value='{TestChoices.MUNICH.value}']"
         ).set_checked(True, force=True)
-    options = treeselect_animal_radio.container.get_by_label(TestChoices.MUNICH.uncategorized_label, exact=True)
+    options = treeselect_animal_radio.options_container.get_by_label(TestChoices.MUNICH.uncategorized_label, exact=True)
     assert options.count() == 2
     for option in options.all():
         expect(option).to_be_checked()
@@ -255,3 +255,15 @@ def test_checking_group_input_opens_group_dropdown(navigate_to_form, page: Page)
     treeselect_animal_radio.check_option(*TestChoices.FRANCE.splitted_label, close_after=False)
     expect(treeselect_animal_radio.get_option(TestChoices.TOULOUSE)).to_be_visible()
     expect(treeselect_animal_radio.get_option(TestChoices.PARIS)).to_be_visible()
+
+
+def test_unselect_all_button(navigate_to_form, page: Page):
+    navigate_to_form(TestForm())
+    treeselect_animal_radio = TreeselectPage(page, page.get_by_test_id("animal_checkbox"))
+
+    expect(treeselect_animal_radio.selected_tags).to_have_count(0)
+    treeselect_animal_radio.open_treeselect()
+    treeselect_animal_radio.check_option(*TestChoices.FRANCE.splitted_label, close_after=False)
+    expect(treeselect_animal_radio.selected_tags).to_have_count(3)
+    treeselect_animal_radio.uncheck_all_by_unselect_button()
+    expect(treeselect_animal_radio.selected_tags).to_have_count(0)

--- a/core/widgets.py
+++ b/core/widgets.py
@@ -193,6 +193,7 @@ class TreeselectCheckbox(widgets.ChoiceWidget):
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
         context["widget"]["has_search_bar"] = self.has_search_bar
+        context["widget"]["allow_multiple_selected"] = self.allow_multiple_selected
         return context
 
     def optgroups(self, name, values, attrs=None):


### PR DESCRIPTION
Ajoute également du code CSS pour empêcher le texte des tags des options sélectionnées de s'étendre sur plus d'une ligne.

<img src="https://github.com/user-attachments/assets/aea1da80-8733-4c5d-ba9c-47c7934dea0b" />
<img src="https://github.com/user-attachments/assets/348ff73c-2299-45a7-9036-3148bbfe7cac" />

