### PR TITLE
Make sure we can still fill a conclusion when nothing is pre-filled

### DIFF
--- a/tiac/forms.py
+++ b/tiac/forms.py
@@ -647,7 +647,7 @@ class ConclusionForm(DsfrBaseForm, forms.ModelForm):
                 self.initial["suspicion_conclusion"] = SuspicionConclusion.SUSPECTED
                 self.initial["selected_hazard"] = self.instance.danger_syndromiques_suspectes
             else:
-                self.fields["selected_hazard"].widget.attrs["disabled"] = True
+                self.fields["selected_hazard"].widget.attrs["data-treeselect-disabled"] = "true"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tiac/static/tiac/tiac_conclusion.mjs
+++ b/tiac/static/tiac/tiac_conclusion.mjs
@@ -35,7 +35,7 @@ class ConclusionFormController extends Controller {
     /** @param {HTMLSelectElement} el */
     selectedHazardTreeselectTargetConnected(el) {
         let disabled = false
-        if (this.selectedHazardTreeselectInputTarget.disabled) {
+        if (this.selectedHazardTreeselectInputTarget.dataset.treeselectDisabled) {
             disabled = true
         }
 

--- a/tiac/tests/test_investigation_conclusion.py
+++ b/tiac/tests/test_investigation_conclusion.py
@@ -403,3 +403,35 @@ def test_conclusion_form_aliment_is_pre_filled_when_unique(live_server, page: Pa
     investigation = InvestigationTiac.objects.get()
     assert investigation.suspicion_conclusion == SuspicionConclusion.UNKNOWN
     assert investigation.conclusion_aliment == AlimentSuspect.objects.get()
+
+
+def test_can_add_conclusion_to_investigation_tiac_when_no_prefill_at_all(
+    live_server,
+    page: Page,
+):
+    evenement = InvestigationTiacFactory(
+        etat=InvestigationTiac.Etat.EN_COURS,
+        no_conclusion=True,
+        with_repas=1,
+        agents_confirmes_ars=[],
+        danger_syndromiques_suspectes=[],
+    )
+    detail_page = InvestigationTiacDetailsPage(page, live_server.url)
+    detail_page.navigate(evenement)
+
+    input_data = {
+        "conclusion_comment": "Mon commentaire",
+        "suspicion_conclusion": SuspicionConclusion.CONFIRMED,
+        "selected_hazard": [CategorieDanger.ALLERGENE_ARACHIDE],
+        "conclusion_repas": evenement.repas.get().pk,
+    }
+
+    detail_page.fill_conclusion(input_data)
+    expect(detail_page.page.get_by_text("L’évènement a été mis à jour avec succès.", exact=True)).to_be_visible()
+    expect(detail_page.page.get_by_text("Conclu", exact=True)).to_be_visible()
+
+    investigation = InvestigationTiac.objects.get()
+    assert investigation.get_etat_display() == "Conclu"
+    assert investigation.conclusion_comment == "Mon commentaire"
+    assert investigation.suspicion_conclusion == SuspicionConclusion.CONFIRMED
+    assert investigation.selected_hazard == [CategorieDanger.ALLERGENE_ARACHIDE]


### PR DESCRIPTION
When the field is disabled it wont be send to the backend, move to a data-attribute to avoid this.