### PR TITLE
Display a confirmation modal when switching the etablissement type

### DIFF
--- a/sa/static/sa/detenteur.mjs
+++ b/sa/static/sa/detenteur.mjs
@@ -1,11 +1,75 @@
 import {applicationReady} from "Application"
+import {resetForm} from "Forms"
 import {Controller} from "Stimulus"
 
 class DetenteurFormController extends Controller {
-    static targets = ["etablissementForm", "particulierForm", "numeroIdentifiantEtablissement", "nomParticulier"]
+    static targets = [
+        "etablissementForm",
+        "particulierForm",
+        "numeroIdentifiantEtablissement",
+        "nomParticulier",
+        "etablissementRadio",
+        "particulierRadio",
+        "confirmModal",
+    ]
 
     connect() {
+        this.currentType = "etablissement"
+        // Type we're about to switch to, waiting for confirmation in the modal
+        this.pendingType = null
         this.showEtablissement()
+    }
+
+    onEtablissementLabelClick(event) {
+        this.handleTypeClick(event, "etablissement")
+    }
+
+    onParticulierLabelClick(event) {
+        this.handleTypeClick(event, "particulier")
+    }
+
+    handleTypeClick(event, type) {
+        if (type === this.currentType) {
+            return
+        }
+        if (this.currentBlockHasData()) {
+            // preventDefault prevents the click on the <label> from checking its radio input:
+            // the switch only happens once the user confirms in the modal
+            event.preventDefault()
+            this.pendingType = type
+            dsfr(this.confirmModalTarget).modal.disclose()
+        } else {
+            this.switchTo(type)
+        }
+    }
+
+    onConfirmSwitch() {
+        resetForm(this.currentType === "etablissement" ? this.etablissementFormTarget : this.particulierFormTarget)
+        this.switchTo(this.pendingType)
+        this.pendingType = null
+        dsfr(this.confirmModalTarget).modal.conceal()
+    }
+
+    onCancelSwitch() {
+        this.pendingType = null
+        dsfr(this.confirmModalTarget).modal.conceal()
+    }
+
+    switchTo(type) {
+        this.currentType = type
+        // Check the radio manually (as the native check was prevented in handleTypeClick)
+        if (type === "etablissement") {
+            this.etablissementRadioTarget.checked = true
+            this.showEtablissement()
+        } else {
+            this.particulierRadioTarget.checked = true
+            this.showParticulier()
+        }
+    }
+
+    currentBlockHasData() {
+        const target = this.currentType === "etablissement" ? this.etablissementFormTarget : this.particulierFormTarget
+        return [...target.querySelectorAll("input, select, textarea")].some(field => field.value.trim() !== "")
     }
 
     showEtablissement() {

--- a/sa/static/sa/detenteur.mjs
+++ b/sa/static/sa/detenteur.mjs
@@ -14,10 +14,17 @@ class DetenteurFormController extends Controller {
     ]
 
     connect() {
-        this.currentType = "etablissement"
+        this.currentType = this.particulierRadioTarget.checked ? "particulier" : "etablissement"
         // Type we're about to switch to, waiting for confirmation in the modal
         this.pendingType = null
-        this.showEtablissement()
+        if (this.currentType === "particulier") {
+            this.showParticulier()
+        } else {
+            this.showEtablissement()
+        }
+        this.confirmModalTarget.addEventListener("close", () => {
+            this.pendingType = null
+        })
     }
 
     onEtablissementLabelClick(event) {

--- a/sa/templates/sa/evenement_animal_form.html
+++ b/sa/templates/sa/evenement_animal_form.html
@@ -80,17 +80,45 @@
                     <legend class="fr-fieldset__legend fr-h3">Détenteur</legend>
                 </div>
 
+                <dialog id="detenteur-type-change-modal" class="fr-modal" aria-labelledby="detenteur-type-change-modal-title" data-detenteur-form-target="confirmModal">
+                    <div class="fr-container fr-container--fluid fr-container-md">
+                        <div class="fr-grid-row fr-grid-row--center">
+                            <div class="fr-col-12 fr-col-md-8 fr-col-lg-6">
+                                <div class="fr-modal__body">
+                                    <div class="fr-modal__header">
+                                        <button aria-controls="detenteur-type-change-modal" title="Fermer" type="button" class="fr-btn--close fr-btn" data-action="click->detenteur-form#onCancelSwitch">Fermer</button>
+                                    </div>
+                                    <div class="fr-modal__content">
+                                        <h2 id="detenteur-type-change-modal-title" class="fr-modal__title">
+                                            Changement de type de détenteur
+                                        </h2>
+                                        <p>Un détenteur ne peut avoir qu'un seul statut : établissement ou particulier. Si vous continuez, les informations saisies dans l'onglet actuel seront perdues.</p>
+                                    </div>
+                                    <div class="fr-modal__footer">
+                                        <div class="fr-btns-group fr-btns-group--right fr-btns-group--inline-lg fr-btns-group--icon-left">
+                                            <button class="fr-btn fr-btn--secondary" type="button" data-action="click->detenteur-form#onCancelSwitch">
+                                                Annuler
+                                            </button>
+                                            <button class="fr-btn" type="button" data-action="click->detenteur-form#onConfirmSwitch">Continuer</button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </dialog>
+
                 <div class="fr-grid-row fr-grid-row--gutters fr-col">
                     <div class="fr-col-12">
                         <fieldset class="fr-segmented">
                             <div class="fr-segmented__elements">
                                 <div class="fr-segmented__element">
-                                    <input value="etablissement" checked type="radio" id="etablissement-btn" name="type_detenteur">
-                                    <label class="fr-label" for="etablissement-btn" data-action="click->detenteur-form#showEtablissement">Établissement</label>
+                                    <input value="etablissement" checked type="radio" id="etablissement-btn" name="type_detenteur" data-detenteur-form-target="etablissementRadio">
+                                    <label class="fr-label" for="etablissement-btn" data-action="click->detenteur-form#onEtablissementLabelClick">Établissement</label>
                                 </div>
                                 <div class="fr-segmented__element">
-                                    <input value="particulier" type="radio" id="particulier-btn" name="type_detenteur">
-                                    <label class="fr-label" for="particulier-btn" data-action="click->detenteur-form#showParticulier">Particulier</label>
+                                    <input value="particulier" type="radio" id="particulier-btn" name="type_detenteur" data-detenteur-form-target="particulierRadio">
+                                    <label class="fr-label" for="particulier-btn" data-action="click->detenteur-form#onParticulierLabelClick">Particulier</label>
                                 </div>
                             </div>
                         </fieldset></div>

--- a/sa/tests/pages.py
+++ b/sa/tests/pages.py
@@ -156,6 +156,20 @@ class EvenementAnimalFormPage(WithPreCreationFormPage, WithAddressAndCommuneUtil
     def particulier_label(self):
         return self.page.locator("label", has_text="Particulier")
 
+    @property
+    def etablissement_label(self):
+        return self.page.locator("label", has_text="Établissement")
+
+    @property
+    def type_change_modal(self):
+        return self.page.locator("#detenteur-type-change-modal")
+
+    def confirm_type_change(self):
+        self.type_change_modal.get_by_role("button", name="Continuer").click()
+
+    def cancel_type_change(self):
+        self.type_change_modal.get_by_role("button", name="Annuler").click()
+
     def fill_required_fields(self, evenement: EvenementAnimal):
         self.statut_evenement.select_option(evenement.statut_evenement)
         self.date_statut_changed.fill(evenement.date_statut_changed.strftime("%Y-%m-%d"))

--- a/sa/tests/test_evenement_animal_creation.py
+++ b/sa/tests/test_evenement_animal_creation.py
@@ -1,6 +1,6 @@
 import json
 
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 from sa.models import EvenementAnimal
 from sa.tests.factories import EspeceFactory, EvenementAnimalFactory, MaladieFactory
@@ -194,3 +194,105 @@ def test_can_create_evenement_animal_with_detenteur_particulier_block(live_serve
     ]
     for field in fields:
         assert getattr(evenement_produit, field) == getattr(input_data, field)
+
+
+def test_no_confirmation_modal_when_switching_detenteur_type_without_data(
+    live_server, mocked_authentification_user, page: Page
+):
+    input_data = EvenementAnimalFactory.build()
+    maladie = MaladieFactory()
+    espece = EspeceFactory()
+
+    creation_page = EvenementAnimalFormPage(page, live_server.url)
+    creation_page.navigate(maladie, espece, input_data.statut_animal)
+
+    creation_page.particulier_label.click()
+
+    expect(creation_page.type_change_modal).not_to_be_visible()
+    expect(creation_page.nom_particulier).to_be_visible()
+    expect(creation_page.numero_identifiant_etablissement).to_be_hidden()
+
+
+def test_confirmation_modal_when_switching_from_etablissement_to_particulier_with_data(
+    live_server, mocked_authentification_user, page: Page
+):
+    input_data = EvenementAnimalFactory.build()
+    maladie = MaladieFactory()
+    espece = EspeceFactory()
+
+    creation_page = EvenementAnimalFormPage(page, live_server.url)
+    creation_page.navigate(maladie, espece, input_data.statut_animal)
+    creation_page.numero_identifiant_etablissement.fill(input_data.numero_identifiant_etablissement)
+    creation_page.raison_sociale_etablissement.fill(input_data.raison_sociale_etablissement)
+
+    creation_page.particulier_label.click()
+
+    expect(creation_page.type_change_modal).to_be_visible()
+    expect(creation_page.numero_identifiant_etablissement).to_be_visible()
+
+
+def test_cancelling_detenteur_type_change_keeps_current_type_and_data(
+    live_server, mocked_authentification_user, page: Page
+):
+    input_data = EvenementAnimalFactory.build()
+    maladie = MaladieFactory()
+    espece = EspeceFactory()
+
+    creation_page = EvenementAnimalFormPage(page, live_server.url)
+    creation_page.navigate(maladie, espece, input_data.statut_animal)
+    creation_page.numero_identifiant_etablissement.fill(input_data.numero_identifiant_etablissement)
+    creation_page.raison_sociale_etablissement.fill(input_data.raison_sociale_etablissement)
+
+    creation_page.particulier_label.click()
+    creation_page.cancel_type_change()
+
+    expect(creation_page.type_change_modal).not_to_be_visible()
+    expect(creation_page.numero_identifiant_etablissement).to_be_visible()
+    assert creation_page.numero_identifiant_etablissement.input_value() == input_data.numero_identifiant_etablissement
+    assert creation_page.raison_sociale_etablissement.input_value() == input_data.raison_sociale_etablissement
+
+
+def test_confirming_detenteur_type_change_clears_previous_block_data(
+    live_server, mocked_authentification_user, page: Page
+):
+    input_data = EvenementAnimalFactory.build()
+    maladie = MaladieFactory()
+    espece = EspeceFactory()
+
+    creation_page = EvenementAnimalFormPage(page, live_server.url)
+    creation_page.navigate(maladie, espece, input_data.statut_animal)
+    creation_page.numero_identifiant_etablissement.fill(input_data.numero_identifiant_etablissement)
+    creation_page.raison_sociale_etablissement.fill(input_data.raison_sociale_etablissement)
+
+    creation_page.particulier_label.click()
+    creation_page.confirm_type_change()
+
+    expect(creation_page.type_change_modal).not_to_be_visible()
+    expect(creation_page.nom_particulier).to_be_visible()
+    expect(creation_page.numero_identifiant_etablissement).to_be_hidden()
+    assert creation_page.numero_identifiant_etablissement.input_value() == ""
+    assert creation_page.raison_sociale_etablissement.input_value() == ""
+
+
+def test_confirmation_modal_when_switching_from_particulier_to_etablissement_with_data(
+    live_server, mocked_authentification_user, page: Page
+):
+    input_data = EvenementAnimalFactory.build(particulier=True)
+    maladie = MaladieFactory()
+    espece = EspeceFactory()
+
+    creation_page = EvenementAnimalFormPage(page, live_server.url)
+    creation_page.navigate(maladie, espece, input_data.statut_animal)
+    creation_page.particulier_label.click()
+    creation_page.nom_particulier.fill(input_data.nom_particulier)
+
+    creation_page.etablissement_label.click()
+
+    expect(creation_page.type_change_modal).to_be_visible()
+
+    creation_page.confirm_type_change()
+
+    expect(creation_page.type_change_modal).not_to_be_visible()
+    expect(creation_page.numero_identifiant_etablissement).to_be_visible()
+    expect(creation_page.nom_particulier).to_be_hidden()
+    assert creation_page.nom_particulier.input_value() == ""

--- a/sa/tests/test_evenement_animal_creation.py
+++ b/sa/tests/test_evenement_animal_creation.py
@@ -196,9 +196,7 @@ def test_can_create_evenement_animal_with_detenteur_particulier_block(live_serve
         assert getattr(evenement_produit, field) == getattr(input_data, field)
 
 
-def test_no_confirmation_modal_when_switching_detenteur_type_without_data(
-    live_server, mocked_authentification_user, page: Page
-):
+def test_no_confirmation_modal_when_switching_detenteur_type_without_data(live_server, page: Page):
     input_data = EvenementAnimalFactory.build()
     maladie = MaladieFactory()
     espece = EspeceFactory()
@@ -213,9 +211,7 @@ def test_no_confirmation_modal_when_switching_detenteur_type_without_data(
     expect(creation_page.numero_identifiant_etablissement).to_be_hidden()
 
 
-def test_confirmation_modal_when_switching_from_etablissement_to_particulier_with_data(
-    live_server, mocked_authentification_user, page: Page
-):
+def test_confirmation_modal_when_switching_from_etablissement_to_particulier_with_data(live_server, page: Page):
     input_data = EvenementAnimalFactory.build()
     maladie = MaladieFactory()
     espece = EspeceFactory()
@@ -231,9 +227,7 @@ def test_confirmation_modal_when_switching_from_etablissement_to_particulier_wit
     expect(creation_page.numero_identifiant_etablissement).to_be_visible()
 
 
-def test_cancelling_detenteur_type_change_keeps_current_type_and_data(
-    live_server, mocked_authentification_user, page: Page
-):
+def test_cancelling_detenteur_type_change_keeps_current_type_and_data(live_server, page: Page):
     input_data = EvenementAnimalFactory.build()
     maladie = MaladieFactory()
     espece = EspeceFactory()
@@ -248,13 +242,11 @@ def test_cancelling_detenteur_type_change_keeps_current_type_and_data(
 
     expect(creation_page.type_change_modal).not_to_be_visible()
     expect(creation_page.numero_identifiant_etablissement).to_be_visible()
-    assert creation_page.numero_identifiant_etablissement.input_value() == input_data.numero_identifiant_etablissement
-    assert creation_page.raison_sociale_etablissement.input_value() == input_data.raison_sociale_etablissement
+    expect(creation_page.numero_identifiant_etablissement).to_have_value(input_data.numero_identifiant_etablissement)
+    expect(creation_page.raison_sociale_etablissement).to_have_value(input_data.raison_sociale_etablissement)
 
 
-def test_confirming_detenteur_type_change_clears_previous_block_data(
-    live_server, mocked_authentification_user, page: Page
-):
+def test_confirming_detenteur_type_change_clears_previous_block_data(live_server, page: Page):
     input_data = EvenementAnimalFactory.build()
     maladie = MaladieFactory()
     espece = EspeceFactory()
@@ -270,13 +262,11 @@ def test_confirming_detenteur_type_change_clears_previous_block_data(
     expect(creation_page.type_change_modal).not_to_be_visible()
     expect(creation_page.nom_particulier).to_be_visible()
     expect(creation_page.numero_identifiant_etablissement).to_be_hidden()
-    assert creation_page.numero_identifiant_etablissement.input_value() == ""
-    assert creation_page.raison_sociale_etablissement.input_value() == ""
+    expect(creation_page.numero_identifiant_etablissement).to_have_value("")
+    expect(creation_page.raison_sociale_etablissement).to_have_value("")
 
 
-def test_confirmation_modal_when_switching_from_particulier_to_etablissement_with_data(
-    live_server, mocked_authentification_user, page: Page
-):
+def test_confirmation_modal_when_switching_from_particulier_to_etablissement_with_data(live_server, page: Page):
     input_data = EvenementAnimalFactory.build(particulier=True)
     maladie = MaladieFactory()
     espece = EspeceFactory()
@@ -295,4 +285,4 @@ def test_confirmation_modal_when_switching_from_particulier_to_etablissement_wit
     expect(creation_page.type_change_modal).not_to_be_visible()
     expect(creation_page.numero_identifiant_etablissement).to_be_visible()
     expect(creation_page.nom_particulier).to_be_hidden()
-    assert creation_page.nom_particulier.input_value() == ""
+    expect(creation_page.nom_particulier).to_have_value("")


### PR DESCRIPTION
### Handle the changing of the holder type with an appropriate modal

- Update SA detenteur JS scripts with some methods to properly handle user interactions, holder type switching & data updates 📝 
- Create a dialog whom display status and interactions relies on these methods 👁️ 
- Test if the modal and the UI responds adequately when the holder type is changed with or without on-going data, wether the use cancels and confirms the change ✅ 

This relies on the feature description available in [this related Notion ticket](https://app.notion.com/p/incubateur-masa/G-rer-le-changement-de-type-de-d-tenteur-avec-modale-tablissement-Particulier-3acde24614be806cb1bfe4e62e95fdc9?v=14dde24614be81169a41000cb299fcd0&source=copy_link) 📄 