### PR TITLE
Treeselect: ajout d'une option permettant de sélectionner automatiquement les options de groupe/enfants pour les options case à cocher

### DIFF
--- a/core/static/core/form/widgets/treeselect.mjs
+++ b/core/static/core/form/widgets/treeselect.mjs
@@ -124,16 +124,20 @@ class TreeselectElement extends TreeselectGroupConnectable {
  * @property {HTMLInputElement[]} accordionBtnTargets
  * *** Values ***
  * @property {Boolean} hiddenValue
+ * @property {Boolean} autoSelectChildrenValue
  */
 class TreeselectGroup extends TreeselectGroupConnectable {
     static values = {
         hidden: {type: Boolean, default: false},
-        selfMatchesSearch: {type: Boolean, default: true},
-        hasChildrenMatching: {type: Boolean, default: true},
+        autoSelectChildren: {type: Boolean, default: false},
     }
     static targets = ["accordionBtn", "collapse"]
 
     #locked = false
+
+    get canAutoSelectChildren() {
+        return this.inputTarget.type === "checkbox" && this.autoSelectChildrenValue
+    }
 
     get labels() {
         const result = []
@@ -203,7 +207,7 @@ class TreeselectGroup extends TreeselectGroupConnectable {
         if (this.#locked) return
 
         await super.onChoicesChanged(evt)
-        if (!this.hasInputTarget || this.inputTarget.type !== "checkbox") return
+        if (!this.hasInputTarget || !this.canAutoSelectChildren) return
 
         try {
             this.#locked = true
@@ -225,7 +229,7 @@ class TreeselectGroup extends TreeselectGroupConnectable {
         if (this.#locked || !this.hasInputTarget) return
 
         const checked = evt.target.checked
-        if (this.inputTarget.type === "checkbox") {
+        if (this.canAutoSelectChildren) {
             try {
                 this.#locked = true
                 for (const it of this.childTargets) {

--- a/core/templates/core/form/widgets/treeselect.html
+++ b/core/templates/core/form/widgets/treeselect.html
@@ -41,6 +41,7 @@
     <div
         class="fr-treeselect__group{% if widget.can_expand %} fr-accordion{% endif %}"
         data-controller="treeselect-group"
+        data-treeselect-group-auto-select-children-value="{{ widget.auto_select_children }}"
     >
         <div class="fr-treeselect__group-header">
             {% if not widget.can_expand %}

--- a/core/tests/test_treeselect.py
+++ b/core/tests/test_treeselect.py
@@ -161,7 +161,7 @@ def test_treeselect_button_label(navigate_to_form, page: Page):
     assert treeselect_animal_radio.main_button.inner_text() == "Choisir dans la liste"
 
 
-def test_checkbox_options_and_parent_behavior(navigate_to_form, page: Page):
+def test_checkbox_options_and_parent_behavior_auto_select_enabled(navigate_to_form, page: Page):
     navigate_to_form(TestForm())
     treeselect_animal_radio = TreeselectPage(page, page.get_by_test_id("animal_checkbox"))
 
@@ -243,6 +243,27 @@ def test_checkbox_options_and_parent_behavior(navigate_to_form, page: Page):
         expect(treeselect_animal_radio.get_option(it)).not_to_be_checked()
 
     assert treeselect_animal_radio.selected_tags.count() == 0
+
+
+def test_checkbox_options_and_parent_behavior_auto_select_disabled(navigate_to_form, page: Page):
+    form = TestForm()
+    form["animal_checkbox"].field.widget.auto_select_children = False
+    navigate_to_form(form)
+    treeselect_animal_radio = TreeselectPage(page, page.get_by_test_id("animal_checkbox"))
+
+    # Tests that checking parent does not check children
+    treeselect_animal_radio.check_option(*TestChoices.FRANCE.splitted_label)
+
+    for it in (TestChoices.TOULOUSE, TestChoices.PARIS):
+        expect(treeselect_animal_radio.get_option(it)).not_to_be_checked()
+
+    # Tests that checking children does not check parent
+    treeselect_animal_radio.uncheck_option(*TestChoices.FRANCE.splitted_label)
+
+    for it in (TestChoices.TOULOUSE, TestChoices.PARIS):
+        treeselect_animal_radio.check_option(*it.splitted_label)
+
+    expect(treeselect_animal_radio.get_option(TestChoices.FRANCE)).not_to_be_checked()
 
 
 def test_shortcut_behavior(navigate_to_form, page: Page):

--- a/core/widgets.py
+++ b/core/widgets.py
@@ -69,7 +69,7 @@ class TreeselectGroupWidget(widgets.ChoiceWidget):
     def option_template_name(self):
         return self.parent.option_template_name
 
-    def __init__(self, parent: "TreeselectCheckbox", item: TreeselectGroup | TreeselectItem):
+    def __init__(self, parent: "TreeselectMixin", item: TreeselectGroup | TreeselectItem):
         self.parent = parent
         self.item = item
         self.group_label = item.label
@@ -90,6 +90,7 @@ class TreeselectGroupWidget(widgets.ChoiceWidget):
         context["group"] = self.group_label
         context["group_index"] = self.parent.get_next_id()
         context["can_expand"] = False
+        context["auto_select_children"] = self.parent.auto_select_children
         context["aria_controls_prefix"] = f"{name}-fr-treeselect-subgroup"
         if isinstance(self.item, TreeselectGroup):
             context["can_expand"] = self.item.can_expand
@@ -143,12 +144,11 @@ class TreeselectGroupWidget(widgets.ChoiceWidget):
         return context
 
 
-class TreeselectCheckbox(widgets.ChoiceWidget):
-    allow_multiple_selected = True
-    input_type = "checkbox"
+class TreeselectMixin(widgets.ChoiceWidget):
     template_name = "core/form/widgets/treeselect.html"
     option_template_name = "core/form/widgets/treeselect.html#option"
     has_search_bar = True
+    auto_select_children = False
 
     @property
     def choices(self) -> _Choices:
@@ -224,6 +224,24 @@ class TreeselectCheckbox(widgets.ChoiceWidget):
         ).create_option(name, value, label, selected, index, subindex, attrs)
 
 
-class TreeselectRadio(TreeselectCheckbox):
+class TreeselectCheckbox(TreeselectMixin):
+    allow_multiple_selected = True
+    input_type = "checkbox"
+    auto_select_children = True
+
+    def __init__(
+        self,
+        attrs=None,
+        choices: _Choices = (),
+        *,
+        input_type: Literal["checkbox", "radio"] = _UNSET,
+        has_search_bar: bool = _UNSET,
+        auto_select_children: bool = True,
+    ):
+        super().__init__(attrs, choices, input_type=input_type, has_search_bar=has_search_bar)
+        self.auto_select_children = auto_select_children
+
+
+class TreeselectRadio(TreeselectMixin):
     allow_multiple_selected = False
     input_type = "radio"


### PR DESCRIPTION
Jusqu'ici, cocher une checkbox de groupe cochait automatiquement les checkboxes des enfants. De même que cocher tous les enfants d'un groupe cochait la checkboxe de groupe s'il y en a une. Mais sur TIAC, on a des usages où on ne souhaite pas ce comportement. Cette PR rajouter une option pour le désactiver. Le comportement est activé par défaut. Est-ce qu'on devrait faire l'inverse ?