### PR TITLE
Correction du déploiment de la recette

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/Scalingo/python-buildpack
 https://github.com/Scalingo/apt-buildpack.git
+https://github.com/Scalingo/python-buildpack

--- a/bin/post_compile
+++ b/bin/post_compile
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 export PYTHONPATH=/build/${REQUEST_ID}/.apt/usr/lib/python3/dist-packages/:${PYTHONPATH}
+export LD_LIBRARY_PATH=/build/${REQUEST_ID}/.apt/usr/lib/x86_64-linux-gnu/blas/:/build/${REQUEST_ID}/.apt/usr/lib/x86_64-linux-gnu/lapack/:${LD_LIBRARY_PATH}
+export PROJ_LIB=/build/${REQUEST_ID}/.apt/usr/share/proj
 
 # collect static
 python manage.py collectstatic --noinput


### PR DESCRIPTION
Il faudra penser à paramétrer :

```
DISABLE_COLLECTSTATIC=1
LD_LIBRARY_PATH=/app/.apt/usr/lib/x86_64-linux-gnu/blas/:/app/.apt/usr/lib/x86_64-linux-gnu/lapack/
PROJ_LIB=/app/.apt/usr/share/proj
```

sur les environnements de prod et pré-prod au moment de la MEP. C'est déjà fait en recette.