### PR TITLE
Allow the setting of map initial style & set it to satellite view

### DIFF
--- a/core/static/core/base_map.mjs
+++ b/core/static/core/base_map.mjs
@@ -1,9 +1,16 @@
 import {StyleSwitcherControl} from "MapStyleSwitcher"
 import {Controller} from "Stimulus"
 
+export const OSM_STYLE_URL = "https://openmaptiles.data.gouv.fr/styles/osm-bright/style.json"
+
 export class BaseMapController extends Controller {
     static values = {
         jsonFile: String,
+        defaultStyle: {type: String, default: "osm"},
+    }
+
+    get initialStyleUrl() {
+        return this.defaultStyleValue === "satellite" ? this.jsonFileValue : OSM_STYLE_URL
     }
 
     addStyleSwitcher() {
@@ -11,20 +18,20 @@ export class BaseMapController extends Controller {
             {
                 id: "osm",
                 name: "Carte",
-                styleUrl: "https://openmaptiles.data.gouv.fr/styles/osm-bright/style.json",
+                styleUrl: OSM_STYLE_URL,
                 description: "Carte",
             },
             {
                 id: "satellite",
-                name: "Vue Satellite",
+                name: "Satellite",
                 styleUrl: this.jsonFileValue,
-                description: "Vue Satellite",
+                description: "Satellite",
             },
         ]
 
         const control = new StyleSwitcherControl({
             styles,
-            activeStyleId: "osm",
+            activeStyleId: this.defaultStyleValue,
             theme: "auto",
             showImages: false,
             onAfterStyleChange: (_from, to) => {

--- a/core/static/core/map.mjs
+++ b/core/static/core/map.mjs
@@ -117,7 +117,7 @@ class MapController extends BaseMapController {
             center: center,
             zoom: zoom,
             attributionControl: false,
-            style: "https://openmaptiles.data.gouv.fr/styles/osm-bright/style.json",
+            style: this.initialStyleUrl,
         })
         this.addStyleSwitcher()
         this.map.addControl(

--- a/core/static/core/map_viewer.mjs
+++ b/core/static/core/map_viewer.mjs
@@ -15,7 +15,7 @@ class MapViewerController extends BaseMapController {
             center: center,
             zoom: 10,
             attributionControl: false,
-            style: "https://openmaptiles.data.gouv.fr/styles/osm-bright/style.json",
+            style: this.initialStyleUrl,
         })
         this.addStyleSwitcher()
         this.map.addControl(

--- a/sa/templates/sa/evenement_animal_form.html
+++ b/sa/templates/sa/evenement_animal_form.html
@@ -141,6 +141,7 @@
                 <div class="fr-grid-row fr-grid-row--gutters fr-col"
                      data-controller="map address-search-autocomplete"
                      data-map-json-file-value="{% static 'core/style_ign.json' %}"
+                     data-map-default-style-value="satellite"
                      data-map-reverse-api-value="{{ REVERSE_GEO_API }}"
                      data-map-geo-api-root-value="{{ GEO_API_ROOT }}"
                      data-map-region-value="{{ form.structure.region.nom }}"


### PR DESCRIPTION
### In SA, display the map in satellite view by default

- Define a configurable default style value 💅 
- Slightly tweak style display wording ✍️ 

This relies on the feature description available in [this related Notion ticket](https://app.notion.com/p/incubateur-masa/Afficher-la-carte-en-vue-satellite-par-d-faut-3acde24614be80eda484c749cc98bc65?v=14dde24614be81169a41000cb299fcd0&source=copy_link) 📄 