### PR TITLE
Create SA detail view with minimal list & history accesses

### DIFF
--- a/sa/context_processors.py
+++ b/sa/context_processors.py
@@ -11,4 +11,4 @@ def pre_creation_form(request):
         return {}
     if match.app_name != SaConfig.name:
         return {}
-    return {"pre_creation_form": EvenementAnimalPreCreationForm()}
+    return {"pre_creation_form": EvenementAnimalPreCreationForm(auto_id="id_pre_creation_%s")}

--- a/sa/filters.py
+++ b/sa/filters.py
@@ -1,0 +1,33 @@
+import django_filters
+from dsfr.forms import DsfrBaseForm
+
+from core.filters_mixins import WithEtatFilterMixin, WithNumeroFilterMixin
+from seves import settings
+
+from .models import Espece, EvenementAnimal, Maladie
+
+
+class EvenementAnimalFilterForm(DsfrBaseForm):
+    pass
+
+
+class EvenementAnimalFilter(
+    WithNumeroFilterMixin,
+    WithEtatFilterMixin,
+    django_filters.FilterSet,
+):
+    maladie = django_filters.ModelChoiceFilter(
+        label="Maladie",
+        queryset=Maladie.objects.all(),
+        empty_label=settings.SELECT_EMPTY_CHOICE,
+    )
+    espece = django_filters.ModelChoiceFilter(
+        label="Espèce",
+        queryset=Espece.objects.all(),
+        empty_label=settings.SELECT_EMPTY_CHOICE,
+    )
+
+    class Meta:
+        model = EvenementAnimal
+        fields = ["annee", "numero", "maladie", "espece", "etat"]
+        form = EvenementAnimalFilterForm

--- a/sa/managers.py
+++ b/sa/managers.py
@@ -1,0 +1,16 @@
+from django.db import models
+
+from core.managers import EvenementManagerMixin
+
+
+class EvenementAnimalManager(models.Manager):
+    def get_queryset(self):
+        return EvenementAnimalQuerySet(self.model, using=self._db).filter(is_deleted=False)
+
+
+class EvenementAnimalQuerySet(EvenementManagerMixin, models.QuerySet):
+    def order_by_numero(self):
+        return self.order_by("-numero_annee", "-numero_evenement")
+
+    def optimized_for_list(self):
+        return self.select_related("maladie", "espece", "createur")

--- a/sa/models/evenement.py
+++ b/sa/models/evenement.py
@@ -5,10 +5,13 @@ from django.core.validators import RegexValidator
 from django.db import models
 from django.urls import reverse
 from django_countries.fields import CountryField
+import reversion
+from reversion.models import Version
 
-from core.mixins import WithEtatMixin, WithNumeroMixin
+from core.mixins import AllowModificationMixin, WithNumeroMixin
 from core.models import Structure
 from core.soft_delete_mixins import AllowsSoftDeleteMixin
+from sa.managers import EvenementAnimalManager
 from sa.models.maladie import Maladie
 
 
@@ -52,7 +55,10 @@ class TypeDetenteur(models.TextChoices):
     PARTICULIER = "particulier", "Particulier"
 
 
