### PR TITLE
Make sure selected hazard are required

### DIFF
--- a/tiac/forms.py
+++ b/tiac/forms.py
@@ -565,9 +565,7 @@ class ConclusionForm(DsfrBaseForm, forms.ModelForm):
     suspicion_conclusion = SEVESChoiceField(
         label="Conclusion de la suspicion de TIAC", choices=SuspicionConclusion, required=True
     )
-    selected_hazard = SimpleArrayField(
-        forms.CharField(), delimiter="||", label="Dangers retenus", required=False, widget=forms.HiddenInput
-    )
+    selected_hazard = SimpleArrayField(forms.CharField(), delimiter="||", label="Dangers retenus", required=False)
 
     class Meta:
         model = InvestigationTiac

--- a/tiac/static/tiac/investigation.css
+++ b/tiac/static/tiac/investigation.css
@@ -44,9 +44,3 @@ fieldset.form-fieldset.analyses-alimentaires-fieldset {
         max-width: unset;
     }
 }
-
-#id_selected_hazard {
-    height: 0;
-    padding: 1px;
-    opacity: 0;
-}

--- a/tiac/static/tiac/investigation_base.css
+++ b/tiac/static/tiac/investigation_base.css
@@ -14,3 +14,9 @@
 .conclusion-comment textarea {
     flex-grow: 1;
 }
+#id_selected_hazard {
+    display: block;
+    height: 0;
+    padding: 1px;
+    opacity: 0;
+}

--- a/tiac/templates/tiac/forms/conclusion.html
+++ b/tiac/templates/tiac/forms/conclusion.html
@@ -34,11 +34,11 @@
 
                                 <div id="selected_hazard-treeselect" class="fr-input-group">
                                     {{ form.selected_hazard.label_tag }}
+                                    {{ form.selected_hazard|set_data:"conclusion-form-target:selectedHazardTreeselectInput" }}
                                     <div
                                         data-conclusion-form-target="selectedHazardTreeselect"
                                         data-action="input->conclusion-form#onTreeselectInput update-dom->conclusion-form#onUpdateDom"
                                     ></div>
-                                    {{ form.selected_hazard|set_data:"conclusion-form-target:selectedHazardTreeselectInput" }}
                                     <template data-conclusion-form-target="selectedHazardTreeselectHeader">
                                         <div class="categorie-danger-header">
                                             <div class="fr-ml-1v">Dangers les plus courants</div>

--- a/tiac/tests/pages.py
+++ b/tiac/tests/pages.py
@@ -784,6 +784,14 @@ class InvestigationTiacDetailsPage(WithEtablissementMixin, WithActionsPage, With
         return self.page.get_by_role("button", name="Modifier la conclusion")
 
     @property
+    def selected_hazard_label(self):
+        return self.page.locator("[for=id_selected_hazard]")
+
+    @property
+    def selected_hazard_hidden_field(self):
+        return self.page.locator("#id_selected_hazard")
+
+    @property
     def repas_field(self):
         return self.page.locator("#id_conclusion_repas")
 
@@ -801,6 +809,11 @@ class InvestigationTiacDetailsPage(WithEtablissementMixin, WithActionsPage, With
     def fill_conclusion(self, input_data):
         self.add_conclusion_button.click()
         self.suspicion_conclusion_field.select_option(input_data["suspicion_conclusion"])
+        self.selected_hazard_label.evaluate(
+            """(el) => {
+                el.closest('.fr-modal__body').scrollTop = 200;
+            }"""
+        )
         if input_data["suspicion_conclusion"] == SuspicionConclusion.CONFIRMED:
             self.clear_treeselect("selected_hazard-treeselect")
             for item in input_data["selected_hazard"]:

--- a/tiac/tests/test_investigation_conclusion.py
+++ b/tiac/tests/test_investigation_conclusion.py
@@ -366,7 +366,7 @@ def test_conclusion_form_shows_notice_when_multiple_aliments(live_server, page: 
     ).to_be_visible()
 
 
-def test_conclusion_form_repas_is_required(live_server, page: Page):
+def test_conclusion_form_required_fields(live_server, page: Page):
     evenement = InvestigationTiacFactory(
         etat=InvestigationTiac.Etat.EN_COURS,
         no_conclusion=True,
@@ -377,13 +377,24 @@ def test_conclusion_form_repas_is_required(live_server, page: Page):
     detail_page.add_conclusion_button.click()
 
     detail_page.suspicion_conclusion_field.select_option(SuspicionConclusion.CONFIRMED)
+    expect(detail_page.selected_hazard_hidden_field).to_have_attribute("required", "")
     expect(detail_page.repas_field).to_have_attribute("required", "")
+    assert detail_page.selected_hazard_label.evaluate("(el) => getComputedStyle(el, '::after').content") == '"*"'
+
     detail_page.suspicion_conclusion_field.select_option(SuspicionConclusion.SUSPECTED)
+    expect(detail_page.selected_hazard_hidden_field).to_have_attribute("required", "")
+    assert detail_page.selected_hazard_label.evaluate("(el) => getComputedStyle(el, '::after').content") == '"*"'
     expect(detail_page.repas_field).to_have_attribute("required", "")
+
     detail_page.suspicion_conclusion_field.select_option(SuspicionConclusion.DISCARDED)
+    expect(detail_page.selected_hazard_hidden_field).not_to_have_attribute("required", "")
     expect(detail_page.repas_field).not_to_have_attribute("required", "")
+    assert detail_page.selected_hazard_label.evaluate("(el) => getComputedStyle(el, '::after').content") == "none"
+
     detail_page.suspicion_conclusion_field.select_option(SuspicionConclusion.UNKNOWN)
+    expect(detail_page.selected_hazard_hidden_field).not_to_have_attribute("required", "")
     expect(detail_page.repas_field).not_to_have_attribute("required", "")
+    assert detail_page.selected_hazard_label.evaluate("(el) => getComputedStyle(el, '::after').content") == "none"
 
 
 def test_conclusion_form_aliment_is_pre_filled_when_unique(live_server, page: Page):


### PR DESCRIPTION
- A part of it was broken when moved to a modal (due to the css not being moved and the fields changed to a hiddeninput)
- The bold / * was not working on the previous page (due to the position of the label relative to the hidden input)
- Scoll into the modal to reduce flakiness, the field is visible but not all the options in the drowdown