### PR TITLE
Add tooltips on animal status

### DIFF
--- a/core/static/core/base.css
+++ b/core/static/core/base.css
@@ -258,6 +258,12 @@ fieldset {
     display: flex;
 }
 
+.fr-fieldset__element--with-tooltip {
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+}
+
 .generic-card-container {
     padding: 1.5rem;
     margin-bottom: 2rem;

--- a/core/templates/core/templatetags/inline_radio_snippet.html
+++ b/core/templates/core/templatetags/inline_radio_snippet.html
@@ -1,4 +1,4 @@
-{% load widget_tweaks dsfr_tags %}
+{% load widget_tweaks dsfr_tags get_item %}
 <fieldset class="fr-fieldset{% if field.errors %} fr-fieldset--error{% endif %} fieldset-flex"
           id="radio-{{ field.auto_id }}"
           aria-labelledby="{{ field.auto_id }}-legend{% if field.errors %} {{ field.auto_id }}-desc-error{% endif %}">
@@ -12,9 +12,14 @@
   <div class="fieldset-flex-options">
     {% with field=field|dsfr_input_class_attr %}
       {% for subwidget in field.subwidgets %}
-        <div class="fr-fieldset__element{% if field.field.widget.inline %} fr-fieldset__element--inline{% endif %}">
-          {{ subwidget }}
-        </div>
+        {% with tooltip_content=tooltips|get_item:subwidget.data.value %}
+          <div class="fr-fieldset__element{% if field.field.widget.inline %} fr-fieldset__element--inline{% endif %}{% if tooltip_content %} fr-fieldset__element--with-tooltip{% endif %}">
+            {{ subwidget }}
+            {% if tooltip_content %}
+              {% dsfr_tooltip content=tooltip_content is_clickable=True id=subwidget.id_for_label|add:"-tooltip" %}
+            {% endif %}
+          </div>
+        {% endwith %}
       {% endfor %}
     {% endwith %}
   </div>

--- a/core/templatetags/render_field_with_inline_label.py
+++ b/core/templatetags/render_field_with_inline_label.py
@@ -4,8 +4,8 @@ register = template.Library()
 
 
 @register.inclusion_tag("core/templatetags/inline_radio_snippet.html")
-def dsfr_inline_radio_field(field) -> dict:
+def dsfr_inline_radio_field(field, tooltips=None) -> dict:
     if field == "":
         raise AttributeError("Invalid form field name in dsfr_form_field.")
 
-    return {"field": field}
+    return {"field": field, "tooltips": tooltips or {}}

--- a/sa/forms/evenement.py
+++ b/sa/forms/evenement.py
@@ -15,6 +15,11 @@ from sa.models.evenement import ContexteSuspicion, EvenementAnimal, HumanInvolve
 
 
 class EvenementAnimalPreCreationForm(DsfrBaseForm):
+    STATUT_ANIMAL_TOOLTIPS = {
+        StatutAnimal.SAUVAGE: "Animal vivant à l'état naturel, non soumis à la surveillance humaine directe",
+        StatutAnimal.DETENU: "Animal maintenu sous la responsabilité d'une personne (élevage, zoo, particulier, ruche…)",
+    }
+
     maladie = forms.ModelChoiceField(queryset=Maladie.objects.all())
     espece = forms.ModelChoiceField(queryset=Espece.objects.all())
     statut_animal = forms.ChoiceField(

--- a/sa/templates/sa/base.html
+++ b/sa/templates/sa/base.html
@@ -28,7 +28,7 @@
                             <form method="get" action="{% url 'sa:evenement-animal-creation' %}">
                                 {% dsfr_form_field pre_creation_form.maladie  %}
                                 {% dsfr_form_field pre_creation_form.espece  %}
-                                {% dsfr_inline_radio_field pre_creation_form.statut_animal %}
+                                {% dsfr_inline_radio_field pre_creation_form.statut_animal tooltips=pre_creation_form.STATUT_ANIMAL_TOOLTIPS %}
                                 <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-mt-4w">
                                     <button class="fr-btn fr-btn--secondary" aria-controls="modal-pre-creation" type="button">Annuler</button>
                                     <button type="submit" class="fr-btn">Suivant > </button>


### PR DESCRIPTION
### Add tooltips on animal status « Sauvage » and « Détenu »

- Define tooltips appropriate display contents in `EvenementAnimalPreCreationForm` 🏷️ 
- Adapt the radio snippet so it's able to display optional tooltips 🔘 

This relies on the feature description available in [this related Notion ticket](https://app.notion.com/p/incubateur-masa/Ajouter-des-infobulles-sur-les-statuts-Sauvage-et-D-tenu-3acde24614be80839f3dd80251604fd4?v=14dde24614be81169a41000cb299fcd0&source=copy_link) 📄 