### PR TITLE
Fix treeselect option name with prefix

### DIFF
--- a/core/tests/test_treeselect.py
+++ b/core/tests/test_treeselect.py
@@ -297,3 +297,13 @@ def test_unselect_all_button(navigate_to_form, page: Page):
     expect(treeselect_animal_radio.selected_tags).to_have_count(3)
     treeselect_animal_radio.uncheck_all_by_unselect_button()
     expect(treeselect_animal_radio.selected_tags).to_have_count(0)
+
+
+def test_shortcut_do_not_accumulate_name_prefix(navigate_to_form, page: Page):
+    navigate_to_form(TestForm())
+    treeselect = TreeselectPage(page, page.get_by_test_id("animal_checkbox"))
+
+    with treeselect.opened_treeselect():
+        for it in TestChoices.les_plus_courants:
+            shortcut_checkbox = treeselect.container.locator(f'input[name^="shortcut"][value="{it.value}"]')
+            expect(shortcut_checkbox).to_have_attribute("name", "shortcut-animal_checkbox")

--- a/core/widgets.py
+++ b/core/widgets.py
@@ -118,14 +118,15 @@ class TreeselectGroupWidget(widgets.ChoiceWidget):
                     choice = TreeselectItem(value=choice[0], label=choice[1], categorised_label=None)
                 if choice.categorised_label:
                     attrs["data-categorised-label"] = choice.categorised_label
+                option_name = name
                 if choice.html_name_prefix:
-                    name = f"{choice.html_name_prefix}-{name}"
+                    option_name = f"{choice.html_name_prefix}-{name}"
                     selected = str(choice.value) in value
                 else:
                     selected = self.get_selected(choice.value, value)
 
                 yield self.create_option(
-                    name,
+                    option_name,
                     choice.value,
                     choice.label,
                     selected,


### PR DESCRIPTION
Test would fail with unexpected value "shortcut-shortcut-animal_checkbox" Variable shadowing bug due to the use of name variable in 2 scopes.