### PR TITLE
Correction des tests du Treeselect instables

### DIFF
--- a/core/tests/pages.py
+++ b/core/tests/pages.py
@@ -132,7 +132,7 @@ class TreeselectPage:
         if self.options_container.is_visible():
             return
         self.main_button.click()
-        expect(self.options_container).to_be_visible()
+        expect(self.search_bar).to_be_focused()
 
     @playwright_repeatable
     def close_treeselect(self):


### PR DESCRIPTION
Il semble que le focus asynchrone sur le champ de recherche du treeselect rende les tests instables. Puisqu'on a désactivé toutes les animations sur le treeselect le code écrit pour gérer ce problème n'a plus lieu d'être. Y'a des chances que ça améliore la situation.