### PR TITLE
Remove contact addition notifications in SV context

### DIFF
--- a/core/notifications.py
+++ b/core/notifications.py
@@ -155,6 +155,8 @@ def notify_contact_agent_added_or_removed(contact: Contact, obj, added, user):
     if added is False:
         if contact.structure == users_structure or (contact.agent and contact.agent.structure == users_structure):
             return  # Never send the notification if the removal is performed by a user inside the same structure
+    if added is True and getattr(obj, "need_notification_contact_added", False) is False:
+        return
 
     action = "ajouté au" if added else "retiré du"
     subject = "Ajout aux contacts" if added else "Retrait des contacts"

--- a/core/tests/generic_tests/contacts.py
+++ b/core/tests/generic_tests/contacts.py
@@ -21,10 +21,13 @@ def generic_test_add_contact_agent_to_an_evenement(live_server, page, choice_js_
     assert page.get_by_test_id("contacts-agents").count() == 1
     assert object.__class__.objects.filter(pk=object.pk, contacts=contact).exists()
 
-    assert len(mailoutbox) == 1
-    mail = mailoutbox[0]
-    assert "Ajout aux contacts" in mail.subject
-    assert "Vous avez été ajouté au suivi de l’évènement" in mail.body
+    if not getattr(object, "need_notification_contact_added", False):
+        assert len(mailoutbox) == 0
+    else:
+        assert len(mailoutbox) == 1
+        mail = mailoutbox[0]
+        assert "Ajout aux contacts" in mail.subject
+        assert "Vous avez été ajouté au suivi de l’évènement" in mail.body
 
 
 def generic_test_add_contact_structure_to_an_evenement(live_server, page, choice_js_fill, object, mailoutbox):
@@ -40,10 +43,13 @@ def generic_test_add_contact_structure_to_an_evenement(live_server, page, choice
     assert page.get_by_test_id("contacts-structures").count() == 1
     assert object.__class__.objects.filter(pk=object.pk, contacts=contact_structure).exists()
 
-    assert len(mailoutbox) == 1
-    mail = mailoutbox[0]
-    assert "Ajout aux contacts" in mail.subject
-    assert "Vous avez été ajouté au suivi de l’évènement" in mail.body
+    if not getattr(object, "need_notification_contact_added", False):
+        assert len(mailoutbox) == 0
+    else:
+        assert len(mailoutbox) == 1
+        mail = mailoutbox[0]
+        assert "Ajout aux contacts" in mail.subject
+        assert "Vous avez été ajouté au suivi de l’évènement" in mail.body
 
 
 def generic_test_add_contact_structure_to_an_evenement_with_dedicated_email(
@@ -64,11 +70,14 @@ def generic_test_add_contact_structure_to_an_evenement_with_dedicated_email(
     expect(page.get_by_text("testemail@test.com", exact=True)).to_be_visible()
     assert object.__class__.objects.filter(pk=object.pk, contacts=contact_structure).exists()
 
-    assert len(mailoutbox) == 1
-    mail = mailoutbox[0]
-    assert "Ajout aux contacts" in mail.subject
-    assert "Vous avez été ajouté au suivi de l’évènement" in mail.body
-    assert mail.to == ["testemail@test.com"], f"Got {mail.to}"
+    if not getattr(object, "need_notification_contact_added", False):
+        assert len(mailoutbox) == 0
+    else:
+        assert len(mailoutbox) == 1
+        mail = mailoutbox[0]
+        assert "Ajout aux contacts" in mail.subject
+        assert "Vous avez été ajouté au suivi de l’évènement" in mail.body
+        assert mail.to == ["testemail@test.com"], f"Got {mail.to}"
 
 
 def generic_test_remove_contact_agent_from_an_evenement(live_server, page, object, mailoutbox):
@@ -131,9 +140,12 @@ def generic_test_add_multiple_contacts_agents_to_an_evenement(live_server, page,
         )
     ).to_be_visible()
 
-    assert len(mailoutbox) == 2
-    assert "Ajout aux contacts" in mailoutbox[0].subject
-    assert "Ajout aux contacts" in mailoutbox[1].subject
+    if not getattr(object, "need_notification_contact_added", False):
+        assert len(mailoutbox) == 0
+    else:
+        assert len(mailoutbox) == 2
+        assert "Ajout aux contacts" in mailoutbox[0].subject
+        assert "Ajout aux contacts" in mailoutbox[1].subject
 
 
 def generic_test_cant_add_contact_agent_if_he_cant_access_domain(live_server, page, choice_js_cant_pick, object):

--- a/sv/models/evenements.py
+++ b/sv/models/evenements.py
@@ -45,6 +45,8 @@ class Evenement(
     WithBlocCommunFieldsMixin,
     models.Model,
 ):
+    need_notification_contact_added = True
+
     numero_annee = models.IntegerField(verbose_name="Année")
     numero_evenement = models.IntegerField(verbose_name="Numéro")
     organisme_nuisible = models.ForeignKey(


### PR DESCRIPTION
#### Supprimer la notification “Ajout aux contacts” pour les Agents et Structures

Pour SSA et TIAC, supprimer la notification d'ajout aux contacts.

[Ticket Notion](https://app.notion.com/p/incubateur-masa/Supprimer-la-notification-Ajout-aux-contacts-pour-les-Agents-et-Structures-3a5de24614be808b887be071e8747b96?source=copy_link)