### PR TITLE
Treeselect: correction de 2 regressions

### DIFF
--- a/core/static/core/form/widgets/treeselect.mjs
+++ b/core/static/core/form/widgets/treeselect.mjs
@@ -67,9 +67,7 @@ class TreeselectGroupConnectable extends TreeselectChoicesListener {
             if (target === it) continue
             if (choices.has(it.value.trim()) && !it.checked) {
                 it.checked = true
-            } else if (!choices.has(it.value.trim()) && it.checked && it.type === "radio") {
-                // Here, we don't want to uncheck if input is of type checkbox since this would interfere with
-                // the feature to automatically select group input when all children are selected
+            } else if (!choices.has(it.value.trim()) && it.checked) {
                 it.checked = false
             }
         }
@@ -224,20 +222,22 @@ class TreeselectGroup extends TreeselectGroupConnectable {
 
     /** @param {Event} evt */
     onSelect(evt) {
-        if (this.#locked) return
-
-        if (!this.hasInputTarget || this.inputTarget.type !== "checkbox") return
+        if (this.#locked || !this.hasInputTarget) return
 
         const checked = evt.target.checked
-        try {
-            this.#locked = true
-            for (const it of this.childTargets) {
-                it.checked = checked
-                it.dispatchEvent(new Event("change"))
+        if (this.inputTarget.type === "checkbox") {
+            try {
+                this.#locked = true
+                for (const it of this.childTargets) {
+                    it.checked = checked
+                    it.dispatchEvent(new Event("change"))
+                }
+            } finally {
+                this.#locked = false
             }
-        } finally {
-            this.#locked = false
         }
+
+        // Open group accordion
         if (checked) {
             this.collapseTargets.forEach(async it => {
                 await dsfrDisclosePromise(dsfr(it).collapse)

--- a/core/tests/test_treeselect.py
+++ b/core/tests/test_treeselect.py
@@ -30,7 +30,7 @@ class TestChoices(GroupedChoicesMixin, TextChoices):
 
     @classproperty
     def les_plus_courants(cls):
-        return cls.MUNICH, cls.BERLIN, cls.CHILI, cls.BRESIL, cls.SAO_POLO
+        return cls.MUNICH, cls.PORTE_DE_BRANDEBOURG, cls.CHILI, cls.BRESIL, cls.SAO_POLO
 
     @classproperty
     def treeselect_choices(cls):
@@ -243,6 +243,36 @@ def test_checkbox_options_and_parent_behavior(navigate_to_form, page: Page):
         expect(treeselect_animal_radio.get_option(it)).not_to_be_checked()
 
     assert treeselect_animal_radio.selected_tags.count() == 0
+
+
+def test_shortcut_behavior(navigate_to_form, page: Page):
+    navigate_to_form(TestForm())
+    treeselect = TreeselectPage(page, page.get_by_test_id("animal_checkbox"))
+
+    # Test that checking option also checks its shortcut
+    treeselect.check_option(*TestChoices.PORTE_DE_BRANDEBOURG.splitted_label)
+    options = treeselect.container.locator(f'input[value="{TestChoices.PORTE_DE_BRANDEBOURG.value}"]').all()
+    assert len(options) == 2
+    for option in options:
+        expect(option).to_be_checked()
+
+    # Test that unchecking option also unchecks its shortcut
+    treeselect.uncheck_option(*TestChoices.PORTE_DE_BRANDEBOURG.splitted_label)
+    for option in options:
+        expect(option).not_to_be_checked()
+
+
+def test_check_group_input_opens_group_accordion(navigate_to_form, page: Page):
+    navigate_to_form(TestForm())
+
+    for treeselect in (
+        TreeselectPage(page, page.get_by_test_id("animal_radio")),
+        TreeselectPage(page, page.get_by_test_id("animal_checkbox")),
+    ):
+        with treeselect.opened_treeselect():
+            treeselect.check_option(*TestChoices.BERLIN.splitted_label, close_after=False)
+            for option in treeselect.container.get_by_label(TestChoices.PORTE_DE_BRANDEBOURG.uncategorized_label).all():
+                expect(option).to_be_visible()
 
 
 def test_checking_group_input_opens_group_dropdown(navigate_to_form, page: Page):


### PR DESCRIPTION
- cocher une option de groupe ouvre l'accordéon
- décocher une checkbox d'un option qui possède également un raccourci décoche aussi le raccourci (ne reproduit que sur le checkboxes)
- ajout de tests pour ces régressions