### PR TITLE
Display agricultural plots on map

### DIFF
--- a/core/static/core/base_map.mjs
+++ b/core/static/core/base_map.mjs
@@ -13,7 +13,7 @@ export class BaseMapController extends Controller {
         return this.defaultStyleValue === "satellite" ? this.jsonFileValue : OSM_STYLE_URL
     }
 
-    addStyleSwitcher() {
+    addStyleSwitcher(onStyleChanged) {
         const styles = [
             {
                 id: "osm",
@@ -36,6 +36,7 @@ export class BaseMapController extends Controller {
             showImages: false,
             onAfterStyleChange: (_from, to) => {
                 this.map.setStyle(to.styleUrl)
+                if (onStyleChanged) this.map.once("idle", onStyleChanged)
             },
         })
         this.map.addControl(control, "bottom-left")

--- a/core/static/core/map.mjs
+++ b/core/static/core/map.mjs
@@ -1,13 +1,70 @@
 import {applicationReady} from "Application"
 import {BaseMapController} from "BaseMapController"
 import maplibregl from "MapLibre"
-import {StyleSwitcherControl} from "MapStyleSwitcher"
 
 const DISTANT_ZOOM = 5
 const CLOSE_UP_ZOOM = 10
 const PRECISE_ZOOM = 15
 
 const DEFAULT_CENTER_CONFIG = {center: {lat: 48.866667, lon: 2.333333}, zoom: DISTANT_ZOOM}
+
+const PARCEL_WFS_URL = "https://data.geopf.fr/wfs/ows"
+const PARCEL_TYPENAME = "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:parcelle"
+const PARCEL_MIN_ZOOM = 12
+const PARCEL_THROTTLE_MS = 400
+const PARCEL_FILL_OPACITY = 0.15
+const PARCEL_OUTLINE_OPACITY = 1
+const PARCEL_SOURCE_ID = "parcel-source"
+const PARCEL_FILL_LAYER_ID = "parcel-fill"
+const PARCEL_OUTLINE_LAYER_ID = "parcel-outline"
+const PARCEL_LABEL_LAYER_ID = "parcel-label"
+const PARCEL_LABEL_FONT = ["Noto Sans Bold"]
+const PARCEL_LABEL_COLOR = "#45327f"
+const PARCEL_LABEL_HALO_WIDTH = 1.5
+const PARCEL_HIGHLIGHT_SOURCE_ID = "parcel-highlight-source"
+const PARCEL_HIGHLIGHT_FILL_LAYER_ID = "parcel-highlight-fill"
+const PARCEL_HIGHLIGHT_OUTLINE_LAYER_ID = "parcel-highlight-outline"
+const PARCEL_HIGHLIGHT_COLOR = "#800bf5"
+const PARCEL_HIGHLIGHT_FILL_OPACITY = 0.25
+const PARCEL_HIGHLIGHT_OUTLINE_WIDTH = 3
+const PARCEL_UNAVAILABLE_MESSAGE = "Les parcelles ne sont pas disponibles pour le moment"
+const PARCEL_ZOOM_MESSAGE = "Zoomez pour afficher les parcelles"
+
+class ParcellesControl {
+    constructor(container) {
+        this._container = container
+        this._container.classList.add("maplibregl-ctrl")
+    }
+
+    onAdd() {
+        return this._container
+    }
+
+    onRemove() {
+        this._container.remove()
+    }
+}
+
+function throttle(func, wait) {
+    let lastCall = 0
+    let timeout = null
+    return function (...args) {
+        const remaining = wait - (Date.now() - lastCall)
+        if (remaining <= 0) {
+            clearTimeout(timeout)
+            timeout = null
+            lastCall = Date.now()
+            func.apply(this, args)
+        } else if (!timeout) {
+            timeout = setTimeout(() => {
+                lastCall = Date.now()
+                timeout = null
+                func.apply(this, args)
+            }, remaining)
+        }
+    }
+}
+
 class MapController extends BaseMapController {
     static targets = [
         "mapDisplay",
@@ -17,6 +74,9 @@ class MapController extends BaseMapController {
         "codePostalInput",
         "departementInput",
         "communeSelect",
+        "parcellesCheckbox",
+        "parcellesMessage",
+        "numeroIdentifiantInput",
     ]
     static values = {
         reverseApi: String,
@@ -77,7 +137,7 @@ class MapController extends BaseMapController {
         fetch(`${this.reverseApiValue}?lon=${e.lngLat.lng}&lat=${e.lngLat.lat}&limit=1`)
             .then(res => res.json())
             .then(json => {
-                const feature = json.features && json.features[0]
+                const feature = json.features?.[0]
                 if (!feature) return null
                 this.communeSelectTarget.dispatchEvent(
                     new CustomEvent("forcedChoice", {
@@ -87,15 +147,19 @@ class MapController extends BaseMapController {
                     }),
                 )
                 this.codeInseeInputTarget.value = feature.properties.citycode
-                this.codePostalInputTarget.value = feature.properties.postcode
-                const twoDigits = feature.properties.citycode.slice(0, 2)
-                const threeDigits = feature.properties.citycode.slice(0, 3)
-                const options = Array.from(this.departementInputTarget.options)
-                const match = options.find(o => o.value === twoDigits) || options.find(o => o.value === threeDigits)
+                if (this.hasCodePostalInputTarget) {
+                    this.codePostalInputTarget.value = feature.properties.postcode
+                }
+                if (this.hasDepartementInputTarget) {
+                    const twoDigits = feature.properties.citycode.slice(0, 2)
+                    const threeDigits = feature.properties.citycode.slice(0, 3)
+                    const options = Array.from(this.departementInputTarget.options)
+                    const match = options.find(o => o.value === twoDigits) || options.find(o => o.value === threeDigits)
 
-                if (!match) return
+                    if (!match) return
 
-                this.departementInputTarget.value = match.value
+                    this.departementInputTarget.value = match.value
+                }
             })
             .catch(error => {
                 console.error("Erreur lors de la récupération des données:", error)
@@ -108,6 +172,87 @@ class MapController extends BaseMapController {
         this.latitudeInputTarget.value = e.lngLat.lat
         this.longitudeInputTarget.value = e.lngLat.lng
         this.setAddressFieldsByLongLat(e)
+        if (this.hasNumeroIdentifiantInputTarget) {
+            this.setNumeroIdentifiantByLongLat(e.lngLat)
+        }
+    }
+
+    setNumeroIdentifiantByLongLat(lngLat) {
+        const params = new URLSearchParams({
+            SERVICE: "WFS",
+            VERSION: "2.0.0",
+            REQUEST: "GetFeature",
+            TYPENAMES: PARCEL_TYPENAME,
+            OUTPUTFORMAT: "application/json",
+            SRSNAME: "EPSG:4326",
+            COUNT: "1",
+            CQL_FILTER: `INTERSECTS(geom,POINT(${lngLat.lat} ${lngLat.lng}))`,
+        })
+
+        fetch(`${PARCEL_WFS_URL}?${params.toString()}`)
+            .then(res => res.json())
+            .then(geojson => {
+                const feature = geojson.features?.[0]
+                const numero = feature?.properties?.numero
+                if (numero) this.numeroIdentifiantInputTarget.value = numero
+                if (feature) {
+                    this._lastFetchedParcel = {numero, feature}
+                    this.highlightParcelle(feature)
+                } else {
+                    this._lastFetchedParcel = null
+                    this.clearParcelleHighlight()
+                }
+            })
+            .catch(error => {
+                console.error("Erreur lors de la récupération de la parcelle:", error)
+            })
+    }
+
+    highlightParcelle(feature) {
+        this._highlightedFeature = feature
+        if (!this.parcellesEnabled) return
+
+        const data = {type: "FeatureCollection", features: [feature]}
+        const source = this.map.getSource(PARCEL_HIGHLIGHT_SOURCE_ID)
+        if (source) {
+            source.setData(data)
+            return
+        }
+        this.map.addSource(PARCEL_HIGHLIGHT_SOURCE_ID, {type: "geojson", data})
+        this.map.addLayer({
+            id: PARCEL_HIGHLIGHT_FILL_LAYER_ID,
+            type: "fill",
+            source: PARCEL_HIGHLIGHT_SOURCE_ID,
+            paint: {"fill-color": PARCEL_HIGHLIGHT_COLOR, "fill-opacity": PARCEL_HIGHLIGHT_FILL_OPACITY},
+        })
+        this.map.addLayer({
+            id: PARCEL_HIGHLIGHT_OUTLINE_LAYER_ID,
+            type: "line",
+            source: PARCEL_HIGHLIGHT_SOURCE_ID,
+            paint: {"line-color": PARCEL_HIGHLIGHT_COLOR, "line-width": PARCEL_HIGHLIGHT_OUTLINE_WIDTH},
+        })
+    }
+
+    removeHighlightLayer() {
+        if (this.map.getLayer(PARCEL_HIGHLIGHT_OUTLINE_LAYER_ID)) {
+            this.map.removeLayer(PARCEL_HIGHLIGHT_OUTLINE_LAYER_ID)
+        }
+        if (this.map.getLayer(PARCEL_HIGHLIGHT_FILL_LAYER_ID)) this.map.removeLayer(PARCEL_HIGHLIGHT_FILL_LAYER_ID)
+        if (this.map.getSource(PARCEL_HIGHLIGHT_SOURCE_ID)) this.map.removeSource(PARCEL_HIGHLIGHT_SOURCE_ID)
+    }
+
+    clearParcelleHighlight() {
+        this._highlightedFeature = null
+        this.removeHighlightLayer()
+    }
+
+    handleNumeroIdentifiantInput() {
+        const value = this.numeroIdentifiantInputTarget.value
+        if (this._lastFetchedParcel && value === this._lastFetchedParcel.numero) {
+            this.highlightParcelle(this._lastFetchedParcel.feature)
+        } else {
+            this.clearParcelleHighlight()
+        }
     }
 
     async connect() {
@@ -119,7 +264,10 @@ class MapController extends BaseMapController {
             attributionControl: false,
             style: this.initialStyleUrl,
         })
-        this.addStyleSwitcher()
+        this.addStyleSwitcher(() => {
+            if (this.parcellesEnabled) this.refreshParcelles()
+            if (this._highlightedFeature) this.highlightParcelle(this._highlightedFeature)
+        })
         this.map.addControl(
             new maplibregl.NavigationControl({
                 showZoom: true,
@@ -127,10 +275,27 @@ class MapController extends BaseMapController {
             }),
         )
 
+        this.map.doubleClickZoom.disable()
         this.marker = new maplibregl.Marker({draggable: false}).setLngLat(center).addTo(this.map)
         this.map.on("dblclick", e => {
             this.handleDoubleClickOnMap(e)
         })
+
+        if (this.hasParcellesCheckboxTarget) {
+            this.parcellesEnabled = false
+            const parcellesControlContainer = this.parcellesCheckboxTarget.closest(".map-parcelles-control")
+            if (parcellesControlContainer) {
+                this.map.addControl(new ParcellesControl(parcellesControlContainer), "top-right")
+            }
+            const throttledRefresh = throttle(() => this.refreshParcelles(), PARCEL_THROTTLE_MS)
+            this.map.on("move", throttledRefresh)
+            this.map.on("moveend", () => this.refreshParcelles())
+        }
+    }
+
+    disconnect() {
+        this._parcelAbortController?.abort()
+        this.map?.remove()
     }
 
     onCoordinateChange() {
@@ -142,6 +307,118 @@ class MapController extends BaseMapController {
         this.marker.setLngLat({lat, lon})
         this.map.setCenter({lat, lon})
         this.map.setZoom(PRECISE_ZOOM)
+    }
+
+    toggleParcelles() {
+        this.parcellesEnabled = this.parcellesCheckboxTarget.checked
+        if (this.parcellesEnabled) {
+            this.refreshParcelles()
+            if (this._highlightedFeature) this.highlightParcelle(this._highlightedFeature)
+        } else {
+            this._parcelAbortController?.abort()
+            this.removeParcellesLayer()
+            this.clearParcellesMessage()
+            this.removeHighlightLayer()
+        }
+    }
+
+    refreshParcelles() {
+        if (!this.parcellesEnabled) return
+        if (this.map.getZoom() < PARCEL_MIN_ZOOM) {
+            this._parcelAbortController?.abort()
+            this.removeParcellesLayer()
+            this.showParcellesMessage(PARCEL_ZOOM_MESSAGE)
+            return
+        }
+        this.fetchAndDisplayParcelles()
+    }
+
+    fetchAndDisplayParcelles() {
+        this._parcelAbortController?.abort()
+        const abortController = new AbortController()
+        this._parcelAbortController = abortController
+
+        const bounds = this.map.getBounds()
+        const bbox = `${bounds.getWest()},${bounds.getSouth()},${bounds.getEast()},${bounds.getNorth()},EPSG:4326`
+        const url =
+            `${PARCEL_WFS_URL}?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=${PARCEL_TYPENAME}`
+            + `&OUTPUTFORMAT=application/json&SRSNAME=EPSG:4326&COUNT=5000&BBOX=${bbox}`
+
+        fetch(url, {signal: abortController.signal})
+            .then(res => {
+                if (!res.ok) throw new Error(`Unexpected response status: ${res.status}`)
+                return res.json()
+            })
+            .then(geojson => {
+                if (geojson.numberReturned < geojson.numberMatched) {
+                    this.removeParcellesLayer()
+                    this.showParcellesMessage(PARCEL_ZOOM_MESSAGE)
+                    return
+                }
+                this.clearParcellesMessage()
+                this.displayParcellesLayer(geojson)
+            })
+            .catch(error => {
+                if (error.name === "AbortError") return
+                console.error("Erreur lors de la récupération des parcelles:", error)
+                this.removeParcellesLayer()
+                this.showParcellesMessage(PARCEL_UNAVAILABLE_MESSAGE)
+            })
+    }
+
+    displayParcellesLayer(geojson) {
+        const source = this.map.getSource(PARCEL_SOURCE_ID)
+        if (source) {
+            source.setData(geojson)
+            return
+        }
+        this.map.addSource(PARCEL_SOURCE_ID, {type: "geojson", data: geojson})
+        this.map.addLayer({
+            id: PARCEL_FILL_LAYER_ID,
+            type: "fill",
+            source: PARCEL_SOURCE_ID,
+            paint: {"fill-color": "#6a4dc4", "fill-opacity": PARCEL_FILL_OPACITY},
+        })
+        this.map.addLayer({
+            id: PARCEL_OUTLINE_LAYER_ID,
+            type: "line",
+            source: PARCEL_SOURCE_ID,
+            paint: {"line-color": "#6a4dc4", "line-width": 2, "line-opacity": PARCEL_OUTLINE_OPACITY},
+        })
+        this.map.addLayer({
+            id: PARCEL_LABEL_LAYER_ID,
+            type: "symbol",
+            source: PARCEL_SOURCE_ID,
+            layout: {
+                "text-field": ["get", "numero"],
+                "text-font": PARCEL_LABEL_FONT,
+                "text-size": 13,
+            },
+            paint: {
+                "text-color": PARCEL_LABEL_COLOR,
+                "text-halo-color": "#ffffff",
+                "text-halo-width": PARCEL_LABEL_HALO_WIDTH,
+            },
+        })
+    }
+
+    removeParcellesLayer() {
+        if (this.map.getLayer(PARCEL_LABEL_LAYER_ID)) this.map.removeLayer(PARCEL_LABEL_LAYER_ID)
+        if (this.map.getLayer(PARCEL_OUTLINE_LAYER_ID)) this.map.removeLayer(PARCEL_OUTLINE_LAYER_ID)
+        if (this.map.getLayer(PARCEL_FILL_LAYER_ID)) this.map.removeLayer(PARCEL_FILL_LAYER_ID)
+        if (this.map.getSource(PARCEL_SOURCE_ID)) this.map.removeSource(PARCEL_SOURCE_ID)
+    }
+
+    showParcellesMessage(text) {
+        if (!this.hasParcellesMessageTarget) return
+        this.parcellesMessageTarget.textContent = text
+        this.parcellesMessageTarget.hidden = false
+    }
+
+    clearParcellesMessage() {
+        if (!this.hasParcellesMessageTarget) return
+        this.parcellesMessageTarget.hidden = true
+        this.parcellesMessageTarget.textContent = ""
     }
 }
 

--- a/core/static/core/style_ign.json
+++ b/core/static/core/style_ign.json
@@ -1,5 +1,6 @@
 {
     "version": 8,
+    "glyphs": "https://openmaptiles.data.gouv.fr/fonts/{fontstack}/{range}.pbf",
     "sources": {
         "ign": {
             "type": "raster",

--- a/sa/static/sa/evenement_animal_form.css
+++ b/sa/static/sa/evenement_animal_form.css
@@ -3,6 +3,28 @@
     min-height: 400px;
 }
 
+.map-wrapper {
+    height: 100%;
+    min-height: 400px;
+}
+
+.map-parcelles-control {
+    max-width: 220px;
+    padding: 0.3rem 0.75rem;
+    background-color: rgba(255, 255, 255, 0.9);
+    border-radius: 4px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+}
+
+.map-parcelles-message {
+    margin: 0.25rem 0 0;
+    font-size: 0.75rem;
+}
+
+.map-parcelles-message[hidden] {
+    display: none;
+}
+
 #context .fr-radio-group {
     margin-top: 0.5rem;
     margin-right: 2rem;

--- a/sa/templates/sa/evenement_animal_form.html
+++ b/sa/templates/sa/evenement_animal_form.html
@@ -176,7 +176,27 @@
                      data-map-departement-value="{{ form.structure.departement.nom }}"
                 >
                     <div class="fr-col-12 fr-col-lg-7">
-                        <div data-map-target="mapDisplay" class="map"></div>
+                        <div class="map-wrapper">
+                            <div data-map-target="mapDisplay" class="map"></div>
+                            <div class="map-parcelles-control">
+                                <div class="fr-checkbox-group fr-checkbox-group--sm">
+                                    <input
+                                        type="checkbox"
+                                        id="map-parcelles-checkbox"
+                                        data-map-target="parcellesCheckbox"
+                                        data-action="change->map#toggleParcelles"
+                                        aria-describedby="map-parcelles-message"
+                                    >
+                                    <label class="fr-label" for="map-parcelles-checkbox">Parcelles</label>
+                                </div>
+                                <p
+                                    id="map-parcelles-message"
+                                    class="map-parcelles-message fr-hint-text"
+                                    data-map-target="parcellesMessage"
+                                    hidden
+                                ></p>
+                            </div>
+                        </div>
                     </div>
                     <div class="fr-col-12 fr-col-lg-5">
 
@@ -190,7 +210,7 @@
                         </div>
 
                         {% dsfr_form_field form.code_insee|set_data:"map-target:codeInseeInput"|set_data:"address-search-autocomplete-target:codeInsee"%}
-                        {% dsfr_form_field form.numero_identifiant %}
+                        {% dsfr_form_field form.numero_identifiant|set_data:"map-target:numeroIdentifiantInput"|append_attr:"data-action:input->map#handleNumeroIdentifiantInput" %}
                         {% dsfr_form_field form.type_lieu %}
                         {% dsfr_form_field form.coordinates %}
                     </div>

--- a/sa/tests/pages.py
+++ b/sa/tests/pages.py
@@ -190,6 +190,18 @@ class EvenementAnimalFormPage(WithPreCreationFormPage, WithAddressAndCommuneUtil
         self.coordinates_0.fill(str(point.y))
 
     @property
+    def parcelles_checkbox(self):
+        return self.page.locator("#map-parcelles-checkbox")
+
+    @property
+    def parcelles_message(self):
+        return self.page.locator("#map-parcelles-message")
+
+    @property
+    def map_canvas(self):
+        return self.page.locator('[data-map-target="mapDisplay"] canvas')
+
+    @property
     def particulier_label(self):
         return self.page.locator("label", has_text="Particulier")
 

--- a/sa/tests/test_evenement_animal_creation.py
+++ b/sa/tests/test_evenement_animal_creation.py
@@ -196,6 +196,30 @@ def test_can_create_evenement_animal_with_detenteur_particulier_block(live_serve
         assert getattr(evenement_produit, field) == getattr(input_data, field)
 
 
+PARCEL_WFS_URL = "https://data.geopf.fr/wfs/ows"
+PARCEL_NUMERO = "0067"
+
+
+def _set_parcelles_checkbox(creation_page, checked):
+    creation_page.parcelles_checkbox.set_checked(checked, force=True)
+
+
+def _parcel_response(properties=None):
+    features = []
+    if properties is not None:
+        features = [
+            {
+                "type": "Feature",
+                "properties": properties,
+                "geometry": {
+                    "type": "MultiPolygon",
+                    "coordinates": [[[[2.35, 48.85], [2.351, 48.85], [2.351, 48.851], [2.35, 48.851], [2.35, 48.85]]]],
+                },
+            }
+        ]
+    return {"type": "FeatureCollection", "features": features}
+
+
 def test_no_confirmation_modal_when_switching_detenteur_type_without_data(live_server, page: Page):
     input_data = EvenementAnimalFactory.build()
     maladie = MaladieFactory()
@@ -286,3 +310,145 @@ def test_confirmation_modal_when_switching_from_particulier_to_etablissement_wit
     expect(creation_page.numero_identifiant_etablissement).to_be_visible()
     expect(creation_page.nom_particulier).to_be_hidden()
     expect(creation_page.nom_particulier).to_have_value("")
+
+
+def test_parcelles_checkbox_unchecked_by_default(live_server, page: Page):
+    maladie = MaladieFactory()
+    espece = EspeceFactory()
+    input_data = EvenementAnimalFactory.build()
+
+    creation_page = EvenementAnimalFormPage(page, live_server.url)
+    creation_page.navigate(maladie, espece, input_data.statut_animal)
+
+    expect(creation_page.parcelles_checkbox).to_be_visible()
+    expect(creation_page.parcelles_checkbox).not_to_be_checked()
+
+
+def test_parcelles_checkbox_displays_and_hides_parcel_layer(live_server, page: Page):
+    maladie = MaladieFactory()
+    espece = EspeceFactory()
+    input_data = EvenementAnimalFactory.build()
+    call_count = {"count": 0}
+
+    def handle(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(_parcel_response({"id_parcel": "1", "code_cultu": "BTH"})),
+        )
+        call_count["count"] += 1
+
+    page.route(lambda url: url.startswith(PARCEL_WFS_URL), handle)
+
+    creation_page = EvenementAnimalFormPage(page, live_server.url)
+    creation_page.navigate(maladie, espece, input_data.statut_animal)
+    creation_page.fill_coordinates(input_data.coordinates)
+    page.wait_for_timeout(600)
+
+    _set_parcelles_checkbox(creation_page, True)
+    page.wait_for_timeout(800)
+
+    assert call_count["count"] == 1
+    expect(creation_page.parcelles_message).to_be_hidden()
+
+    _set_parcelles_checkbox(creation_page, False)
+    page.mouse.wheel(0, -100)
+    page.wait_for_timeout(800)
+
+    assert call_count["count"] == 1
+
+
+def test_parcelles_insufficient_zoom_shows_message(live_server, page: Page):
+    maladie = MaladieFactory()
+    espece = EspeceFactory()
+    input_data = EvenementAnimalFactory.build()
+    call_count = {"count": 0}
+
+    def handle(route):
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(_parcel_response({"id_parcel": "1", "code_cultu": "BTH"})),
+        )
+        call_count["count"] += 1
+
+    page.route(lambda url: url.startswith(PARCEL_WFS_URL), handle)
+
+    creation_page = EvenementAnimalFormPage(page, live_server.url)
+    creation_page.navigate(maladie, espece, input_data.statut_animal)
+
+    _set_parcelles_checkbox(creation_page, True)
+    page.wait_for_timeout(800)
+
+    expect(creation_page.parcelles_message).to_be_visible()
+    expect(creation_page.parcelles_message).to_have_text("Zoomez pour afficher les parcelles")
+    assert call_count["count"] == 0
+
+
+def test_parcelles_api_failure_shows_message(live_server, page: Page):
+    maladie = MaladieFactory()
+    espece = EspeceFactory()
+    input_data = EvenementAnimalFactory.build()
+    page_errors = []
+    page.on("pageerror", lambda exc: page_errors.append(exc))
+
+    page.route(lambda url: url.startswith(PARCEL_WFS_URL), lambda route: route.fulfill(status=500, body="error"))
+
+    creation_page = EvenementAnimalFormPage(page, live_server.url)
+    creation_page.navigate(maladie, espece, input_data.statut_animal)
+    creation_page.fill_coordinates(input_data.coordinates)
+
+    _set_parcelles_checkbox(creation_page, True)
+    page.wait_for_timeout(800)
+
+    expect(creation_page.parcelles_message).to_be_visible()
+    expect(creation_page.parcelles_message).to_have_text("Les parcelles ne sont pas disponibles pour le moment")
+    assert page_errors == []
+
+
+def test_double_click_on_map_fills_numero_identifiant(live_server, page: Page):
+    maladie = MaladieFactory()
+    espece = EspeceFactory()
+    input_data = EvenementAnimalFactory.build()
+
+    page.route(
+        lambda url: url.startswith(PARCEL_WFS_URL),
+        lambda route: route.fulfill(
+            status=200, content_type="application/json", body=json.dumps(_parcel_response({"numero": PARCEL_NUMERO}))
+        ),
+    )
+
+    creation_page = EvenementAnimalFormPage(page, live_server.url)
+    creation_page.navigate(maladie, espece, input_data.statut_animal)
+
+    expect(creation_page.map_canvas).to_be_visible()
+    page.wait_for_timeout(600)
+    creation_page.map_canvas.dblclick()
+    page.wait_for_timeout(800)
+
+    expect(creation_page.numero_identifiant).to_have_value(PARCEL_NUMERO)
+
+
+def test_double_click_on_map_without_parcelle_leaves_numero_identifiant_unchanged(live_server, page: Page):
+    maladie = MaladieFactory()
+    espece = EspeceFactory()
+    input_data = EvenementAnimalFactory.build()
+    call_count = {"count": 0}
+
+    def handle(route):
+        route.fulfill(status=200, content_type="application/json", body=json.dumps(_parcel_response()))
+        call_count["count"] += 1
+
+    page.route(lambda url: url.startswith(PARCEL_WFS_URL), handle)
+
+    creation_page = EvenementAnimalFormPage(page, live_server.url)
+    creation_page.navigate(maladie, espece, input_data.statut_animal)
+    creation_page.numero_identifiant.fill("valeur-existante")
+
+    expect(creation_page.map_canvas).to_be_visible()
+    page.wait_for_timeout(600)
+    creation_page.map_canvas.dblclick()
+    page.wait_for_timeout(800)
+
+    assert call_count["count"] == 1
+    expect(creation_page.numero_identifiant).to_have_value("valeur-existante")


### PR DESCRIPTION
### Display parcels on the map

- Retrieve and display the parcel from the cadastre data source 🗺️ 
- Hide the parcels and display an appropriate message when the zoom level is to low / when the displayed geographic field is too wide to retrieve all the related data 🛡️ 
- Populate the parcel ID location field with the corresponding data, when the user double cliks on a parcel 🖱️ 
- Highlight the selected parcel the user selects 🖌️ 
- Make parcels available both on map and satellite views 📡 

This relies on the feature description available in [this related Notion ticket](https://app.notion.com/p/incubateur-masa/Afficher-les-parcelles-sur-la-carte-3acde24614be80cb9460fecb6b28e7ea?v=14dde24614be81169a41000cb299fcd0&source=copy_link) 📄 