### PR TITLE
Make sure we can update only our own message

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -11,7 +11,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.http import HttpResponseRedirect
-from django.http.response import HttpResponse, HttpResponseServerError, JsonResponse
+from django.http.response import Http404, HttpResponse, HttpResponseServerError, JsonResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.utils import timezone
 from django.utils.translation import ngettext
@@ -182,10 +182,17 @@ class MessageCreateView(PreventActionIfVisibiliteBrouillonMixin, UserPassesTestM
     def setup(self, request, *args, **kwargs):
         super().setup(request, *args, **kwargs)
         self.reply_message = None
+        agent = self.request.user.agent
         if self.request.method == "GET":
-            self.message = Message.objects.create_unsaved(self.request.user.agent, related_to=self.fiche_objet)
+            self.message = Message.objects.create_unsaved(agent, related_to=self.fiche_objet)
         else:
-            self.message = Message.objects.get_base_queryset().get(pk=self.request.POST.get("id"))
+            authorized_messages = Message.objects.get_base_queryset().filter(
+                sender=agent.contact_set.get(), status=Message.Status.AVANT_SAUVEGARDE
+            )
+            try:
+                self.message = authorized_messages.get(pk=self.request.POST.get("id"))
+            except Message.DoesNotExist:
+                raise Http404("Message non trouvé")
 
     def get_fiche_object(self):
         self.fiche_object_class = ContentType.objects.get(pk=self.kwargs.get("obj_type_pk")).model_class()

--- a/sv/tests/test_evenement_message.py
+++ b/sv/tests/test_evenement_message.py
@@ -329,7 +329,7 @@ def test_cant_add_message_if_evenement_brouillon(client, mocked_authentification
     evenement = EvenementFactory(etat=Evenement.Etat.BROUILLON)
     message = Message.objects.create_unsaved(active_contact, related_to=evenement)
 
-    response = client.post(
+    client.post(
         evenement.add_message_url,
         data={
             "id": message.pk,
@@ -341,10 +341,8 @@ def test_cant_add_message_if_evenement_brouillon(client, mocked_authentification
         follow=True,
     )
 
-    messages = list(response.context["messages"])
-    assert len(messages) == 1
-    assert messages[0].level_tag == "error"
-    assert str(messages[0]) == "Action impossible car la fiche est en brouillon"
+    message = Message._base_objects.get()
+    assert message.status == Message.Status.AVANT_SAUVEGARDE
 
 
 def test_can_see_more_than_4_search_result_in_recipients_and_recipients_copy_field(
@@ -589,9 +587,36 @@ def test_cant_forge_post_of_message_in_evenement_we_cant_see(client, mocked_auth
         reverse("message-add", kwargs={"obj_type_pk": content_type, "obj_pk": evenement.pk}), data=payload
     )
 
-    assert response.status_code == 403
+    assert response.status_code == 404
     evenement.refresh_from_db()
     assert evenement.messages.count() == 0
+
+
+@pytest.mark.django_db
+def test_cant_forge_post_of_message_to_update_existing_message(client, mocked_authentification_user):
+    evenement = EvenementFactory(visibilite=Visibilite.NATIONALE, etat=Evenement.Etat.EN_COURS)
+    contact = ContactAgentFactory(with_active_agent__with_groups=[settings.SV_GROUP])
+    message = MessageFactory(status=Message.Status.FINALISE, content_object=evenement, message_type=Message.MESSAGE)
+
+    content_type = ContentType.objects.get_for_model(evenement).id
+
+    payload = {
+        "id": message.pk,
+        "content_type": content_type,
+        "object_id": evenement.pk,
+        "recipients": contact.pk,
+        "title": "Test",
+        "content": "Test",
+        "action": "finalise",
+    }
+    url = reverse("message-add", kwargs={"obj_type_pk": content_type, "obj_pk": evenement.pk})
+    response = client.post(f"{url}?type=message", data=payload)
+
+    assert response.status_code == 404
+    evenement.refresh_from_db()
+    message = evenement.messages.get()
+    assert message.content != "Test"
+    assert message.title != "Test"
 
 
 def test_can_delete_document_attached_to_message(live_server, page: Page, mocked_authentification_user: User):


### PR DESCRIPTION
Due to the introduction of the new state we sometime need to "update" a message, even if it is done in the message creation view. Make sure we can only update message that we own and that are in before state to avoid tampering of other messages.