### PR TITLE
Use thousand separator so big numbers are easily readable

### DIFF
--- a/seves/settings.py
+++ b/seves/settings.py
@@ -63,6 +63,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.humanize",
     "widget_tweaks",
     "dsfr",
     "django.forms",
@@ -169,12 +170,6 @@ TIME_ZONE = "Europe/Paris"
 USE_I18N = True
 
 USE_TZ = True
-
-USE_THOUSAND_SEPARATOR = True
-
-THOUSAND_SEPARATOR = " "
-
-NUMBER_GROUPING = 3
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.0/howto/static-files/

--- a/seves/settings.py
+++ b/seves/settings.py
@@ -170,6 +170,12 @@ USE_I18N = True
 
 USE_TZ = True
 
+USE_THOUSAND_SEPARATOR = True
+
+THOUSAND_SEPARATOR = " "
+
+NUMBER_GROUPING = 3
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.0/howto/static-files/
 STATIC_ROOT = "staticfiles"


### PR DESCRIPTION
#### Use a space separator between thousands wen displaying numbers

Django documentation on `THOUSAND_SEPARATOR` and `NUMBER_GROUPING` can be found [here](https://docs.djangoproject.com/en/6.0/ref/settings/#std-setting-USE_THOUSAND_SEPARATOR)