### PR TITLE
Wait for 1s after interacting with map, when testing lieu map

### DIFF
--- a/sv/tests/test_fichedetection_create.py
+++ b/sv/tests/test_fichedetection_create.py
@@ -984,6 +984,7 @@ def test_lieu_map(
     x = box["x"] + box["width"] / 2
     y = box["y"] + box["height"] / 2
     page.mouse.dblclick(x, y)
+    page.wait_for_timeout(1000)
     assert call_count["count"] == 1
 
     lieu_form_elements.close_with(action="save")


### PR DESCRIPTION
When testing `lieu` map, wait for the map to actually init & respond internally before checking the result value