### PR TITLE
Switch conclusion modal to new treeselect

### DIFF
--- a/tiac/forms.py
+++ b/tiac/forms.py
@@ -5,7 +5,7 @@ import re
 from django import forms
 from django.conf import settings
 from django.contrib.postgres.forms import SimpleArrayField
-from django.forms import Media
+from django.forms import Media, MultipleChoiceField
 from django.utils import timezone
 from dsfr.forms import DsfrBaseForm
 
@@ -589,13 +589,35 @@ class ConclusionForm(DsfrBaseForm, forms.ModelForm):
     suspicion_conclusion = SEVESChoiceField(
         label="Conclusion de la suspicion de TIAC", choices=SuspicionConclusion, required=True
     )
-    selected_hazard = SimpleArrayField(forms.CharField(), delimiter="||", label="Dangers retenus", required=False)
+
+    selected_hazard_confirmed = MultipleChoiceField(
+        required=False,
+        label="Dangers retenus",
+        choices=CategorieDanger,
+        widget=TreeselectCheckbox(
+            choices=CategorieDanger.treeselect_choices_with_dangers_courants(CategorieDanger.danger_courants_tiac),
+            attrs={"placeholder": "Choisir dans la liste d’après les résultats d’analyse"},
+            auto_select_children=False,
+        ),
+    )
+    selected_hazard_suspected = MultipleChoiceField(
+        required=False,
+        label="Dangers retenus",
+        choices=DangersSyndromiques,
+        widget=TreeselectCheckbox(
+            choices=[(c[0], DangersSyndromiques(c[0]).short_name) for c in DangersSyndromiques.choices],
+            attrs={"placeholder": "Choisir dans la liste parmi les dangers syndromiques"},
+            auto_select_children=False,
+        ),
+    )
 
     class Meta:
         model = InvestigationTiac
         fields = (
             "suspicion_conclusion",
             "selected_hazard",
+            "selected_hazard_confirmed",
+            "selected_hazard_suspected",
             "conclusion_comment",
             "conclusion_repas",
             "conclusion_aliment",
@@ -608,37 +630,33 @@ class ConclusionForm(DsfrBaseForm, forms.ModelForm):
     @property
     def media(self):
         return super().media + Media(
-            js=(
-                js_module("tiac/tiac_conclusion.mjs"),
-                js_module("ssa/treeselectjs.umd.js"),
-                js_module("ssa/form/widgets/legacy_treeselect.mjs"),
-            ),
-            css={
-                "all": (
-                    "https://cdn.jsdelivr.net/npm/treeselectjs@0.13.1/dist/treeselectjs.css",
-                    "ssa/form/widgets/_custom_tree_select.css",
-                )
-            },
+            js=(js_module("tiac/tiac_conclusion.mjs"),),
         )
 
     def clean_suspicion_conclusion_and_selected_hazard(self):
         suspicion_conclusion = self.cleaned_data.get("suspicion_conclusion")
-        selected_hazard = self.cleaned_data.get("selected_hazard")
+        selected_hazard_confirmed = self.cleaned_data.get("selected_hazard_confirmed")
+        selected_hazard_suspected = self.cleaned_data.get("selected_hazard_suspected")
 
         if suspicion_conclusion not in (SuspicionConclusion.CONFIRMED, SuspicionConclusion.SUSPECTED):
             self.cleaned_data["selected_hazard"] = []
-        elif suspicion_conclusion == SuspicionConclusion.CONFIRMED and any(
-            item not in CategorieDanger.values for item in selected_hazard
-        ):
-            self.add_error(
-                "selected_hazard", f"La valeur doit être comprise parmis [{', '.join(CategorieDanger.labels)}]"
-            )
-        elif suspicion_conclusion == SuspicionConclusion.SUSPECTED and any(
-            item not in DangersSyndromiques.values for item in selected_hazard
-        ):
-            self.add_error(
-                "selected_hazard", f"La valeur doit être comprise parmis [{', '.join(DangersSyndromiques.labels)}]"
-            )
+        elif suspicion_conclusion == SuspicionConclusion.CONFIRMED:
+            if any(item not in CategorieDanger.values for item in selected_hazard_confirmed):
+                self.add_error(
+                    "selected_hazard", f"La valeur doit être comprise parmis [{', '.join(CategorieDanger.labels)}]"
+                )
+            else:
+                self.cleaned_data["selected_hazard"] = selected_hazard_confirmed
+        elif suspicion_conclusion == SuspicionConclusion.SUSPECTED:
+            if any(item not in DangersSyndromiques.values for item in selected_hazard_suspected):
+                self.add_error(
+                    "selected_hazard", f"La valeur doit être comprise parmis [{', '.join(DangersSyndromiques.labels)}]"
+                )
+            else:
+                self.cleaned_data["selected_hazard"] = selected_hazard_suspected
+
+        if "selected_hazard" in self.cleaned_data:
+            self.instance.selected_hazard = self.cleaned_data["selected_hazard"]
 
     def clean(self):
         cleaned_data = super().clean()
@@ -663,13 +681,11 @@ class ConclusionForm(DsfrBaseForm, forms.ModelForm):
                 choices=self.fields["suspicion_conclusion"].choices,
             )
             self.initial["suspicion_conclusion"] = SuspicionConclusion.CONFIRMED