-class EvenementAnimal(AllowsSoftDeleteMixin, WithNumeroMixin, WithEtatMixin, models.Model):
+@reversion.register()
+class EvenementAnimal(AllowsSoftDeleteMixin, WithNumeroMixin, AllowModificationMixin, models.Model):
+    objects = EvenementAnimalManager()
+
     # Common fields for event handling
     statut_evenement = models.CharField(
         max_length=100,
@@ -204,6 +210,15 @@ class EvenementAnimal(AllowsSoftDeleteMixin, WithNumeroMixin, WithEtatMixin, mod
 
     def get_absolute_url(self):
         return reverse("sa:evenement-animal-details", kwargs={"numero": self.numero})
+
+    @property
+    def latest_version(self):
+        return (
+            Version.objects.get_for_object(self)
+            .select_related("revision")
+            .select_related("revision__user__agent__structure")
+            .first()
+        )
 
     class Meta:
         constraints = [

--- a/sa/static/sa/evenement_animal_details.css
+++ b/sa/static/sa/evenement_animal_details.css
@@ -1,0 +1,4 @@
+.map {
+    height: 100%;
+    min-height: 400px;
+}

--- a/sa/templates/sa/_evenement_animal_badges.html
+++ b/sa/templates/sa/_evenement_animal_badges.html
@@ -1,0 +1,5 @@
+{% load etat_tags %}
+<div>
+    <p class="fr-badge fr-badge--{{ etat.etat|etat_color }} fr-badge--no-icon">{{ etat.readable_etat }}</p>
+    <p class="fr-badge fr-badge--no-icon">{{ object.get_statut_evenement_display }}</p>
+</div>

--- a/sa/templates/sa/evenement_animal_details.html
+++ b/sa/templates/sa/evenement_animal_details.html
@@ -1,4 +1,186 @@
 {% extends "sa/base.html" %}
+{% load static l10n %}
+{% load or_empty_value_tag %}
+
+{% block extrahead %}
+    <link rel="stylesheet" href="{% static 'sa/evenement_animal_details.css' %}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/maplibre-gl@5.3.0/dist/maplibre-gl.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/map-gl-style-switcher@0.10.0/dist/map-gl-style-switcher.min.css">
+{% endblock extrahead %}
+
+{% block scripts %}
+    <script type="module" src="{% static 'core/map_viewer.mjs' %}"></script>
+{% endblock scripts %}
 
 {% block content %}
+    <main class="main-container">
+        <div data-testid="evenement-header">
+            <div class="details-top-row">
+                <h1 class="fr-mb-0-5v">Événement {{ object.numero }}</h1>
+            </div>
+            {% include "sa/_evenement_animal_badges.html" %}
+            {% include "core/_latest_revision.html" with content_type_pk=content_type.pk object_pk=object.pk %}
+        </div>
+
+        <div class="detail-content">
+            <div class="white-container fr-mb-4v">
+                <h2 class="fr-h6">Informations générales</h2>
+                <div class="fr-grid-row fr-grid-row--gutters">
+                    <div class="fr-col-12 fr-col-lg-4">
+                        <div class="bold">Maladie suspectée</div>
+                        <div>{{ object.maladie.name|or_empty_value_tag }}</div>
+                    </div>
+                    <div class="fr-col-12 fr-col-lg-4">
+                        <div class="bold">Espèce concernée</div>
+                        <div>{{ object.espece.name|or_empty_value_tag }}</div>
+                    </div>
+                    <div class="fr-col-12 fr-col-lg-4">
+                        <div class="bold">Statut de l'animal</div>
+                        <div>{{ object.get_statut_animal_display|or_empty_value_tag }}</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="white-container fr-mb-4v">
+                <h2 class="fr-h6">Informations</h2>
+                <div class="fr-grid-row fr-grid-row--gutters">
+                    <div class="fr-col-12 fr-col-lg-6">
+                        <div class="bold">Date de création</div>
+                        <div>{{ object.date_creation|date:"d/m/Y"|or_empty_value_tag }}</div>
+                    </div>
+                    <div class="fr-col-12 fr-col-lg-6">
+                        <div class="bold">Statut de l'événement</div>
+                        <div>{{ object.get_statut_evenement_display|or_empty_value_tag }}</div>
+                    </div>
+                    <div class="fr-col-12 fr-col-lg-6">
+                        <div class="bold">Date à prendre en compte pour le changement de statut</div>
+                        <div>{{ object.date_statut_changed|date:"d/m/Y"|or_empty_value_tag }}</div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="white-container fr-mb-4v">
+                {% if object.numero_identifiant_etablissement %}
+                    <h2 class="fr-h6">Détenteur : Établissement</h2>
+                    <div class="fr-grid-row fr-grid-row--gutters">
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">N° identifiant</div>
+                            <div>{{ object.numero_identifiant_etablissement|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Autre identifiant / Numagrit</div>
+                            <div>{{ object.autre_identifiant_etablissement|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">SIRET</div>
+                            <div>{{ object.siret_etablissement|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Raison sociale</div>
+                            <div>{{ object.raison_sociale_etablissement|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Adresse</div>
+                            <div>{{ object.adresse_lieu_dit_etablissement|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Commune</div>
+                            <div>{{ object.commune_etablissement|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Département</div>
+                            <div>{{ object.departement_etablissement|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Code INSEE</div>
+                            <div>{{ object.code_insee_etablissement|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Pays</div>
+                            <div>{{ object.get_pays_etablissement_display|or_empty_value_tag }}</div>
+                        </div>
+                    </div>
+                {% elif object.nom_particulier %}
+                    <h2 class="fr-h6">Détenteur : Particulier</h2>
+                    <div class="fr-grid-row fr-grid-row--gutters">
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Nom</div>
+                            <div>{{ object.nom_particulier|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Prénom</div>
+                            <div>{{ object.prenom_particulier|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Adresse</div>
+                            <div>{{ object.adresse_particulier|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Commune</div>
+                            <div>{{ object.commune_particulier|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Département</div>
+                            <div>{{ object.departement_particulier|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Code INSEE</div>
+                            <div>{{ object.code_insee_particulier|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Courriel</div>
+                            <div>{{ object.email_particulier|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-col-12 fr-col-lg-4">
+                            <div class="bold">Numéro de téléphone</div>
+                            <div>{{ object.telephone_particulier|or_empty_value_tag }}</div>
+                        </div>
+                    </div>
+                {% endif %}
+            </div>
+
+            <div class="white-container fr-mb-4v">
+                <h2 class="fr-h6">Localisation</h2>
+                <div class="fr-grid-row fr-grid-row--gutters">
+                    <div class="fr-col-12 fr-col-lg-7">
+                        <div data-controller="map-viewer" class="map"
+                             data-map-viewer-lat-value="{{ object.coordinates.y|unlocalize }}"
+                             data-map-viewer-long-value="{{ object.coordinates.x|unlocalize }}"
+                             data-map-viewer-json-file-value="{% static 'core/style_ign.json' %}"
+                        ></div>
+                    </div>
+                    <div class="fr-col-12 fr-col-lg-5">
+                        <div class="fr-mb-2v">
+                            <div class="bold">Adresse ou lieu-dit</div>
+                            <div>{{ object.adresse_lieu_dit|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-mb-2v">
+                            <div class="bold">Commune</div>
+                            <div>{{ object.commune|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-mb-2v">
+                            <div class="bold">Code INSEE</div>
+                            <div>{{ object.code_insee|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-mb-2v">
+                            <div class="bold">Identifiant parcelle, culture</div>
+                            <div>{{ object.numero_identifiant|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-mb-2v">
+                            <div class="bold">Type de lieu</div>
+                            <div>{{ object.get_type_lieu_display|or_empty_value_tag }}</div>
+                        </div>
+                        <div class="fr-mb-2v">
+                            <div class="bold">Latitude</div>
+                            <div>{{ object.coordinates.y|unlocalize }}</div>
+                        </div>
+                        <div>
+                            <div class="bold">Longitude</div>
+                            <div>{{ object.coordinates.x|unlocalize }}</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
 {% endblock content %}

--- a/sa/templates/sa/evenementanimal_list.html
+++ b/sa/templates/sa/evenementanimal_list.html
@@ -1,3 +1,81 @@
 {% extends "sa/base.html" %}
+{% load etat_tags or_empty_value_tag static dsfr_tags %}
+
+{% block extrahead %}
+    <link rel="stylesheet" href="{% static 'core/list.css' %}">
+{% endblock %}
 
 {% block highlight_menu_evenements %}menu__item--active{% endblock %}
+
+{% block content %}
+    <form id="search-form" method="get">
+        <div class="fr-p-4v evenements_liste__header">
+            <div class="evenements_liste__header--title">
+                <h2 class="fr-h3">Rechercher un événement</h2>
+            </div>
+            <div class="evenements_liste__search-form">
+                <div class="fr-fieldset__element">
+                    {% dsfr_form_field filter.form.annee %}
+                </div>
+                <div class="fr-fieldset__element">
+                    {% dsfr_form_field filter.form.numero %}
+                </div>
+                <div class="fr-fieldset__element">
+                    {% dsfr_form_field filter.form.maladie %}
+                </div>
+                <div class="fr-fieldset__element">
+                    {% dsfr_form_field filter.form.espece %}
+                </div>
+                <div class="fr-fieldset__element">
+                    {% dsfr_form_field filter.form.etat %}
+                </div>
+                <div class="fr-fieldset__element evenements_liste__header--actions">
+                    <button type="reset" class="fr-btn fr-btn--tertiary-no-outline fr-mr-2w" id="reset-btn">Effacer</button>
+                    <button type="submit" class="fr-btn" data-testid="submit-search">Rechercher</button>
+                </div>
+            </div>
+        </div>
+    </form>
+
+    <div class="main-container">
+        <div class="evenements_liste__table--header">
+            <div>{{ paginator.count }} sur un total de {{ total_object_count }}</div>
+        </div>
+
+        {% if paginator.count > 0 %}
+            <div class="fr-table fr-table--no-caption fr-table--layout-fixed">
+                <table>
+                    <thead>
+                        <tr>
+                            <th scope="col">{% include 'core/_evenement_sort_link.html' with field='numero_evenement' display_name='Événement' %}</th>
+                            <th scope="col">{% include 'core/_evenement_sort_link.html' with field='maladie' display_name='Maladie' %}</th>
+                            <th scope="col">{% include 'core/_evenement_sort_link.html' with field='espece' display_name='Espèce' %}</th>
+                            <th scope="col">{% include 'core/_evenement_sort_link.html' with field='statut_evenement' display_name='Statut de l’événement' %}</th>
+                            <th scope="col">{% include 'core/_evenement_sort_link.html' with field='creation' display_name='Date de création' %}</th>
+                            <th scope="col">{% include 'core/_evenement_sort_link.html' with field='createur' display_name='Créateur' %}</th>
+                            <th scope="col">{% include 'core/_evenement_sort_link.html' with field='etat' display_name='État' %}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for evenement in evenementanimal_list %}
+                            <tr class="evenements__list-row">
+                                <td>
+                                    <a href="{{ evenement.get_absolute_url }}" class="fr-link">{{ evenement.numero }}</a>
+                                </td>
+                                <td>{{ evenement.maladie|or_empty_value_tag:"table" }}</td>
+                                <td>{{ evenement.espece|or_empty_value_tag:"table" }}</td>
+                                <td>{{ evenement.get_statut_evenement_display|or_empty_value_tag:"table" }}</td>
+                                <td>{{ evenement.date_creation|date:"d/m/Y" }}</td>
+                                <td>{{ evenement.createur|truncatechars:30 }}</td>
+                                <td>
+                                    <span class="fr-badge fr-badge--{{ evenement.etat|etat_color }} fr-badge--no-icon">{{ evenement.readable_etat }}</span>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                {% include "core/_pagination.html" %}
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/sa/tests/pages.py
+++ b/sa/tests/pages.py
@@ -78,19 +78,23 @@ class WithPreCreationFormPage:
         self.page = page
         self.base_url = base_url
 
+    @property
+    def pre_creation_modal(self):
+        return self.page.locator("#modal-pre-creation")
+
     def open_pre_creation_form(self):
         self.page.get_by_role("button", name="Créer un évènement", exact=True).click()
 
     def set_statut_animal(self, value):
-        self.page.locator("#radio-id_statut_animal").locator(
+        self.page.locator("#radio-id_pre_creation_statut_animal").locator(
             f"input[type='radio'][value='{str(value).lower()}' i]"
         ).check(force=True)
 
     def fill_pre_creation_form(self, evenement: EvenementAnimal):
-        self.page.get_by_label("Maladie").select_option(evenement.maladie.name)
-        self.page.get_by_label("Espece").select_option(evenement.espece.name)
+        self.pre_creation_modal.get_by_label("Maladie").select_option(evenement.maladie.name)
+        self.pre_creation_modal.get_by_label("Espece").select_option(evenement.espece.name)
         self.set_statut_animal(evenement.statut_animal)
-        self.page.get_by_role("button", name="Suivant >", exact=True).click()
+        self.pre_creation_modal.get_by_role("button", name="Suivant >", exact=True).click()
 
 
 class EvenementListPage(WithPreCreationFormPage):
@@ -101,6 +105,39 @@ class EvenementListPage(WithPreCreationFormPage):
 
     def navigate(self):
         self.page.goto(f"{self.base_url}{reverse('sa:evenement-liste')}")
+
+    @property
+    def search_form(self):
+        return self.page.locator("#search-form")
+
+    @property
+    def annee_field(self):
+        return self.search_form.get_by_label("Année")
+
+    @property
+    def numero_field(self):
+        return self.search_form.get_by_label("N° événement")
+
+    @property
+    def maladie_field(self):
+        return self.search_form.get_by_label("Maladie")
+
+    @property
+    def espece_field(self):
+        return self.search_form.get_by_label("Espèce")
+
+    @property
+    def etat_field(self):
+        return self.search_form.get_by_label("État de l'événement")
+
+    def submit_search(self):
+        self.page.get_by_role("button", name="Rechercher").click()
+
+    def reset_search(self):
+        self.page.get_by_role("button", name="Effacer", exact=True).click()
+
+    def row(self, numero):
+        return self.page.locator(".evenements__list-row").filter(has_text=numero)
 
 
 class EvenementAnimalFormPage(WithPreCreationFormPage, WithAddressAndCommuneUtils):
@@ -219,3 +256,27 @@ class EvenementAnimalFormPage(WithPreCreationFormPage, WithAddressAndCommuneUtil
         self.code_insee_particulier.fill(evenement.code_insee_particulier)
         self.email_particulier.fill(evenement.email_particulier)
         self.telephone_particulier.fill(evenement.telephone_particulier)
+
+
+class EvenementAnimalDetailsPage:
+    def __init__(self, page: Page, base_url):
+        self.page = page
+        self.base_url = base_url
+
+    def navigate(self, evenement: EvenementAnimal):
+        self.page.goto(f"{self.base_url}{evenement.get_absolute_url()}")
+
+    @property
+    def title(self):
+        return self.page.locator(".details-top-row h1")
+
+    @property
+    def etat_badge(self):
+        return self.page.get_by_test_id("evenement-header").locator(".fr-badge").nth(0)
+
+    @property
+    def statut_evenement_badge(self):
+        return self.page.get_by_test_id("evenement-header").locator(".fr-badge").nth(1)
+
+    def block(self, title):
+        return self.page.get_by_role("heading", name=title, exact=True).locator("..")

--- a/sa/tests/test_evenement_animal_details.py
+++ b/sa/tests/test_evenement_animal_details.py
@@ -1,0 +1,101 @@
+from playwright.sync_api import Page, expect
+
+from sa.tests.factories import EvenementAnimalFactory
+from sa.tests.pages import EvenementAnimalDetailsPage
+
+
+def test_evenement_animal_details_page_header(live_server, page: Page):
+    evenement = EvenementAnimalFactory()
+
+    details_page = EvenementAnimalDetailsPage(page, live_server.url)
+    details_page.navigate(evenement)
+
+    assert details_page.title.text_content() == f"Événement {evenement.numero}"
+    assert details_page.etat_badge.text_content() == evenement.get_etat_display()
+    assert details_page.statut_evenement_badge.text_content() == evenement.get_statut_evenement_display()
+
+
+def test_evenement_animal_details_page_informations_generales_block(live_server, page: Page):
+    evenement = EvenementAnimalFactory()
+
+    details_page = EvenementAnimalDetailsPage(page, live_server.url)
+    details_page.navigate(evenement)
+
+    block = details_page.block("Informations générales")
+    expect(block.get_by_text(evenement.maladie.name, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.espece.name, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.get_statut_animal_display(), exact=True)).to_be_visible()
+
+
+def test_evenement_animal_details_page_informations_block(live_server, page: Page):
+    evenement = EvenementAnimalFactory()
+
+    details_page = EvenementAnimalDetailsPage(page, live_server.url)
+    details_page.navigate(evenement)
+
+    block = details_page.block("Informations")
+    expect(block.get_by_text(evenement.date_creation.strftime("%d/%m/%Y"), exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.get_statut_evenement_display(), exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.date_statut_changed.strftime("%d/%m/%Y"), exact=True)).to_be_visible()
+
+
+def test_evenement_animal_details_page_detenteur_etablissement_block(live_server, page: Page):
+    evenement = EvenementAnimalFactory()
+
+    details_page = EvenementAnimalDetailsPage(page, live_server.url)
+    details_page.navigate(evenement)
+
+    block = details_page.block("Détenteur : Établissement")
+    expect(block.get_by_text(evenement.numero_identifiant_etablissement, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.autre_identifiant_etablissement, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.siret_etablissement, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.raison_sociale_etablissement, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.adresse_lieu_dit_etablissement, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.commune_etablissement, exact=True)).to_be_visible()
+    expect(block.get_by_text(str(evenement.departement_etablissement), exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.code_insee_etablissement, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.get_pays_etablissement_display(), exact=True)).to_be_visible()
+
+
+def test_evenement_animal_details_page_detenteur_particulier_block(live_server, page: Page):
+    evenement = EvenementAnimalFactory(particulier=True)
+
+    details_page = EvenementAnimalDetailsPage(page, live_server.url)
+    details_page.navigate(evenement)
+
+    block = details_page.block("Détenteur : Particulier")
+    expect(block.get_by_text(evenement.nom_particulier, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.prenom_particulier, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.adresse_particulier, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.commune_particulier, exact=True)).to_be_visible()
+    expect(block.get_by_text(str(evenement.departement_particulier), exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.code_insee_particulier, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.email_particulier, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.telephone_particulier, exact=True)).to_be_visible()
+
+
+def test_evenement_animal_details_page_localisation_block(live_server, page: Page):
+    evenement = EvenementAnimalFactory()
+
+    details_page = EvenementAnimalDetailsPage(page, live_server.url)
+    details_page.navigate(evenement)
+
+    block = details_page.block("Localisation")
+    expect(block.get_by_text(evenement.adresse_lieu_dit, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.commune, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.code_insee, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.numero_identifiant, exact=True)).to_be_visible()
+    expect(block.get_by_text(evenement.get_type_lieu_display(), exact=True)).to_be_visible()
+    expect(block.get_by_text("Latitude", exact=True)).to_be_visible()
+    expect(block.get_by_text("Longitude", exact=True)).to_be_visible()
+    expect(page.locator('[data-controller="map-viewer"]')).to_be_visible()
+
+
+def test_evenement_animal_details_page_with_missing_information(live_server, page: Page):
+    evenement = EvenementAnimalFactory(numero_identifiant="", adresse_lieu_dit="")
+
+    details_page = EvenementAnimalDetailsPage(page, live_server.url)
+    details_page.navigate(evenement)
+
+    block = details_page.block("Localisation")
+    expect(block.get_by_text("Vide").first).to_be_visible()

--- a/sa/tests/test_evenement_animal_list.py
+++ b/sa/tests/test_evenement_animal_list.py
@@ -1,0 +1,88 @@
+from playwright.sync_api import Page, expect
+
+from sa.tests.factories import EspeceFactory, EvenementAnimalFactory, MaladieFactory
+from sa.tests.pages import EvenementListPage
+from seves import settings
+
+
+def test_search_form_have_all_fields(live_server, page: Page):
+    search_page = EvenementListPage(page, live_server.url)
+    search_page.navigate()
+
+    expect(page.get_by_role("heading", name="Rechercher un événement")).to_be_visible()
+    expect(search_page.annee_field).to_be_visible()
+    expect(search_page.numero_field).to_be_visible()
+    expect(search_page.maladie_field).to_be_visible()
+    expect(search_page.maladie_field).to_contain_text(settings.SELECT_EMPTY_CHOICE)
+    expect(search_page.espece_field).to_be_visible()
+    expect(search_page.etat_field).to_be_visible()
+    expect(page.get_by_role("button", name="Effacer", exact=True)).to_be_visible()
+    expect(page.get_by_role("button", name="Rechercher")).to_be_visible()
+
+
+def test_reset_button_clears_form(live_server, page: Page):
+    maladie = MaladieFactory()
+
+    search_page = EvenementListPage(page, live_server.url)
+    search_page.navigate()
+    search_page.annee_field.fill("2026")
+    search_page.maladie_field.select_option(str(maladie.pk))
+
+    search_page.reset_search()
+
+    expect(search_page.annee_field).to_be_empty()
+    expect(search_page.maladie_field).to_have_value("")
+
+
+def test_evenement_animal_list_displays_events_and_links_to_details(live_server, page: Page):
+    evenement = EvenementAnimalFactory()
+
+    search_page = EvenementListPage(page, live_server.url)
+    search_page.navigate()
+
+    row = search_page.row(evenement.numero)
+    expect(row).to_be_visible()
+    expect(row).to_contain_text(evenement.maladie.name)
+    expect(row).to_contain_text(evenement.espece.name)
+    expect(row).to_contain_text(evenement.get_statut_evenement_display())
+    expect(row).to_contain_text(evenement.get_etat_display())
+
+    row.get_by_role("link", name=evenement.numero, exact=True).click()
+    page.wait_for_url(f"**{evenement.get_absolute_url()}")
+
+
+def test_evenement_animal_list_compteur(live_server, page: Page):
+    EvenementAnimalFactory.create_batch(3)
+
+    search_page = EvenementListPage(page, live_server.url)
+    search_page.navigate()
+
+    expect(page.get_by_text("3 sur un total de 3")).to_be_visible()
+
+
+def test_evenement_animal_list_filter_by_maladie(live_server, page: Page):
+    maladie = MaladieFactory()
+    matching = EvenementAnimalFactory(maladie=maladie)
+    other = EvenementAnimalFactory()
+
+    search_page = EvenementListPage(page, live_server.url)
+    search_page.navigate()
+    search_page.maladie_field.select_option(str(maladie.pk))
+    search_page.submit_search()
+
+    expect(search_page.row(matching.numero)).to_be_visible()
+    expect(search_page.row(other.numero)).to_have_count(0)
+
+
+def test_evenement_animal_list_filter_by_espece(live_server, page: Page):
+    espece = EspeceFactory()
+    matching = EvenementAnimalFactory(espece=espece)
+    other = EvenementAnimalFactory()
+
+    search_page = EvenementListPage(page, live_server.url)
+    search_page.navigate()
+    search_page.espece_field.select_option(str(espece.pk))
+    search_page.submit_search()
+
+    expect(search_page.row(matching.numero)).to_be_visible()
+    expect(search_page.row(other.numero)).to_have_count(0)

--- a/sa/tests/test_evenement_animal_list_order.py
+++ b/sa/tests/test_evenement_animal_list_order.py
@@ -1,0 +1,46 @@
+from playwright.sync_api import Page
+import pytest
+
+from sa.tests.factories import EvenementAnimalFactory, MaladieFactory
+
+
+@pytest.mark.parametrize(
+    "direction,expected_order",
+    [
+        ("asc", ["evenement_2", "evenement_3", "evenement_1"]),
+        ("desc", ["evenement_1", "evenement_3", "evenement_2"]),
+    ],
+    ids=["asc", "desc"],
+)
+def test_order_by_numero_evenement(
+    live_server, page: Page, url_builder_for_list_ordering, assert_events_order, direction, expected_order
+):
+    evenements = {
+        "evenement_1": EvenementAnimalFactory(numero_annee=2026, numero_evenement=3),
+        "evenement_2": EvenementAnimalFactory(numero_annee=2026, numero_evenement=1),
+        "evenement_3": EvenementAnimalFactory(numero_annee=2026, numero_evenement=2),
+    }
+    page.goto(url_builder_for_list_ordering("numero_evenement", direction, "sa:evenement-liste"))
+    page.get_by_role("link", name="Événement", exact=True).click()
+    assert_events_order(page, evenements, expected_order, column=1)
+
+
+@pytest.mark.parametrize(
+    "direction,expected_order",
+    [
+        ("asc", ["evenement_maladie_a", "evenement_maladie_b", "evenement_maladie_c"]),
+        ("desc", ["evenement_maladie_c", "evenement_maladie_b", "evenement_maladie_a"]),
+    ],
+    ids=["asc", "desc"],
+)
+def test_order_by_maladie(
+    live_server, page: Page, url_builder_for_list_ordering, assert_events_order, direction, expected_order
+):
+    evenements = {
+        "evenement_maladie_a": EvenementAnimalFactory(maladie=MaladieFactory(name="Anthrax")),
+        "evenement_maladie_b": EvenementAnimalFactory(maladie=MaladieFactory(name="Brucellose")),
+        "evenement_maladie_c": EvenementAnimalFactory(maladie=MaladieFactory(name="Charbon")),
+    }
+    page.goto(url_builder_for_list_ordering("maladie", direction, "sa:evenement-liste"))
+    page.get_by_role("link", name="Maladie").click()
+    assert_events_order(page, evenements, expected_order, column=1)

--- a/sa/views/evenement.py
+++ b/sa/views/evenement.py
@@ -1,3 +1,5 @@
+from django.contrib.contenttypes.models import ContentType
+from django.forms import Media
 from django.http import Http404
 from django.views.generic import CreateView, DetailView, ListView
 
@@ -6,11 +8,27 @@ from sa.forms.evenement import EvenementAnimalForm
 from sa.models import Espece, EvenementAnimal, Maladie
 from sa.models.evenement import StatutAnimal
 
+from .mixins import WithFilteredListMixin
 
-class EvenementListView(ListView):
-    paginate_by = 100
-    context_object_name = "objects"
+
+class EvenementListView(WithFilteredListMixin, MediaDefiningMixin, ListView):
     model = EvenementAnimal
+    paginate_by = 100
+
+    def get_media(self, **context_data) -> Media:
+        return context_data["filter"].form.media if "filter" in context_data else Media()
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["filter"] = self.filter
+        context["total_object_count"] = self.get_raw_queryset().count()
+
+        for evenement in context["evenementanimal_list"]:
+            etat_data = evenement.get_etat_data_from_fin_de_suivi(evenement.has_fin_de_suivi)
+            evenement.etat = etat_data["etat"]
+            evenement.readable_etat = etat_data["readable_etat"]
+
+        return context
 
 
 class EvenementAnimalCreationView(WithFormErrorsAsMessagesMixin, MediaDefiningMixin, CreateView):
@@ -56,3 +74,11 @@ class EvenementAnimalDetailsView(DetailView):
             return self.object
         except (ValueError, EvenementAnimal.DoesNotExist):
             raise Http404("Fiche non trouvée")
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        contact = self.request.user.agent.structure.contact_set.get()
+        context["etat"] = self.object.get_etat_data_for_contact(contact)
+        context["content_type"] = ContentType.objects.get_for_model(self.object)
+        context["latest_version"] = self.object.latest_version
+        return context

--- a/sa/views/mixins.py
+++ b/sa/views/mixins.py
@@ -1,0 +1,28 @@
+from core.mixins import WithOrderingMixin
+from sa.filters import EvenementAnimalFilter
+from sa.models import EvenementAnimal
+
+
+class WithFilteredListMixin(WithOrderingMixin):
+    def get_ordering_fields(self):
+        return {
+            "numero_evenement": ("numero_annee", "numero_evenement"),
+            "maladie": "maladie__name",
+            "espece": "espece__name",
+            "statut_evenement": "statut_evenement",
+            "creation": "date_creation",
+            "createur": "createur__libelle",
+            "etat": "etat",
+        }
+
+    def get_default_order_by(self):
+        return "creation"
+
+    def get_raw_queryset(self):
+        contact = self.request.user.agent.structure.contact_set.get()
+        return EvenementAnimal.objects.all().with_fin_de_suivi(contact).optimized_for_list()
+
+    def get_queryset(self):
+        queryset = self.apply_ordering(self.get_raw_queryset())
+        self.filter = EvenementAnimalFilter(self.request.GET, queryset=queryset)
+        return self.filter.qs


### PR DESCRIPTION
### Implement SA detailed view

- Create SA event detailed view based on the other verticals equivalence 🐄 

This relies on the feature description available in [this related Notion ticket](https://app.notion.com/p/incubateur-masa/Cr-er-la-vue-d-taill-e-d-un-v-nement-3aede24614be80b0a86ad9928fa064ff?v=14dde24614be81169a41000cb299fcd0&source=copy_link) 📄 