### PR TITLE
Remove JavaScript from PDF before scanning them

### DIFF
--- a/core/pdf.py
+++ b/core/pdf.py
@@ -1,0 +1,19 @@
+import io
+
+from django.core.files.base import ContentFile
+import pikepdf
+from pikepdf.sanitize import remove_javascript
+
+
+def strip_javascript_from_pdf(document):
+    with document.file.open("rb") as f:
+        pdf = pikepdf.Pdf.open(f)
+        remove_javascript(pdf)
+        buffer = io.BytesIO()
+        pdf.save(buffer)
+        pdf.close()
+
+    storage = document.file.storage
+    name = document.file.name
+    storage.delete(name)
+    storage.save(name, ContentFile(buffer.getvalue()))

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -4,6 +4,8 @@ from celery import shared_task
 
 from core.antivirus import scan_document
 from core.models import Document
+from core.pdf import strip_javascript_from_pdf
+from core.validators import AllowedMimeTypes
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +14,10 @@ logger = logging.getLogger(__name__)
 def scan_for_viruses(document_pk):
     logger.info(f"Will start scanning of {document_pk}")
     document = Document.objects.get(pk=document_pk)
+
+    if document.mimetype == AllowedMimeTypes.APPLICATION_PDF:
+        strip_javascript_from_pdf(document)
+
     is_infected = scan_document(document)
     if is_infected is not None:
         document.is_infected = is_infected


### PR DESCRIPTION
Make sure we remove any JS in the PDF before showing them in the preview modal to avoid any XSS.

https://pikepdf.readthedocs.io/en/stable/api/sanitize.html