-            self.initial["selected_hazard"] = categories_danger + self.instance.agents_confirmes_ars
+            self.initial["selected_hazard_confirmed"] = categories_danger + self.instance.agents_confirmes_ars
         else:
             if self.instance.danger_syndromiques_suspectes:
                 self.initial["suspicion_conclusion"] = SuspicionConclusion.SUSPECTED
-                self.initial["selected_hazard"] = self.instance.danger_syndromiques_suspectes
-            else:
-                self.fields["selected_hazard"].widget.attrs["data-treeselect-disabled"] = "true"
+                self.initial["selected_hazard_suspected"] = self.instance.danger_syndromiques_suspectes
 
         repas = self.instance.repas.all()
         if len(repas) == 1:
@@ -687,7 +703,12 @@ class ConclusionForm(DsfrBaseForm, forms.ModelForm):
                 queryset.filter(investigation=self.instance) if self.instance.pk else queryset.none()
             )
 
-        if not self.instance.suspicion_conclusion:
+        if self.instance.suspicion_conclusion:
+            if self.instance.suspicion_conclusion == SuspicionConclusion.SUSPECTED:
+                self.fields["selected_hazard_suspected"].initial = self.instance.selected_hazard
+            if self.instance.suspicion_conclusion == SuspicionConclusion.CONFIRMED:
+                self.fields["selected_hazard_confirmed"].initial = self.instance.selected_hazard
+        else:
             self._init_conclusion()
 
     @cached_property

--- a/tiac/static/tiac/investigation_base.css
+++ b/tiac/static/tiac/investigation_base.css
@@ -14,7 +14,7 @@
 .conclusion-comment textarea {
     flex-grow: 1;
 }
-#id_selected_hazard {
+#required-proxy {
     display: block;
     height: 0;
     padding: 1px;

--- a/tiac/static/tiac/tiac_conclusion.mjs
+++ b/tiac/static/tiac/tiac_conclusion.mjs
@@ -1,182 +1,111 @@
 import {applicationReady} from "Application"
-import {hideHeader, patchItems, showHeader, tsDefaultOptions} from "CustomTreeSelect"
 import {Controller} from "Stimulus"
 
 /**
  * @property {Object.<string, {value: string, label: string}>} suspicionConclusionChoicesValue
  * @property {string} suspicionConclusionValue
- * @property {Object[]} selectedHazardConfirmedChoicesValue
- * @property {Object[]} selectedHazardSuspectedChoicesValue
- * @property {string} selectedHazardIdValue
- * @property {boolean} selectedHazardTreeselectInitializedValue
  * @property {HTMLSelectElement} suspicionConclusionTarget
- * @property {HTMLDivElement} selectedHazardTreeselectTarget
- * @property {HTMLInputElement} selectedHazardTreeselectInputTarget
- * @property {HTMLTemplateElement} selectedHazardTreeselectHeaderTarget
  */
 class ConclusionFormController extends Controller {
     static targets = [
         "suspicionConclusion",
         "conclusionRepas",
         "conclusionAliment",
-        "selectedHazardTreeselect",
-        "selectedHazardTreeselectInput",
-        "selectedHazardTreeselectHeader",
         "notice",
         "noticeAliment",
         "noticeRepas",
+        "selectedHazardConfirmedContainer",
+        "selectedHazardSuspectedContainer",
+        "requiredProxy",
     ]
     static values = {
         suspicionConclusionChoices: Object,
         suspicionConclusion: String,
         selectedHazardConfirmedChoices: Array,
         selectedHazardSuspectedChoices: Array,
-        selectedHazardTreeselectInitialized: {type: Boolean, default: false},
     }
+    static outlets = ["treeselect"]
 
-    /** @param {HTMLSelectElement} el */
-    selectedHazardTreeselectTargetConnected(el) {
-        let disabled = false
-        if (this.selectedHazardTreeselectInputTarget.dataset.treeselectDisabled) {
-            disabled = true
+    treeselectOutletConnected(outlet) {
+        if (outlet.element.id === "fr-treeselect-id_selected_hazard_confirmed") {
+            this.treeselectConfirmedOutlet = outlet
+        } else if (outlet.element.id === "fr-treeselect-id_selected_hazard_suspected") {
+            this.treeselectSuspectedOutlet = outlet
         }
-
-        this.treeselect = new Treeselect({
-            ...tsDefaultOptions,
-            parentHtmlContainer: el,
-            value: [],
-            options: [],
-            isSingleSelect: false,
-            isIndependentNodes: true,
-            disabled: disabled,
-            openCallback: this.treeselectOpenCallback.bind(this),
-            searchCallback: item => {
-                if (item.length === 0) {
-                    showHeader(this.treeselect.srcElement, ".categorie-danger-header")
-                } else {
-                    hideHeader(this.treeselect.srcElement, ".categorie-danger-header")
-                }
-            },
-        })
-        patchItems(this.treeselect.srcElement)
+        outlet.element.addEventListener("treeselect:choices", this.onTreeselectChoicesChanged)
+        this.#syncTreeselects()
+        this.#syncRequiredProxyValue()
     }
 
-    selectedHazardTreeselectTargetDiconnected() {
-        this.treeselect.destroy()
-        this.treeselect = undefined
+    treeselectOutletDisconnected(outlet) {
+        outlet.element.removeEventListener("treeselect:choices", this.onTreeselectChoicesChanged)
     }
 
+    onTreeselectChoicesChanged = () => {
+        this.#syncRequiredProxyValue()
+    }
+
+    // The hidden field is needed to "fake" a required checkbox, sync the value so that we can submit the modal
+    // when we have a value
+    #syncRequiredProxyValue() {
+        const value = this.suspicionConclusionValue
+        if (value === this.suspicionConclusionChoicesValue.CONFIRMED.value) {
+            this.requiredProxyTarget.value = this.treeselectConfirmedOutlet?.choices.size > 0 ? "x" : ""
+        } else if (value === this.suspicionConclusionChoicesValue.SUSPECTED.value) {
+            this.requiredProxyTarget.value = this.treeselectSuspectedOutlet?.choices.size > 0 ? "x" : ""
+        }
+    }
     suspicionConclusionTargetConnected(el) {
         el.dispatchEvent(new Event("change"))
     }
 
-    onUpdateDom() {
-        if (this.treeselect === undefined) return
-        patchItems(this.treeselect.srcElement)
-    }
+    #syncTreeselects() {
+        if (!this.treeselectConfirmedOutlet || !this.treeselectSuspectedOutlet) return
 
-    onTreeselectInput({detail}) {
-        if (detail.length === 0) {
-            this.selectedHazardTreeselectInputTarget.value = ""
-            this.element.querySelectorAll("[id^='shortcut_']").forEach(checkbox => {
-                checkbox.checked = false
-            })
-        } else {
-            this.selectedHazardTreeselectInputTarget.value = detail.join("||")
-        }
-    }
+        const value = this.suspicionConclusionValue
+        const isConfirmed = value === this.suspicionConclusionChoicesValue.CONFIRMED.value
+        const isSuspected = value === this.suspicionConclusionChoicesValue.SUSPECTED.value
 
-    treeselectOpenCallback() {
-        if (this.suspicionConclusionValue === this.suspicionConclusionChoicesValue.CONFIRMED.value) {
-            patchItems(this.treeselect.srcElement)
-            if (this.treeselect.srcElement.querySelectorAll(".categorie-danger-header").length !== 0) {
-                showHeader(this.treeselect.srcElement, ".categorie-danger-header")
-                return
-            }
-            const list = this.selectedHazardTreeselectTarget.querySelector(".treeselect-list")
-            if (list) {
-                const fragment = this.selectedHazardTreeselectHeaderTarget.content.cloneNode(true)
-                list.prepend(fragment)
-                this.customHeaderAddedValue = true
-            }
-        }
-    }
+        this.treeselectConfirmedOutlet.setDisabledState(!isConfirmed)
+        if (!isConfirmed) this.treeselectConfirmedOutlet.unselectAll()
 
-    onShortcut({target}) {
-        const label = target.getElementsByTagName("label")[0]
-        const value = label.textContent.trim()
-        const checkbox = this.selectedHazardTreeselectTarget.querySelector(`[id$="${label.getAttribute("for")}"]`)
-        checkbox.checked = !checkbox.checked
-
-        const valuesToSet = this.treeselect.value
-        if (checkbox.checked) {
-            valuesToSet.push(value)
-        } else {
-            valuesToSet.pop(value)
-        }
-
-        this.treeselect.updateValue(valuesToSet)
-        this.selectedHazardTreeselectInputTarget.value = valuesToSet.join("||")
-        let text = ""
-        if (valuesToSet.length === 1) {
-            text = valuesToSet[0]
-        } else {
-            text = `${valuesToSet.length} ${this.treeselect.tagsCountText}`
-        }
-        this.selectedHazardTreeselectTarget.querySelector(".treeselect-input__tags-count").innerText = text
+        this.treeselectSuspectedOutlet.setDisabledState(!isSuspected)
+        if (!isSuspected) this.treeselectSuspectedOutlet.unselectAll()
     }
 
     suspicionConclusionValueChanged(value) {
-        if (this.treeselect === undefined) return
+        const isConfirmed = value === this.suspicionConclusionChoicesValue.CONFIRMED.value
+        const isSuspected = value === this.suspicionConclusionChoicesValue.SUSPECTED.value
+        const isDiscarded = value === this.suspicionConclusionChoicesValue.DISCARDED.value
 
-        this.conclusionRepasTarget.disabled = false
-        this.conclusionRepasTarget.required = false
-        this.conclusionAlimentTarget.disabled = false
-        if (value === this.suspicionConclusionChoicesValue.CONFIRMED.value) {
-            this.conclusionRepasTarget.required = true
-            this.treeselect.disabled = false
-            this.treeselect.placeholder = "Choisir dans la liste d’après les résultats d’analyse"
-            this.selectedHazardTreeselectInputTarget.required = true
-            this.treeselect.options = this.selectedHazardConfirmedChoicesValue
-            this.treeselect.mount()
-        } else if (value === this.suspicionConclusionChoicesValue.SUSPECTED.value) {
-            this.conclusionRepasTarget.required = true
-            this.treeselect.disabled = false
-            this.treeselect.placeholder = "Choisir dans la liste parmi les dangers syndromiques"
-            this.selectedHazardTreeselectInputTarget.required = true
-            this.treeselect.options = this.selectedHazardSuspectedChoicesValue
-            this.treeselect.mount()
-        } else if (value === this.suspicionConclusionChoicesValue.DISCARDED.value) {
-            this.treeselect.options = []
-            this.treeselect.placeholder = "Choisir dans la liste"
-            this.treeselect.disabled = true
+        this.conclusionRepasTarget.disabled = isDiscarded
+        this.conclusionRepasTarget.required = isConfirmed || isSuspected
+        this.requiredProxyTarget.required = isConfirmed || isSuspected
+        this.conclusionAlimentTarget.disabled = isDiscarded
+
+        if (isDiscarded) {
             this.conclusionRepasTarget.value = ""
-            this.conclusionRepasTarget.disabled = true
             this.conclusionAlimentTarget.value = ""
-            this.conclusionAlimentTarget.disabled = true
-            this.selectedHazardTreeselectInputTarget.required = false
-            this.treeselect.mount()
-        } else if (value === this.suspicionConclusionChoicesValue.UNKNOWN.value) {
-            this.treeselect.options = []
-            this.treeselect.placeholder = "Choisir dans la liste"
-            this.treeselect.disabled = true
-            this.selectedHazardTreeselectInputTarget.required = false
-            this.treeselect.mount()
         }
 
-        if (this.selectedHazardTreeselectInitializedValue) {
-            this.treeselect.updateValue("")
-            this.selectedHazardTreeselectInputTarget.value = ""
-        } else if (value) {
-            this.treeselect.updateValue(this.selectedHazardTreeselectInputTarget.value.split("||"))
-            this.selectedHazardTreeselectInitializedValue = true
-        }
+        // Still show this fields as a "fake" one for Discarded, Unknwon and no value
+        this.selectedHazardConfirmedContainerTarget.classList.toggle("fr-hidden", isSuspected)
+        this.selectedHazardConfirmedContainerTarget
+            .querySelector("label")
+            .classList.toggle("required-field", isConfirmed)
+
+        this.selectedHazardSuspectedContainerTarget.classList.toggle("fr-hidden", !isSuspected)
+        this.selectedHazardSuspectedContainerTarget
+            .querySelector("label")
+            .classList.toggle("required-field", isSuspected)
 
         if (this.suspicionConclusionTarget.selectedOptions?.[0]?.dataset?.needsNotice === "true") {
             this.noticeTarget.classList.remove("fr-hidden")
         } else {
             this.noticeTarget.classList.add("fr-hidden")
         }
+        this.#syncTreeselects()
+        this.#syncRequiredProxyValue()
     }
 
     onSuspicionConclusionChanged({target: {value}}) {

--- a/tiac/templates/tiac/forms/conclusion.html
+++ b/tiac/templates/tiac/forms/conclusion.html
@@ -21,8 +21,7 @@
                                 class="fr-fieldset fr-flex fr-flex--align-normal form-fieldset fr-mt-2w"
                                 data-controller="conclusion-form"
                                 data-conclusion-form-suspicion-conclusion-choices-value="{{ form.SuspicionConclusion.as_json }}"
-                                data-conclusion-form-selected-hazard-confirmed-choices-value="{{ form.selected_hazard_confirmed_choices }}"
-                                data-conclusion-form-selected-hazard-suspected-choices-value="{{ form.selected_hazard_suspected_choices }}"
+                                data-conclusion-form-treeselect-outlet="#treeselect-confirmed .fr-treeselect, #treeselect-suspected .fr-treeselect"
                             >
                                 <p>Certains champs ont été préremplis à partir des éléments de la fiche. Vous pouvez les modifier.</p>
 
@@ -32,38 +31,14 @@
                                     {% dsfr_notice title="Êtes vous sûr qu'il ne s'agit pas d'une tiac à agent confirmé ? Un danger détecté sur les malades ou les aliments est enregistré dans la fiche. Pour rappel, un agent peut être confirmé soit par des analyses effectuées sur les malades, soit par des analyses effectuées sur les aliments ou leur environnement de production." %}
                                 </div>
 
-                                <div id="selected_hazard-treeselect" class="fr-input-group">
-                                    {{ form.selected_hazard.label_tag }}
-                                    {{ form.selected_hazard|set_data:"conclusion-form-target:selectedHazardTreeselectInput" }}
-                                    <div
-                                        data-conclusion-form-target="selectedHazardTreeselect"
-                                        data-action="input->conclusion-form#onTreeselectInput update-dom->conclusion-form#onUpdateDom"
-                                    ></div>
-                                    <template data-conclusion-form-target="selectedHazardTreeselectHeader">
-                                        <div class="categorie-danger-header">
-                                            <div class="fr-ml-1v">Dangers les plus courants</div>
-                                            {% for danger in form.common_danger %}
-                                                <div
-                                                    class="treeselect-list__item"
-                                                    level="0"
-                                                    group="false"
-                                                    data-action="mousedown->conclusion-form#onShortcut:prevent:stop"
-                                                >
-                                                    <input
-                                                        type="checkbox"
-                                                        id="shortcut_{{ forloop.counter0 }}"
-                                                        class="treeselect-list__item-checkbox-container"
-                                                    >
-                                                    <label
-                                                        class="treeselect-list__item-label shortcut"
-                                                        for="shortcut_{{ forloop.counter0 }}"
-                                                    >{{ danger }}</label>
-                                                </div>
-                                            {% endfor %}
-                                            <div class="fr-ml-1v">Liste complète des dangers</div>
-                                        </div>
-                                    </template>
+                                <div class="fr-input-group" id="treeselect-confirmed" data-conclusion-form-target="selectedHazardConfirmedContainer">
+                                    {% dsfr_form_field form.selected_hazard_confirmed %}
                                 </div>
+                                <div class="fr-input-group" id="treeselect-suspected" data-conclusion-form-target="selectedHazardSuspectedContainer">
+                                    {% dsfr_form_field form.selected_hazard_suspected %}
+                                </div>
+                                <input data-conclusion-form-target="requiredProxy" id="required-proxy" required>
+
                                 {% dsfr_form_field form.conclusion_comment|remove_attr:"cols"|remove_attr:"rows" %}
 
                                 {% dsfr_form_field form.conclusion_repas|set_data:"conclusion-form-target:conclusionRepas"|set_data:"action:conclusion-form#onRepasChanged" %}

--- a/tiac/tests/pages.py
+++ b/tiac/tests/pages.py
@@ -718,6 +718,8 @@ class InvestigationTiacDetailsPage(WithEtablissementMixin, WithActionsPage, With
     def __init__(self, page: Page, base_url):
         self.page = page
         self.base_url = base_url
+        self.treeselect_confirmed = TreeselectPage(self.page, self.page.locator("#treeselect-confirmed"))
+        self.treeselect_suspected = TreeselectPage(self.page, self.page.locator("#treeselect-suspected"))
 
     @property
     def title(self):
@@ -793,11 +795,11 @@ class InvestigationTiacDetailsPage(WithEtablissementMixin, WithActionsPage, With
 
     @property
     def selected_hazard_label(self):
-        return self.page.locator("[for=id_selected_hazard]")
+        return self.page.locator("label", has_text="Dangers retenus").filter(visible=True)
 
     @property
     def selected_hazard_hidden_field(self):
-        return self.page.locator("#id_selected_hazard")
+        return self.page.locator("#required-proxy")
 
     @property
     def delete_conclusion_button(self):
@@ -827,15 +829,14 @@ class InvestigationTiacDetailsPage(WithEtablissementMixin, WithActionsPage, With
             }"""
         )
         if input_data["suspicion_conclusion"] == SuspicionConclusion.CONFIRMED:
-            self.clear_treeselect("selected_hazard-treeselect")
+            self.treeselect_confirmed.uncheck_all()
             for item in input_data["selected_hazard"]:
                 final_label = CategorieDanger(item).label.split(">")[-1].strip()
-                self._set_treeselect_option_by_search_term("selected_hazard-treeselect", final_label, final_label)
+                self.treeselect_confirmed.check_option(final_label)
         elif input_data["suspicion_conclusion"] == SuspicionConclusion.SUSPECTED:
-            self.clear_treeselect("selected_hazard-treeselect")
+            self.treeselect_suspected.uncheck_all()
             for item in input_data["selected_hazard"]:
-                label = DangersSyndromiques(item).short_name
-                self._set_treeselect_option_by_search_term("selected_hazard-treeselect", label, label)
+                self.treeselect_suspected.check_option(DangersSyndromiques(item).short_name)
         self.page.locator("#id_conclusion_comment").fill(input_data["conclusion_comment"])
 
         if input_data["suspicion_conclusion"] != SuspicionConclusion.DISCARDED:

--- a/tiac/tests/test_investigation_conclusion.py
+++ b/tiac/tests/test_investigation_conclusion.py
@@ -162,7 +162,9 @@ def test_edit_investigation_show_previous_danger_value(live_server, page: Page):
     detail_page = InvestigationTiacDetailsPage(page, live_server.url)
     detail_page.navigate(evenement)
     detail_page.edit_conclusion_button.click()
-    expect(detail_page.current_modal.get_by_text("Allergène - Lait")).to_be_visible()
+    expect(
+        detail_page.current_modal.get_by_role("button", name="Allergène - composition ou étiquetage > Allergène - Lait")
+    ).to_be_visible()
 
 
 def test_edit_investigation_show_previous_danger_values(live_server, page: Page):
@@ -178,7 +180,7 @@ def test_edit_investigation_show_previous_danger_values(live_server, page: Page)
     detail_page = InvestigationTiacDetailsPage(page, live_server.url)
     detail_page.navigate(evenement)
     detail_page.edit_conclusion_button.click()
-    expect(detail_page.current_modal.get_by_text("3 éléments sélectionnés")).to_be_visible()
+    expect(detail_page.current_modal.get_by_text("3 éléments")).to_be_visible()
 
 
 def test_conclusion_investigation_tiac_conditional_ui(
@@ -333,7 +335,7 @@ def test_conclusion_form_is_initialized_when_dangers_syndromiques_are_not_set(li
     detail_page.navigate(evenement)
     detail_page.add_conclusion_button.click()
     expect(detail_page.suspicion_conclusion_field).to_have_value("")
-    expect(detail_page.page.locator("#selected_hazard-treeselect .treeselect--disabled")).to_have_count(1)
+    expect(detail_page.page.locator("#treeselect-confirmed .fr-treeselect--disabled")).to_have_count(1)
 
 
 def test_conclusion_form_shows_notice_when_multiple_repas(live_server, page: Page):


### PR DESCRIPTION
- I had to play around with the outlets in order to make them required / enabled / empty when needed
- We still needed an hidden field to fake the fact that this field is required (not possible for the checkboxes)
___

@christophehenry je me suis demandé si pour les checkboxes avoir une option "required" ne pourrait pas faire partie intégrante du treeselect (a priori on l'a que pour ce cas ci ?). Je l'ai mis à part pour le moment